### PR TITLE
Portal page handlers part 3

### DIFF
--- a/.env
+++ b/.env
@@ -1,16 +1,16 @@
 # ################################################################
-# Accounts Service
+# Identity Service
 # ################################################################
 
-# Configuration file for the accounts service.
-ITEMS_DOCKER_ACCOUNTS_SVC_CONFIG_FILE=./configs/accounts.cfg
+# Configuration file for the identity service.
+ITEMS_DOCKER_IDENTITY_SVC_CONFIG_FILE=./configs/identity.cfg
 
-# Sqlite database to be used by the accounts service.
-ITEMS_DOCKER_ACCOUNTS_SVC_DB_FILE=./databases/items_accounts_svc.db
+# Sqlite database to be used by the identity service.
+ITEMS_DOCKER_IDENTITY_SVC_DB_FILE=./databases/items_identity.LATEST.db
 
 # When using (pulling) a Docker image, this is the tag used to pull from
 # Docker Hub.
-ACCOUNTS_SVC_DOCKER_TAG=NIGHTLY
+IDENTITY_SVC_DOCKER_TAG=NIGHTLY
 
 # ################################################################
 # Contents Management System Service
@@ -20,7 +20,7 @@ ACCOUNTS_SVC_DOCKER_TAG=NIGHTLY
 ITEMS_DOCKER_CMS_SVC_CONFIG_FILE=./configs/cms.cfg
 
 # Sqlite database to be used by the CMS service.
-ITEMS_DOCKER_CMS_SVC_DB_FILE=./databases/items_cms_svc.LATEST.db
+ITEMS_DOCKER_CMS_SVC_DB_FILE=./databases/items_cms.LATEST.db
 
 # When using (pulling) a Docker image, this is the tag used to pull from
 # Docker Hub.
@@ -44,7 +44,7 @@ GATEWAY_SVC_DOCKER_TAG=NIGHTLY
 # Web Portal Service
 # ################################################################
 
-# Configuration file for the gateway service.
+# Configuration file for the web portal service.
 ITEMS_DOCKER_WEB_PORTAL_SVC_CONFIG_FILE=./configs/web_portal.cfg
 
 # When using (pulling) a Docker image, this is the tag used to pull from

--- a/configs/cms.cfg
+++ b/configs/cms.cfg
@@ -2,4 +2,4 @@
 log_level=INFO
 
 [backend]
-db_filename=/usr/local/items/cms_svc.db
+db_filename=/usr/local/items/cms.db

--- a/configs/gateway.cfg
+++ b/configs/gateway.cfg
@@ -5,5 +5,6 @@ log_level=INFO
 metadata_config_file=/usr/local/items/metadata.config
 
 [apis]
-accounts_svc=http://accounts_svc:4000/
-cms_svc=http://cms_svc:5050/
+identity_svc=http://identity_svc:5050/
+cms_svc=http://cms_svc:6050/
+web_portal_svc=http://web_portal_svc:8000/

--- a/configs/identity.cfg
+++ b/configs/identity.cfg
@@ -2,4 +2,4 @@
 log_level=INFO
 
 [backend]
-db_filename=/usr/local/items/identity_svc.db
+db_filename=/usr/local/items/identity.db

--- a/configs/web_portal.cfg
+++ b/configs/web_portal.cfg
@@ -2,4 +2,4 @@
 log_level=INFO
 
 [apis]
-gateway_svc=http://gateway_svc:3000/
+gateway_svc=http://gateway_svc:7050/

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,11 @@
 services:
-  accounts_svc:
+  identity_svc:
     build:
       context: .
-      dockerfile: ./docker/Dockerfile.accounts_svc
-    image: swatkat1977/items_accounts_svc:latest
+      dockerfile: ./docker/Dockerfile.identity_svc
+    image: swatkat1977/items_identity_svc:latest
     ports:
-      - 4000:4000
+      - 5050:5050
 
   cms_svc:
     build:
@@ -13,7 +13,7 @@ services:
       dockerfile: ./docker/Dockerfile.cms_svc
     image: swatkat1977/items_cms_svc:latest
     ports:
-      - 5050:5050
+      - 6050:6050
 
   gateway_svc:
     build:
@@ -21,7 +21,7 @@ services:
       dockerfile: ./docker/Dockerfile.gateway_svc
     image: swatkat1977/items_gateway_svc:latest
     ports:
-      - 3000:3000
+      - 7050:7050
 
   web_portal_svc:
     build:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,5 +1,5 @@
 services:
-  accounts_svc:
+  identity_svc:
     image: swatkat1977/a:latest
     restart: always  # Ensures auto-restart in production
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
-  accounts_svc:
-    image: swatkat1977/items:items_accounts_svc-${ACCOUNTS_SVC_DOCKER_TAG}
-    container_name: accounts_svc
+  identity_svc:
+    image: swatkat1977/items:items_identity_svc-${IDENTITY_SVC_DOCKER_TAG}
+    container_name: identity_svc
     ports:
-      - "4000:4000"
+      - "5050:5050"
     networks:
       - backend
     environment:
-      - SERVICE_NAME=items_accounts_svc
+      - SERVICE_NAME=identity_svc
       - ITEMS_ENVIRONMENT=development
     volumes:
-      - "${ITEMS_DOCKER_ACCOUNTS_SVC_CONFIG_FILE}:/usr/local/items/accounts_svc.config"
-      - "${ITEMS_DOCKER_ACCOUNTS_SVC_DB_FILE}:/usr/local/items/accounts_svc.db"
+      - "${ITEMS_DOCKER_IDENTITY_SVC_CONFIG_FILE}:/usr/local/items/identity.cfg"
+      - "${ITEMS_DOCKER_IDENTITY_SVC_DB_FILE}:/usr/local/items/identity.db"
     env_file:
       - .env
 
@@ -19,15 +19,15 @@ services:
     image: swatkat1977/items:items_cms_svc-${CMS_SVC_DOCKER_TAG}
     container_name: cms_svc
     ports:
-      - "5050:5050"
+      - "6050:6050"
     networks:
       - backend
     environment:
-      - SERVICE_NAME=cms_accounts_svc
+      - SERVICE_NAME=cms_svc
       - ITEMS_ENVIRONMENT=development
     volumes:
-      - "${ITEMS_DOCKER_CMS_SVC_CONFIG_FILE}:/usr/local/items/cms_svc.config"
-      - "${ITEMS_DOCKER_CMS_SVC_DB_FILE}:/usr/local/items/cms_svc.db"
+      - "${ITEMS_DOCKER_CMS_SVC_CONFIG_FILE}:/usr/local/items/cms.cfg"
+      - "${ITEMS_DOCKER_CMS_SVC_DB_FILE}:/usr/local/items/cms.db"
     env_file:
       - .env
 
@@ -35,14 +35,14 @@ services:
     image: swatkat1977/items:items_gateway_svc-${GATEWAY_SVC_DOCKER_TAG}
     container_name: gateway_svc
     ports:
-      - "3000:3000"
+      - "7050:7050"
     networks:
       - backend
     environment:
       - SERVICE_NAME=gateway_svc
       - ITEMS_ENVIRONMENT=development
     volumes:
-      - "${ITEMS_DOCKER_GATEWAY_SVC_CONFIG_FILE}:/usr/local/items/gateway_svc.config"
+      - "${ITEMS_DOCKER_GATEWAY_SVC_CONFIG_FILE}:/usr/local/items/gateway.cfg"
       - "${ITEMS_DOCKER_GATEWAY_SVC_METADATA_CONFIG_FILE}:/usr/local/items/metadata.config"
     env_file:
       - .env
@@ -51,14 +51,14 @@ services:
     image: swatkat1977/items:items_web_portal_svc-${WEB_PORTAL_SVC_DOCKER_TAG}
     container_name: web_portal_svc
     ports:
-      - "8080:8080"
+      - "8000:8000"
     networks:
       - backend
     environment:
       - SERVICE_NAME=web_portal_svc
       - ITEMS_ENVIRONMENT=development
     volumes:
-      - "${ITEMS_DOCKER_WEB_PORTAL_SVC_CONFIG_FILE}:/usr/local/items/web_portal_svc.config"
+      - "${ITEMS_DOCKER_WEB_PORTAL_SVC_CONFIG_FILE}:/usr/local/items/web_portal.cfg"
     env_file:
       - .env
 

--- a/docker/Dockerfile.identity_svc
+++ b/docker/Dockerfile.identity_svc
@@ -1,27 +1,3 @@
-FROM python:3.13.2-alpine
-
-# Add a user and group for ITEMS and then setup file paths.
-RUN addgroup -S items && \
-    adduser -S items -G items && \
-    mkdir /usr/local/items &&  \
-    chown items:items /usr/local/items
-
-RUN apk add --no-cache
-
-# Switch to the non-root user
-USER items
-
-
-
-
-
-
-
-
-
-
-
-
 FROM python:3.14.6-alpine
 
 # Add a user and group for ITEMS and then setup file paths.

--- a/docker/Dockerfile.web_portal_svc
+++ b/docker/Dockerfile.web_portal_svc
@@ -1,44 +1,38 @@
-
-FROM python:3.13.2-alpine
+FROM python:3.14.6-alpine
 
 # Add a user and group for ITEMS and then setup file paths.
 RUN addgroup -S items && \
     adduser -S items -G items && \
     mkdir /usr/local/items &&  \
+    mkdir /usr/local/items/services &&  \
     chown items:items /usr/local/items
 
-RUN apk add --no-cache
-
-# Switch to the non-root user
-USER items
-
-ENV PATH=$PATH:/home/items/.local/bin
-
-# Ensure latest pip is installed
-RUN pip install --upgrade pip
-
-# Web Portal dependencies
-COPY docker/requirements-web_portal_svc.txt .
-RUN pip install --no-cache-dir -r requirements-web_portal_svc.txt
-
-USER items
-
-# Copy base files into Docker image.
-COPY --chown=items:items items/web_portal_svc /usr/local/items/web_portal_svc
-COPY --chown=items:items items/shared /usr/local/items/shared
-
-# Configure the environment
 WORKDIR /usr/local/items
-ENV PYTHONPATH=/usr/local/items/web_portal_svc:/usr/local/items/shared
-ENV ITEMS_WEB_PORTAL_SVC_CONFIG_FILE=/usr/local/items/web_portal_svc.config
-ENV ITEMS_WEB_PORTAL_SVC_CONFIG_FILE_REQUIRED=1
-ENV QUART_APP=web_portal_svc
 
-EXPOSE 8080
+# Install Python dependencies
+COPY requirements/requirements_web_portal.txt .
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements_web_portal.txt
 
-# Default command (can be overridden)
-CMD ["sh", "-c", "if [ \"$ITEMS_ENVIRONMENT\" = \"production\" ]; then \
-    exec uvicorn main:app --host 0.0.0.0 --port 5000; \
-else \
-    exec python -m quart run -p 8080 -h 0.0.0.0 --reload; \
-fi"]
+# Copy application
+COPY --chown=items:items items ./items
+
+# Runtime configuration
+ENV PYTHONPATH=/usr/local/items
+
+# These should match the names your application actually uses
+ENV ITEMS_WEB_PORTAL_CONFIG_FILE_REQUIRED=1
+ENV ITEMS_WEB_PORTAL_CONFIG_FILE=/usr/local/items/web_portal.cfg
+
+# Listen on all interfaces inside the container
+ENV ITEMS_WEB_PORTAL_HOST=0.0.0.0
+ENV ITEMS_WEB_PORTAL_PORT=8000
+
+# Optional logging
+ENV LOGGING_LOG_LEVEL=DEBUG
+
+EXPOSE 8000
+
+USER items
+
+CMD ["python", "-m", "items.services.items_web_portal.run"]

--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -17,6 +17,10 @@ limitations under the License.
 from quart import Blueprint
 from items.services.items_web_portal.page_handler_injections import (
     PageHandlerInjections)
+from items.services.items_web_portal.page_handlers.admin.admin_customisations_page_handler import \
+    AdminCustomisationsPageHandler
+from items.services.items_web_portal.page_handlers.admin.admin_integrations_page_handler import \
+    AdminIntegrationsPageHandler
 from items.services.items_web_portal.page_handlers.admin.admin_manage_data_page_handler import \
     AdminManageDataPageHandler
 from items.services.items_web_portal.page_handlers.admin.admin_site_settings_page_handler import \
@@ -71,6 +75,16 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
                                       injections.config,
                                       injections.rest_client,
                                       injections.metadata)
+    handler_customisations: AdminCustomisationsPageHandler = \
+        AdminCustomisationsPageHandler(injections.logger,
+                                       injections.config,
+                                       injections.rest_client,
+                                       injections.metadata)
+    handler_integrations: AdminIntegrationsPageHandler = \
+        AdminIntegrationsPageHandler(injections.logger,
+                                     injections.config,
+                                     injections.rest_client,
+                                     injections.metadata)
 
     # Register admin dashboard pages
     routes.register_blueprint(create_admin_dashboard_page_handler(injections,
@@ -91,6 +105,22 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
     @routes.route('/manage_data', methods=['GET'])
     async def admin_admin_manage_data_request():
         return await handler_manage_data.manage_data()
+
+    # Admin page | Customisations (read): '/admin/customisations'
+    injections.logger.debug("=> %s GET /admin/customisations",
+                            "Admin customisations page (read)".ljust(40))
+
+    @routes.route('/customisations', methods=['GET'])
+    async def admin_customisations_request():
+        return await handler_customisations.customisations()
+
+    # Admin page | Integrations (read): '/admin/integrations'
+    injections.logger.debug("=> %s GET /admin/integrations",
+                            "Admin integrations page (read)".ljust(40))
+
+    @routes.route('/integrations', methods=['GET'])
+    async def admin_integrations_request():
+        return await handler_integrations.integrations()
 
     # Admin page | Site Settings (read): '/admin/site_settings'
     injections.logger.debug("=> %s GET /admin/site_settings",

--- a/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+
+class AdminCustomisationsPageHandler(PortalPageHandler):
+    """Handles requests for the administration customisations page.
+
+    This handler renders the administration page used to view and manage
+    instance customisations.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialize the administration customisations page handler.
+
+        Args:
+            logger: Logger used to record diagnostic and operational messages.
+            config: Application configuration settings.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Instance metadata used to populate page content.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    @require_session
+    async def customisations(self):
+        """Render the administration customisations page.
+
+        Returns:
+            The rendered administration customisations page response.
+        """
+        return await self._render_page(
+            pages.PAGE_INSTANCE_ADMIN_CUSTOMISATIONS,
+            instance_name=self._metadata_settings.instance_name,
+            active_page="administration",
+            active_admin_page="admin_page_customisations")

--- a/items/services/items_web_portal/page_handlers/admin/admin_integrations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_integrations_page_handler.py
@@ -1,0 +1,61 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+
+class AdminIntegrationsPageHandler(PortalPageHandler):
+    """Handles requests for the administration integrations page.
+
+    This handler renders the administration page used to view and manage
+    third-party integrations.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialize the administration integrations page handler.
+
+        Args:
+            logger: Logger used to record diagnostic and operational messages.
+            config: Application configuration settings.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Instance metadata used to populate page content.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    @require_session
+    async def integrations(self):
+        """Render the administration integrations page.
+
+        Returns:
+            The rendered administration integrations page response.
+        """
+        return await self._render_page(
+            pages.PAGE_INSTANCE_ADMIN_INTEGRATIONS,
+            instance_name=self._metadata_settings.instance_name,
+            active_page="administration",
+            active_admin_page="admin_page_integrations")

--- a/items/services/items_web_portal/page_handlers/admin/admin_manage_data_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_manage_data_page_handler.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -46,6 +47,7 @@ class AdminManageDataPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def manage_data(self):
         """Render the administration manage data page.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_site_settings_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_site_settings_page_handler.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -46,6 +47,7 @@ class AdminSiteSettingsPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def site_settings(self):
         """Render the administration site settings page.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -46,6 +47,7 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def users_and_roles(self):
         """Render the administration users and roles page.
 

--- a/items/services/items_web_portal/page_handlers/admin/dashboard/admin_overview_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/dashboard/admin_overview_page_handler.py
@@ -17,6 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -47,6 +48,7 @@ class AdminOverviewPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def overview(self):
         """Render the administration overview page.
 

--- a/items/services/items_web_portal/page_handlers/projects/__init__.py
+++ b/items/services/items_web_portal/page_handlers/projects/__init__.py
@@ -41,15 +41,16 @@ def create_projects_page_handlers(injections: PageHandlerInjections) -> Blueprin
     handler_project_overview: GetProjectOverviewPageHandler = \
         GetProjectOverviewPageHandler(injections.logger,
                                       injections.config,
-                                      injections.rest_client)
+                                      injections.rest_client,
+                                      injections.metadata)
 
     injections.logger.debug(" Projects Page Handlers:")
 
     # Index page: '/'
-    injections.logger.debug("=> %s GET /<int:project_id>",
+    injections.logger.debug("=> %s GET /<int:project_id>/overview",
                             "Project overview page".ljust(40))
 
-    @routes.route('/<int:project_id>',
+    @routes.route('/<int:project_id>/overview',
                   methods=['GET'])
     async def project_overview_request(project_id: int):
         return await handler_project_overview.project_overview(project_id)

--- a/items/services/items_web_portal/page_handlers/projects/get_project_overview_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/projects/get_project_overview_page_handler.py
@@ -20,6 +20,7 @@ import logging
 from quart import Response
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 from items.services.items_web_portal.portal_page_handler import PortalPageHandler
 import items.services.items_web_portal.page_locations as pages
@@ -49,6 +50,7 @@ class GetProjectOverviewPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def project_overview(self, project_id: int):
         """Render the overview page for a project.
 

--- a/items/services/items_web_portal/page_handlers/projects/get_project_overview_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/projects/get_project_overview_page_handler.py
@@ -14,25 +14,86 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from items.services.items_web_portal.portal_page_handler import (
-    PortalPageHandler)
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+from items.services.items_web_portal.portal_page_handler import PortalPageHandler
 import items.services.items_web_portal.page_locations as pages
 
 
 class GetProjectOverviewPageHandler(PortalPageHandler):
     """Handles requests for the project overview page.
 
-    This handler is responsible for rendering the overview page for an
-    individual project.
+    This handler fetches project details from the gateway service and renders
+    the project overview page, including the project name, announcement banner,
+    and stubbed statistics sections.
     """
 
-    async def project_overview(self, _project_id: int):
-        """Render the overview page for a project.
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialises the project overview page handler.
 
         Args:
-            _project_id: Identifier of the project to display.
+            logger: Logger used for diagnostic and error messages.
+            config: Application configuration containing service endpoints.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Metadata settings used when rendering portal pages.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    async def project_overview(self, project_id: int):
+        """Render the overview page for a project.
+
+        Fetches project details from the gateway service and renders the
+        overview page. Returns an internal server error response if the
+        project cannot be retrieved.
+
+        Args:
+            project_id: Identifier of the project to display.
 
         Returns:
-            The rendered project overview page response.
+            The rendered project overview page, or a JSON error response with
+            HTTP 500 status if the gateway request fails.
         """
-        return await self._render_page(pages.TEMPLATE_INTERNAL_ERROR_PAGE)
+        gateway_svc: str = self._config.apis_gateway_svc
+        url: str = f"{gateway_svc}web/projects/{project_id}"
+
+        response = await self._rest_client.get(url)
+
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            response_json = {"status": 0, "error": "Project not found"}
+            return Response(json.dumps(response_json),
+                            status=HTTPStatus.NOT_FOUND,
+                            content_type="application/json")
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.critical(
+                "Gateway svc request invalid - Reason: %s",
+                response.exception_msg)
+            response_json = {"status": 0, "error": "Internal error!"}
+            return Response(json.dumps(response_json),
+                            status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                            content_type="application/json")
+
+        project = response.body
+        project_name: str = project.get("name", "Unknown Project")
+        announcement: str = project.get("announcement", "")
+        show_announcement: bool = project.get("show_announcement_on_overview",
+                                              False)
+
+        return await self._render_page(
+            pages.PAGE_PROJECT_OVERVIEW,
+            active_page="overview",
+            project_id=project_id,
+            project_name=project_name,
+            announcement=announcement,
+            show_announcement=show_announcement,
+            instance_name=self._metadata_settings.instance_name)

--- a/items/services/items_web_portal/page_handlers/testcases/get_project_testcases_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/testcases/get_project_testcases_page_handler.py
@@ -79,8 +79,15 @@ class GetProjectTestcasesPageHandler(PortalPageHandler):
         """
         gateway_svc: str = self._config.apis_gateway_svc
 
-        url: str = f"{gateway_svc}web/{project_id}/testcases"
+        # Fetch project details to get the project name for the sidebar.
+        project_url: str = f"{gateway_svc}web/projects/{project_id}"
+        project_response = await self._rest_client.get(project_url)
 
+        project_name: str = "Unknown Project"
+        if project_response.status_code == HTTPStatus.OK:
+            project_name = project_response.body.get("name", project_name)
+
+        url: str = f"{gateway_svc}web/{project_id}/testcases"
         response = await self._rest_client.get(url)
 
         if response.status_code != HTTPStatus.OK:
@@ -96,11 +103,13 @@ class GetProjectTestcasesPageHandler(PortalPageHandler):
 
         details = self._transform_tests_details_data(response.body)
 
-        page = "test-cases"  # Default to 'Overview'
         return await self._render_page(
             pages.TEMPLATE_TEST_DEFINITIONS_PAGE,
-            data=details, active_page=page,
+            data=details,
+            active_page="test-cases",
             has_testcases=len(details) > 0,
+            project_id=project_id,
+            project_name=project_name,
             instance_name=self._metadata_settings.instance_name)
 
     def _transform_tests_details_data(self, data):

--- a/items/services/items_web_portal/page_handlers/testcases/get_project_testcases_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/testcases/get_project_testcases_page_handler.py
@@ -20,6 +20,7 @@ import logging
 from quart import Response
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_session
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -58,6 +59,7 @@ class GetProjectTestcasesPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def test_cases(self, project_id: int):
         """Renders the test cases page for a project.
 

--- a/items/services/items_web_portal/page_locations.py
+++ b/items/services/items_web_portal/page_locations.py
@@ -42,6 +42,8 @@ PAGE_INSTANCE_ADMIN_OVERVIEW: str = "instance_admin_overview.html"
 PAGE_INSTANCE_ADMIN_PROJECTS: str = "instance_admin_projects.html"
 PAGE_INSTANCE_ADMIN_USERS_AND_ROLES: str = "instance_admin_users_roles.html"
 PAGE_INSTANCE_ADMIN_MANAGE_DATA: str = "instance_admin_manage_data.html"
+PAGE_INSTANCE_ADMIN_CUSTOMISATIONS: str = "instance_admin_customisations.html"
+PAGE_INSTANCE_ADMIN_INTEGRATIONS: str = "instance_admin_integrations.html"
 PAGE_INSTANCE_ADMIN_SITE_SETTINGS: str = "instance_admin_site_settings.html"
 
 PAGE_INSTANCE_ADMIN_ADD_PROJECT: str = "instance_admin_add_project.html"

--- a/items/services/items_web_portal/static/css/instance_admin_customisations.css
+++ b/items/services/items_web_portal/static/css/instance_admin_customisations.css
@@ -1,0 +1,65 @@
+/* Administration customisations - tabbed layout */
+
+.customisations-tabs {
+    border-bottom: 1px solid #cddceb;
+    overflow: hidden;
+    flex-wrap: nowrap;
+}
+
+.customisations-tabs .nav-link {
+    color: #45525f;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 10px 16px;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.customisations-tabs .nav-link:hover {
+    color: #2a72b5;
+    border-bottom-color: #cddceb;
+}
+
+.customisations-tabs .nav-link.active {
+    color: #2a72b5;
+    font-weight: 600;
+    background-color: transparent;
+    border-bottom-color: #2a72b5;
+}
+
+.customisations-tabs .nav-link i {
+    font-size: 1.05rem;
+    line-height: 1;
+}
+
+.customisations-tab-content {
+    background-color: #ffffff;
+    border: 1px solid #cddceb;
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+    padding: 24px;
+    min-height: 240px;
+}
+
+.customisations-placeholder {
+    color: #7a8794;
+    margin: 0;
+}
+
+/*
+ * Collapse the tab labels to icons only once the full-label tab bar can no
+ * longer fit its container. The `icons-only` class is toggled by
+ * instance_admin_customisations.js based on actual overflow, so the switch
+ * happens exactly when a scroll bar would otherwise appear. The icon and the
+ * button's title attribute keep each tab identifiable when the label is hidden.
+ */
+.customisations-tabs.icons-only .nav-link .tab-label {
+    display: none;
+}
+
+.customisations-tabs.icons-only .nav-link {
+    padding: 10px 14px;
+}

--- a/items/services/items_web_portal/static/css/project_overview.css
+++ b/items/services/items_web_portal/static/css/project_overview.css
@@ -1,0 +1,101 @@
+.project-content,
+#overview-content {
+    background-color: #cce8ff;
+    min-height: 100%;
+}
+
+#overview-title-bar {
+    background-color: #cce8ff;
+    padding: 8px 12px;
+    border-bottom: 1px solid #a8d0f0;
+}
+
+#overview-title-bar h5 {
+    font-size: 1.35rem;
+    font-weight: 600;
+    color: #222;
+}
+
+.overview-body {
+    padding: 16px;
+}
+
+/* ── Announcement banner ── */
+.overview-announcement {
+    background-color: #fff8e1;
+    border: 1px solid #ffe082;
+    border-left: 4px solid #f9a825;
+    border-radius: 4px;
+    padding: 10px 14px;
+    margin-bottom: 16px;
+    font-size: 0.9rem;
+    color: #5a4000;
+}
+
+/* ── Stats row ── */
+.overview-stats-row {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.stat-box {
+    flex: 1;
+    background-color: #fff;
+    border: 1px solid #b8d4ee;
+    border-radius: 6px;
+    padding: 14px 10px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+}
+
+.stat-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.stat-label {
+    font-size: 0.75rem;
+    color: #6c757d;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.stat-passed  { color: #28a745; }
+.stat-failed  { color: #dc3545; }
+.stat-blocked { color: #6c757d; }
+.stat-retest  { color: #fd7e14; }
+.stat-skipped { color: #adb5bd; }
+
+/* ── Milestones / Test Runs sections ── */
+.overview-sections {
+    display: flex;
+    gap: 16px;
+}
+
+.overview-section {
+    flex: 1;
+    background-color: #fff;
+    border: 1px solid #b8d4ee;
+    border-radius: 6px;
+    padding: 14px 16px;
+}
+
+.overview-section-title {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: #294665;
+    margin-bottom: 4px;
+    padding-bottom: 6px;
+    border-bottom: 2px solid #294665;
+}
+
+.overview-empty-state {
+    padding: 12px 0 4px;
+    color: #6c757d;
+    font-size: 0.875rem;
+}

--- a/items/services/items_web_portal/static/css/project_overview.css
+++ b/items/services/items_web_portal/static/css/project_overview.css
@@ -1,11 +1,11 @@
 .project-content,
 #overview-content {
-    background-color: #cce8ff;
+    background-color: #EBF1F6;
     min-height: 100%;
 }
 
 #overview-title-bar {
-    background-color: #cce8ff;
+    background-color: #EBF1F6;
     padding: 8px 12px;
     border-bottom: 1px solid #a8d0f0;
 }

--- a/items/services/items_web_portal/static/css/project_page_template.css
+++ b/items/services/items_web_portal/static/css/project_page_template.css
@@ -27,10 +27,95 @@
     margin-top: 0;
 }
 
-.menubar_third-line {
+/* ── Project layout ── */
+.project-layout {
+    display: flex;
+    min-height: calc(100vh - 72px); /* subtract nav + instance bar */
+}
+
+/* ── Sidebar ── */
+.project-sidebar {
+    width: 220px;
+    min-width: 220px;
+    background-color: #ffffff;
+    border-right: 1px solid #dee2e6;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.sidebar-project-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 12px;
+    border-bottom: 1px solid #dee2e6;
+    background-color: #f8f9fa;
+}
+
+.sidebar-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
     background-color: #294665;
-    padding: 0px 10px; /* Reduce padding */
-    margin: 0; /* Ensure no margins */
+    color: #fff;
+    font-weight: 700;
+    font-size: 0.85rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+}
+
+.sidebar-project-name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: #1e3550;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.sidebar-nav {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 0;
+}
+
+.sidebar-nav-item {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 8px 14px;
+    color: #4a5e6e;
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: background-color 0.15s, color 0.15s;
+}
+
+.sidebar-nav-item i {
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+
+.sidebar-nav-item:hover {
+    background-color: #eef3f8;
+    color: #294665;
+    text-decoration: none;
+}
+
+.sidebar-nav-item.active {
+    background-color: #e0eaf4;
+    color: #294665;
+    font-weight: 600;
+    border-left: 3px solid #294665;
+    padding-left: 11px;
+}
+
+/* ── Content area ── */
+.project-content {
+    flex: 1;
+    overflow: auto;
 }
 
 /* Prevent navbar from collapsing */

--- a/items/services/items_web_portal/static/css/project_testcases.css
+++ b/items/services/items_web_portal/static/css/project_testcases.css
@@ -1,10 +1,11 @@
-#body-pd, #body-pd .wrapper, #body-pd #content {
-    background-color: #cce8ff !important;
-    min-height: 100vh;
+.project-content,
+#content {
+    background-color: #EBF1F6;
+    min-height: 100%;
 }
 
 #testcases-title-bar {
-    background-color: #cce8ff;
+    background-color: #EBF1F6;
     padding: 8px 12px;
     border-bottom: 1px solid #a8d0f0;
 }

--- a/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
@@ -1,0 +1,28 @@
+/*
+ * Customisations tab bar responsive behaviour.
+ *
+ * Rather than relying on a fixed breakpoint, this collapses the tab labels to
+ * icons only as soon as the full-label tab bar would overflow its container
+ * (which would otherwise show a horizontal scroll bar). Labels are restored
+ * whenever there is room for them again.
+ */
+(function () {
+  const tabBar = document.getElementById('customisationsTabs');
+  if (!tabBar) {
+    return;
+  }
+
+  function updateTabLabels() {
+    // Measure in the labels-shown state so the decision is based on the space
+    // the labels actually need, not the collapsed width. Removing the class
+    // first forces a synchronous reflow before we read the dimensions.
+    tabBar.classList.remove('icons-only');
+
+    if (tabBar.scrollWidth > tabBar.clientWidth) {
+      tabBar.classList.add('icons-only');
+    }
+  }
+
+  window.addEventListener('resize', updateTabLabels);
+  updateTabLabels();
+})();

--- a/items/services/items_web_portal/templates/dashboard.html
+++ b/items/services/items_web_portal/templates/dashboard.html
@@ -19,7 +19,9 @@
     <div class="card p-3 border-dark mx-0 mb-3">
         <div class="d-flex align-items-center">
             <i class="bi bi-briefcase-fill fs-3 me-2"></i>
-            <h5 class="m-0 fw-bold">{{ project.name }}</h5>
+            <h5 class="m-0 fw-bold">
+                <a href="/{{ project.id }}/overview" class="text-black text-decoration-none">{{ project.name }}</a>
+            </h5>
         </div>
         <p class="mt-2">
             <a href="/{{ project.id }}/milestones" class="text-primary text-decoration-none">Milestones</a> |

--- a/items/services/items_web_portal/templates/instance_admin_customisations.html
+++ b/items/services/items_web_portal/templates/instance_admin_customisations.html
@@ -1,0 +1,100 @@
+{% extends "instance_admin_template.html" %}
+{% block title %}Integrated Test Management Suite | Customisations{% endblock %}
+{% block head %}{{ super() }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_customisations.css') }}">
+{% endblock %}
+
+{% block body_params %}id="body-pd"{% endblock %}
+
+{% block instance_admin_body %}
+    <div class="flex-grow-1">
+      <h4 class="mb-3">Customisations</h4>
+
+      <!-- Tab navigation -->
+      <ul class="nav nav-tabs customisations-tabs flex-nowrap" id="customisationsTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="case-fields-tab" data-bs-toggle="tab"
+                  data-bs-target="#case-fields" type="button" role="tab"
+                  aria-controls="case-fields" aria-selected="true" title="Case Fields">
+            <i class="bi bi-input-cursor-text"></i>
+            <span class="tab-label">Case Fields</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="result-fields-tab" data-bs-toggle="tab"
+                  data-bs-target="#result-fields" type="button" role="tab"
+                  aria-controls="result-fields" aria-selected="false" title="Result Fields">
+            <i class="bi bi-clipboard-data"></i>
+            <span class="tab-label">Result Fields</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="case-types-tab" data-bs-toggle="tab"
+                  data-bs-target="#case-types" type="button" role="tab"
+                  aria-controls="case-types" aria-selected="false" title="Case Types">
+            <i class="bi bi-tags"></i>
+            <span class="tab-label">Case Types</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="priorities-tab" data-bs-toggle="tab"
+                  data-bs-target="#priorities" type="button" role="tab"
+                  aria-controls="priorities" aria-selected="false" title="Priorities">
+            <i class="bi bi-flag"></i>
+            <span class="tab-label">Priorities</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="result-statuses-tab" data-bs-toggle="tab"
+                  data-bs-target="#result-statuses" type="button" role="tab"
+                  aria-controls="result-statuses" aria-selected="false" title="Result Statuses">
+            <i class="bi bi-check2-circle"></i>
+            <span class="tab-label">Result Statuses</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="case-statuses-tab" data-bs-toggle="tab"
+                  data-bs-target="#case-statuses" type="button" role="tab"
+                  aria-controls="case-statuses" aria-selected="false" title="Case Statuses">
+            <i class="bi bi-list-check"></i>
+            <span class="tab-label">Case Statuses</span>
+          </button>
+        </li>
+      </ul>
+
+      <!-- Tab content -->
+      <div class="tab-content customisations-tab-content" id="customisationsTabsContent">
+        <div class="tab-pane fade show active" id="case-fields" role="tabpanel"
+             aria-labelledby="case-fields-tab">
+          <p class="customisations-placeholder">Case Fields contents go here ...</p>
+        </div>
+        <div class="tab-pane fade" id="result-fields" role="tabpanel"
+             aria-labelledby="result-fields-tab">
+          <p class="customisations-placeholder">Result Fields contents go here ...</p>
+        </div>
+        <div class="tab-pane fade" id="case-types" role="tabpanel"
+             aria-labelledby="case-types-tab">
+          <p class="customisations-placeholder">Case Types contents go here ...</p>
+        </div>
+        <div class="tab-pane fade" id="priorities" role="tabpanel"
+             aria-labelledby="priorities-tab">
+          <p class="customisations-placeholder">Priorities contents go here ...</p>
+        </div>
+        <div class="tab-pane fade" id="result-statuses" role="tabpanel"
+             aria-labelledby="result-statuses-tab">
+          <p class="customisations-placeholder">Result Statuses contents go here ...</p>
+        </div>
+        <div class="tab-pane fade" id="case-statuses" role="tabpanel"
+             aria-labelledby="case-statuses-tab">
+          <p class="customisations-placeholder">Case Statuses contents go here ...</p>
+        </div>
+      </div>
+    </div>
+{% endblock %}
+
+{% block postBody %}{{ super() }}
+<script type="text/javascript"
+        src="{{ url_for('static', filename='scripts/instance_admin_customisations.js') }}">
+</script>
+{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_integrations.html
+++ b/items/services/items_web_portal/templates/instance_admin_integrations.html
@@ -1,0 +1,10 @@
+{% extends "instance_admin_template.html" %}
+{% block title %}Integrated Test Management Suite | Integrations{% endblock %}
+{% block head %}{{ super() }}
+{% endblock %}
+
+{% block body_params %}id="body-pd"{% endblock %}
+
+{% block instance_admin_body %}
+    <h3>Integrations contents go here ...</h3>
+{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_overview.html
+++ b/items/services/items_web_portal/templates/instance_admin_overview.html
@@ -69,6 +69,34 @@
           </div>
         </div>
 
+        <!-- Customisations -->
+        <div class="col-12 col-lg-6">
+          <div class="admin-card d-flex">
+            <div class="admin-card-icon me-3"><i class="bi bi-palette"></i></div>
+            <div>
+              <p class="admin-card-title"><a href="/admin/customisations">Customisations</a></p>
+              <p class="admin-card-description">Tailor fields, templates and the look &amp; feel of your instance.</p>
+              <ul class="admin-card-links">
+                <li><a href="/admin/customisations">Manage customisations</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <!-- Integrations -->
+        <div class="col-12 col-lg-6">
+          <div class="admin-card d-flex">
+            <div class="admin-card-icon me-3"><i class="bi bi-plug"></i></div>
+            <div>
+              <p class="admin-card-title"><a href="/admin/integrations">Integrations</a></p>
+              <p class="admin-card-description">Connect third-party tools, webhooks and external services.</p>
+              <ul class="admin-card-links">
+                <li><a href="/admin/integrations">Manage integrations</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
         <!-- Site Settings -->
         <div class="col-12 col-lg-6">
           <div class="admin-card d-flex">

--- a/items/services/items_web_portal/templates/instance_admin_template.html
+++ b/items/services/items_web_portal/templates/instance_admin_template.html
@@ -26,6 +26,14 @@
                class="nav-link text-dark {% if active_admin_page == 'admin_page_manage_data' %}fw-bold{% endif %}">
                 Manage Data
             </a>
+            <a href="/admin/customisations"
+               class="nav-link text-dark {% if active_admin_page == 'admin_page_customisations' %}fw-bold{% endif %}">
+                Customisations
+            </a>
+            <a href="/admin/integrations"
+               class="nav-link text-dark {% if active_admin_page == 'admin_page_integrations' %}fw-bold{% endif %}">
+                Integrations
+            </a>
             <a href="/admin/site_settings"
                class="nav-link text-dark {% if active_admin_page == 'admin_page_site_settings' %}fw-bold{% endif %}">
                 Site Settings

--- a/items/services/items_web_portal/templates/project_overview.html
+++ b/items/services/items_web_portal/templates/project_overview.html
@@ -1,0 +1,71 @@
+{% extends "project_page_template.html" %}
+{% block title %}Integrated Test Management Suite | Project Overview{% endblock %}
+{% block head %}{{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/project_overview.css') }}">
+{% endblock %}
+
+{% block project_content %}
+<div id="overview-content">
+
+    <!-- Title bar -->
+    <div id="overview-title-bar">
+        <h5 class="mb-0">Overview</h5>
+    </div>
+
+    <div class="overview-body">
+
+        <!-- Announcement banner -->
+        {% if show_announcement and announcement %}
+        <div class="overview-announcement">
+            <i class="bi bi-megaphone me-2"></i>{{ announcement }}
+        </div>
+        {% endif %}
+
+        <!-- Stats row (stubbed) -->
+        <div class="overview-stats-row">
+            <div class="stat-box">
+                <span class="stat-value stat-passed">0</span>
+                <span class="stat-label">Passed</span>
+            </div>
+            <div class="stat-box">
+                <span class="stat-value stat-failed">0</span>
+                <span class="stat-label">Failed</span>
+            </div>
+            <div class="stat-box">
+                <span class="stat-value stat-blocked">0</span>
+                <span class="stat-label">Blocked</span>
+            </div>
+            <div class="stat-box">
+                <span class="stat-value stat-retest">0</span>
+                <span class="stat-label">Retest</span>
+            </div>
+            <div class="stat-box">
+                <span class="stat-value stat-skipped">0</span>
+                <span class="stat-label">Skipped</span>
+            </div>
+        </div>
+
+        <!-- Milestones + Test Runs -->
+        <div class="overview-sections">
+
+            <!-- Milestones -->
+            <div class="overview-section">
+                <h6 class="overview-section-title">Milestones</h6>
+                <div class="overview-empty-state">
+                    <p>This project doesn't have any active milestones.</p>
+                </div>
+            </div>
+
+            <!-- Test Runs -->
+            <div class="overview-section">
+                <h6 class="overview-section-title">Test Runs</h6>
+                <div class="overview-empty-state">
+                    <p>This project doesn't have any active test runs.</p>
+                </div>
+            </div>
+
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/items/services/items_web_portal/templates/project_page_template.html
+++ b/items/services/items_web_portal/templates/project_page_template.html
@@ -61,12 +61,12 @@
             </div>
 
             <nav class="sidebar-nav">
-                <a href="/{{ project_id }}/testcases#"
+                <a href="/{{ project_id }}/overview"
                    class="sidebar-nav-item {% if active_page == 'overview' %}active{% endif %}">
                     <i class="bi bi-clipboard-data"></i>
                     <span>Project Overview</span>
                 </a>
-                <a href="/{{ project_id }}/testcases#"
+                <a href="#"
                    class="sidebar-nav-item {% if active_page == 'todo' %}active{% endif %}">
                     <i class="bi bi-check2-square"></i>
                     <span>To-Do</span>

--- a/items/services/items_web_portal/templates/project_page_template.html
+++ b/items/services/items_web_portal/templates/project_page_template.html
@@ -61,12 +61,12 @@
             </div>
 
             <nav class="sidebar-nav">
-                <a href="/{{ project_id }}/overview"
+                <a href="/{{ project_id }}/testcases#"
                    class="sidebar-nav-item {% if active_page == 'overview' %}active{% endif %}">
                     <i class="bi bi-clipboard-data"></i>
                     <span>Project Overview</span>
                 </a>
-                <a href="/{{ project_id }}/todo"
+                <a href="/{{ project_id }}/testcases#"
                    class="sidebar-nav-item {% if active_page == 'todo' %}active{% endif %}">
                     <i class="bi bi-check2-square"></i>
                     <span>To-Do</span>

--- a/items/services/items_web_portal/templates/project_page_template.html
+++ b/items/services/items_web_portal/templates/project_page_template.html
@@ -1,25 +1,22 @@
 {% extends "bootstrap_enabled_template.html" %}
 {% block head %}{{ super() }}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
     <link rel="stylesheet" href="{{ url_for('static', filename='css/project_page_template.css') }}">
 {% endblock %}
 
 {% block body_params %}id="body-pd"{% endblock %}
 {% block page_body %}
 
-    <!-- First Line: Wibble, User Dropdown, Help Dropdown -->
+    <!-- First Line: Back to Dashboard, User/Help -->
     <nav class="navbar navbar-expand-lg navbar-custom">
         <div class="container-fluid menubar_first-line">
-            <!-- Left-hand link: Wibble -->
             <a class="navbar-brand" href="/">
                 <span class="menubar_first_line_link">
                     <i class="fas fa-arrow-left menubar_first_line_link_arrow"></i>
                     Back to Dashboard
                 </span>
             </a>
-
-            <!-- Right-aligned items: User and Help Dropdowns -->
             <div class="d-flex">
-                <!-- User Dropdown -->
                 <div class="dropdown light-blue-box">
                     <a class="nav-link dropdown-toggle user_dropdown_text" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         User
@@ -30,8 +27,6 @@
                         <li><a class="dropdown-item" href="#">Logout</a></li>
                     </ul>
                 </div>
-
-                <!-- Help Dropdown -->
                 <div class="dropdown light-blue-box">
                     <a class="nav-link dropdown-toggle help_dropdown_text" href="#" id="helpDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         Help
@@ -45,42 +40,65 @@
         </div>
     </nav>
 
-    <!-- Second Line: Indented Name -->
+    <!-- Second Line: Instance Name -->
     <div class="menubar_second-line">
         <div class="container-fluid">
-            <span class="fs-6 fs-md-5 fs-lg-4">
-                <img src=  "{{ url_for('static', filename='logo.png') }}"
+            <span class="fs-6">
+                <img src="{{ url_for('static', filename='logo.png') }}"
                      width=30 height=30 alt="ITEMS Logo">
                 {{ instance_name }}</span>
         </div>
     </div>
 
-    <!-- Third Line: Menu Items -->
-    <nav class="navbar navbar-expand-lg navbar-light menubar_third-line">
-        <div class="container-fluid">
-            <!-- Left-justified items: Overview, Todo, Test Cases -->
-            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'overview' %}current{% endif %}"
-                       href="#">Overview</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'todo' %}current{% endif %}"
-                       href="#">Todo</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link {% if active_page == 'test-cases' %}current{% endif %}"
-                       href="#">Test Cases</a>
-                </li>
-            </ul>
+    <!-- Main layout: sidebar + content -->
+    <div class="project-layout">
 
-            <!-- Right-justified item: Administration -->
-            <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link" href="#">Administration</a>
-                </li>
-            </ul>
+        <!-- Sidebar -->
+        <div class="project-sidebar">
+            <div class="sidebar-project-header">
+                <span class="sidebar-badge">{{ project_name[0]|upper if project_name else 'P' }}</span>
+                <span class="sidebar-project-name">{{ project_name }}</span>
+            </div>
+
+            <nav class="sidebar-nav">
+                <a href="/{{ project_id }}/overview"
+                   class="sidebar-nav-item {% if active_page == 'overview' %}active{% endif %}">
+                    <i class="bi bi-clipboard-data"></i>
+                    <span>Project Overview</span>
+                </a>
+                <a href="/{{ project_id }}/todo"
+                   class="sidebar-nav-item {% if active_page == 'todo' %}active{% endif %}">
+                    <i class="bi bi-check2-square"></i>
+                    <span>To-Do</span>
+                </a>
+                <a href="/{{ project_id }}/testcases"
+                   class="sidebar-nav-item {% if active_page == 'test-cases' %}active{% endif %}">
+                    <i class="bi bi-journal-code"></i>
+                    <span>Test Cases</span>
+                </a>
+                <a href="#"
+                   class="sidebar-nav-item {% if active_page == 'test-runs' %}active{% endif %}">
+                    <i class="bi bi-play-circle"></i>
+                    <span>Test Runs &amp; Results</span>
+                </a>
+                <a href="#"
+                   class="sidebar-nav-item {% if active_page == 'milestones' %}active{% endif %}">
+                    <i class="bi bi-flag"></i>
+                    <span>Milestones</span>
+                </a>
+                <a href="#"
+                   class="sidebar-nav-item {% if active_page == 'reports' %}active{% endif %}">
+                    <i class="bi bi-bar-chart"></i>
+                    <span>Reports</span>
+                </a>
+            </nav>
         </div>
-    </nav>
+
+        <!-- Content area -->
+        <div class="project-content">
+            {% block project_content %}{% endblock %}
+        </div>
+
+    </div>
 
 {% endblock %}

--- a/items/services/items_web_portal/templates/project_testcases.html
+++ b/items/services/items_web_portal/templates/project_testcases.html
@@ -4,14 +4,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/project_testcases.css') }}">
 {% endblock %}
 
-{% block body_params %}id="body-pd"{% endblock %}
-{% block page_body %}
-{{ super() }}
-
 {% macro render_folder(folders, level=0) %}
     {% for folder in folders %}
         <div class="folder" style="margin-left: {{ level * 20 }}px;">
-            {{ folder.name }}  <!-- Folder name -->
+            {{ folder.name }}
         </div>
 
         {% if folder.test_cases %}
@@ -33,49 +29,48 @@
             </table>
         {% endif %}
 
-        {% if folder.subfolders %}  {# Check if this folder has subfolders #}
-            {{ render_folder(folder.subfolders, level + 1) }}  {# Recursive call #}
+        {% if folder.subfolders %}
+            {{ render_folder(folder.subfolders, level + 1) }}
         {% endif %}
     {% endfor %}
 {% endmacro %}
 
-    <div class="wrapper mx-2 height-100">
+{% block project_content %}
+<div id="content">
+    <div id="testcases-title-bar">
+        <h5 class="mb-0">Test Cases</h5>
+    </div>
 
-      <div id="content">
-        <div class="row">
-          <div id="testcases-title-bar">
-            <h5 class="mb-0">Test Cases</h5>
-          </div>
-        </div>
-        <div class="row m-2">{% if has_testcases == True %}
+    <div class="p-3">
+        {% if has_testcases == True %}
             <div id="folder-structure">
                 {{ render_folder(data) }}
             </div>
-
-          {% else %}
-          <div id="no_data_msg_jumbo" class="jumbotron text-black border border-dark w-100">
-            <div class="container mt-1 mx-0" id="no_data_msg_container">
-              <div class="row w-100">
-                <div class="col-1 text-center d-flex justify-content-center align-items-center">
-                  <i class='lead bx bx-info-circle text-primary'></i>
+        {% else %}
+            <div id="no_data_msg_jumbo" class="jumbotron text-black border border-dark w-100">
+                <div class="container mt-1 mx-0" id="no_data_msg_container">
+                    <div class="row w-100">
+                        <div class="col-1 text-center d-flex justify-content-center align-items-center">
+                            <i class='lead bx bx-info-circle text-primary'></i>
+                        </div>
+                        <div class="col">
+                            <p class="fw-bold mb-1">There aren't any test cases, yet.</p>
+                            <p class="mb-2">There aren't any sections or test cases. Use the following buttons to create the first test case and section.</p>
+                            <p>
+                                <button type="button" class="btn btn-sm btn-header me-1" data-bs-toggle="modal"
+                                        data-bs-target="#addSectionModal">
+                                    <strong>+</strong> Add Section
+                                </button>
+                                <button type="button" class="btn btn-sm btn-header" data-bs-toggle="modal"
+                                        data-bs-target="#addTestCaseModal">
+                                    <strong>+</strong> Add Test Case
+                                </button>
+                            </p>
+                        </div>
+                    </div>
                 </div>
-                <div class="col">
-                  <p class="fw-bold mb-1">There aren't any test cases, yet.</p>
-                  <p class="mb-2">There aren't any sections or test cases. Use the following buttons to create the first test case and section.</p>
-                  <p>
-                    <button type="button" class="btn btn-sm btn-header me-1" data-bs-toggle="modal"
-                            data-bs-target="#addSectionModal">
-                      <strong>+</strong> Add Section
-                    </button>
-                    <button type="button" class="btn btn-sm btn-header" data-bs-toggle="modal"
-                            data-bs-target="#addTestCaseModal">
-                      <strong>+</strong> Add Test Case
-                    </button>
-                  </p>
-                </div>
-              </div>
             </div>
-          </div>{% endif %}
-        </div>
-      </div>
-    </div>{% endblock %}
+        {% endif %}
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What does this PR do?

# Web portal page handlers part 3 + Docker/compose fixes

**Branch:** `portal_page_handlers_part_3` → `main`
**Stats:** 10 commits, 41 files changed, +1527/−642

## Summary

Finishes porting the remaining admin stub pages off the old `apis/dashboard_api_view.py`
into the `page_handlers/admin/` structure (completing the work flagged as a
deliberate follow-up in the previous PR), adds the project overview and
project testcases pages, fixes a real webhook signature bug in `service.py`,
and — the main session's work — fixes the Docker build and the entire
`docker-compose` stack, which had drifted badly out of date.

## New: remaining admin pages
`page_handlers/admin/admin_{customisations,integrations,manage_data,site_settings,users_and_roles}_page_handler.py`

Five new page handlers, replacing routes that were previously calling
`injections.admin_manage_data()` / `injections.admin_site_settings()` /
`injections.admin_users_and_roles()` — `PageHandlerInjections` is a plain
dependency-injection dataclass and has no such methods, so these routes would
have crashed with `AttributeError` the moment anyone hit them. Also fixed:
the routes were registered as `/admin/users_roles` etc. *inside* a blueprint
already mounted at the `/admin` prefix, doubling up to `/admin/admin/...` —
now registered relative to the blueprint (`/users_roles`, `/manage_data`, ...).
Sidebar nav (`instance_admin_template.html`) updated with links to the two
genuinely new pages (Customisations, Integrations).

## New: project overview / testcases pages
- `page_handlers/projects/get_project_overview_page_handler.py` — fleshed out
  (`GET /<project_id>/overview`).
- `page_handlers/testcases/get_project_testcases_page_handler.py` — new
  (`GET /<project_id>/testcases`), replacing the old, dead
  `apis/projects_api_view.py` → `page_handlers/testcases/projects_api_view.py`
  file from the previous branch (now deleted).
- New CSS for both (`project_overview.css`, `project_testcases.css`,
  `project_page_template.css` extended).

## Dead code removed
`apis/dashboard_api_view.py` (290 lines) — the `DashboardApiView` class flagged
as orphaned dead code in the previous PR (its routes had already moved to
`page_handlers/admin/`, and by the time the admin pages above landed, nothing
referenced it at all). Deleted now that the port is complete.

## Bug fixes in `service.py`
- **Metadata retrieval re-enabled** — `_get_metadata()` was previously commented
  out behind a `# TEMPORARY DISABLE`, meaning the web portal never actually
  fetched instance metadata (timezone, instance name) from the gateway on
  startup. Re-enabled, wrapped with proper handling for `CancelledError`/
  `KeyboardInterrupt` during startup (closes the HTTP session cleanly instead
  of leaking an "Unclosed client session" warning) and a clean early-return on
  failure.
- **`_close_http_session()` made idempotent** — extracted from the shutdown
  path so it can also be called from the new interrupted-startup path without
  risk of double-closing the session.
- **Webhook signature path mismatch** — the signature was computed over
  `/web/webhook/get_metadata:{nonce}` and the request sent to
  `.../web/webhook/get_metadata?nonce=...`, but the gateway's actual route is
  `/web/webhook/metadata` (confirmed against `GetMetadataHandler.get_metadata()`,
  which signs against the real incoming `request.path`). Every metadata fetch
  would have failed signature verification. Both the signed string and the
  request URL now correctly say `metadata`, not `get_metadata`.

## Docker build + compose stack fixes

Started from a report that the nightly Web Portal Docker build was failing.
Root cause and everything it led to:

**`docker/Dockerfile.web_portal_svc`** — never updated after the source moved
to `items/services/items_web_portal/`:
- `COPY docker/requirements-web_portal_svc.txt .` referenced a file that
  doesn't exist (`requirements/requirements_web_portal.txt` is the real one).
- `COPY items/web_portal_svc ...` copied from a path that doesn't exist
  (`items/services/items_web_portal` is real) — this alone broke the build.
- `CMD`/`ENV`/`EXPOSE` were also stale: ran `quart run -p 8080`/`uvicorn main:app`
  instead of the real entry point `python -m items.services.items_web_portal.run`;
  used `ITEMS_WEB_PORTAL_SVC_CONFIG_FILE` (extra `_SVC_`, doesn't match what
  `service.py` reads) instead of `ITEMS_WEB_PORTAL_CONFIG_FILE`; exposed 8080
  instead of the real default port, 8000.
- Rewritten to match the already-correct `Dockerfile.gateway_svc`/`Dockerfile.cms_svc`
  pattern. Verified with a local `docker build` + `docker run` — starts clean,
  fails only on a missing config file as expected without one mounted.

**`docker/Dockerfile.identity_svc`** — corrected alongside (24 lines).

**The entire `docker-compose` stack was stale**, none of it matching the
services' real ports or config paths:

| Service | Was | Now |
|---|---|---|
| `accounts_svc` → `identity_svc` | wrong image name (`items_accounts_svc`), port 4000, `Dockerfile.accounts_svc` referenced in the override file (doesn't exist) | correct image (`items_identity_svc`), port 5050 |
| `cms_svc` | port 5050 | port 6050 |
| `gateway_svc` | port 3000 | port 7050 |
| `web_portal_svc` | port 8080 | port 8000 |

Fixed across `docker-compose.yml`, `docker-compose.override.yml`, `.env`
(renamed `ACCOUNTS_SVC_*` → `IDENTITY_SVC_*` throughout, corrected stale DB
filenames that didn't match what's actually on disk), and all four mounted
`configs/*.cfg` files — `gateway.cfg` was still pointing at `accounts_svc:4000`
and `cms_svc:5050` (both wrong), and was missing a `web_portal_svc` entry
entirely; `web_portal.cfg` pointed at `gateway_svc:3000`.

`docker-compose.production.yml` was left mostly untouched — it's an
unfinished draft (single-letter placeholder image tags, no `web_portal_svc`
entry, a port mapping that doesn't correspond to any real port) — only the
service key was renamed to `identity_svc` so it doesn't silently orphan when
merged with the base file. Didn't want to invent production image tags that
haven't actually been decided.

**Verified with a full `docker compose up --build`**: all four containers
built and started cleanly, gateway successfully reached `identity_svc:5050`
and `cms_svc:6050` over the Docker network during its own startup health
checks, and all four services answered correctly from the host
(`/system/health` on identity/CMS, `/login` on web portal).

## Small fixes
- `dashboard.html` — project name is now a clickable link to
  `/<project_id>/overview`; the "Test Cases" link now points at
  `/<project_id>/testcases` (was `/test_cases`, didn't match the registered
  route).
- `instance_admin_add_project.html` — announcement `<textarea>` no longer has
  stray leading/trailing whitespace baked into the rendered value (added
  `|trim`).


## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [x] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [ ] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
