### PR TITLE
[CMS] Testcase Folders

### DIFF
--- a/design_docs/folder_deletion_and_testcases.md
+++ b/design_docs/folder_deletion_and_testcases.md
@@ -1,0 +1,70 @@
+# Folder deletion vs. test case deletion
+
+**Status:** Design note — not yet implemented. Revisit when test case CRUD
+work begins.
+
+## Context
+
+CMS testcase folder CRUD (`items/services/items_cms/routes/folders/`)
+currently deletes a folder unconditionally, relying on `ON DELETE CASCADE`
+to remove any child folders and — once test case CRUD exists — any test
+cases sitting in that subtree too (`tc_test_cases.folder_id` also cascades
+from `tc_folders`).
+
+This is fine today because there is no way to create a test case yet, so a
+folder can never actually contain one. It stops being fine once test case
+CRUD lands: a folder delete would then silently wipe out real work product
+(test cases, and whatever custom field values or future test-run history
+hang off them) with no warning and no way to undo it.
+
+## Decision (agreed, not yet built)
+
+- **Test cases get soft/hard delete**, mirroring the pattern already used
+  by projects (`awaiting_purge` for soft delete, permanent removal for hard
+  delete). Test cases represent real work product, so accidental loss
+  matters more than it does for a folder.
+- **Folders stay hard-delete-only.** A folder is pure organisation — there's
+  nothing to lose by deleting the folder itself, only by deleting what's
+  inside it.
+- **`DELETE /folders/<id>` refuses by default if the folder contains any
+  test cases, recursively** (i.e. in the folder itself or any descendant
+  folder). Returns `409 Conflict` with the count in the body, e.g.
+  `{"error": "...", "testcase_count": 12}`. No deletion happens.
+- **`DELETE /folders/<id>?cascade=true` proceeds anyway**, deleting the
+  folder, all descendant folders, and all test cases underneath. Mirrors the
+  existing `?hard_delete=true` query param already used on project delete,
+  so the shape is consistent with precedent elsewhere in this API.
+- **A separate read-only "count" endpoint** (exact route TBD — something
+  like `GET /folders/<id>/testcase_count`) is worth adding *in addition*,
+  purely so the web portal can show "this folder contains 12 test cases"
+  proactively in a confirmation dialog, before the user even attempts the
+  delete. This is a UI convenience, not the actual safety mechanism — the
+  409-by-default behaviour on `DELETE` is what actually prevents accidental
+  data loss, since a separate count-then-delete flow has an inherent race
+  condition (a test case could be added between the count call and the
+  delete call).
+
+## Why this wasn't built into the folder CRUD PR
+
+A `cascade` query param on `DELETE /folders/<id>` is purely additive —
+optional, defaults to today's behaviour — so there's no compatibility cost
+to adding it later. Building it now would mean either:
+- the 409/cascade logic never actually triggers (no folder can contain a
+  test case yet), so it ships as untested dead code, or
+- inventing a fake "testcase_count" concept ahead of the real test case
+  schema/service work, which risks not matching what that work actually
+  needs.
+
+Better to pick this up once test case CRUD is underway and there's a real
+`tc_test_cases` service to query against.
+
+## Open questions for when this is picked up
+
+- Exact route/shape for the count endpoint — dedicated route vs. a query
+  param on `GET /folders/<id>` (e.g. `?include_testcase_count=true`).
+- Whether the count should distinguish soft-deleted (awaiting purge) test
+  cases from active ones, once test cases have that concept.
+- Whether `cascade=true` on folder delete should hard-delete or soft-delete
+  the test cases underneath — likely soft-delete by default, with a further
+  `hard_delete=true` needed on top, matching how project delete already
+  layers these two flags.

--- a/items/services/items_cms/repositories/folder_repository.py
+++ b/items/services/items_cms/repositories/folder_repository.py
@@ -1,0 +1,204 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterface
+from items.services.items_cms.cms_configuration import CMSConfiguration
+import items.services.items_cms.cms_db_tables as cms_tables
+
+
+class FolderRepository:
+    """
+    Persistence operations for testcase folder data.
+
+    Encapsulates all database access for the folders domain. Raises
+    SqliteInterfaceException on database failures; callers are responsible
+    for handling those exceptions and updating service state accordingly.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: CMSConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._db = SqliteInterface(self._logger, config.backend_db_filename)
+
+    async def is_valid_project_id(self, project_id: int) -> bool:
+        """Return True if the project ID exists in the database.
+
+        Args:
+            project_id: ID of the project to check.
+
+        Returns:
+            True if the project exists, False otherwise.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = f"SELECT id FROM {cms_tables.PRJ_PROJECTS} WHERE id = ?"
+        row = await self._db.run_query(query, (project_id,), fetch_one=True)
+        return bool(row)
+
+    async def get_folder(self, folder_id: int) -> Optional[dict]:
+        """Retrieve full details for a single folder.
+
+        Args:
+            folder_id: Primary key of the folder.
+
+        Returns:
+            A dict with ``id``, ``project_id``, ``parent_id``, and ``name``
+            if found, or None if no row matches.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT id, project_id, parent_id, name "
+            f"FROM {cms_tables.TC_FOLDERS} WHERE id = ?"
+        )
+        row = await self._db.run_query(query, (folder_id,), fetch_one=True)
+
+        if not row:
+            return None
+
+        folder_id, project_id, parent_id, name = row
+        return {
+            'id': folder_id,
+            'project_id': project_id,
+            'parent_id': parent_id,
+            'name': name
+        }
+
+    async def get_folders(self, project_id: int) -> list[dict]:
+        """Retrieve every folder belonging to a project, as a flat list.
+
+        Args:
+            project_id: ID of the project to query.
+
+        Returns:
+            A list of ``{id, parent_id, name}`` dicts, ordered by parent
+            then id.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT id, parent_id, name FROM {cms_tables.TC_FOLDERS} "
+            "WHERE project_id = ? ORDER BY parent_id, id"
+        )
+        rows = await self._db.run_query(query, (project_id,))
+
+        return [
+            {'id': folder_id, 'parent_id': parent_id, 'name': name}
+            for folder_id, parent_id, name in (rows or [])
+        ]
+
+    async def folder_name_exists(self,
+                                 project_id: int,
+                                 parent_id: Optional[int],
+                                 name: str,
+                                 exclude_id: Optional[int] = None) -> bool:
+        """Return True if a sibling folder with the given name already exists.
+
+        Case-sensitive match against folders sharing the same project and
+        parent. SQL ``NULL`` never equals ``NULL``, so root-level folders
+        (``parent_id IS NULL``) are compared with an explicit ``IS NULL``
+        clause rather than ``= ?``.
+
+        Args:
+            project_id:  Project the folder belongs to.
+            parent_id:   Parent folder ID, or None for a root-level folder.
+            name:        Folder name to check.
+            exclude_id:  ID of the folder being updated (excluded from the
+                         check), or None when creating a new folder.
+
+        Returns:
+            True if the name is already taken by a sibling folder.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        parent_clause = "parent_id IS NULL" if parent_id is None \
+            else "parent_id = ?"
+        params: list = [project_id]
+        if parent_id is not None:
+            params.append(parent_id)
+        params.append(name)
+
+        query = (
+            f"SELECT 1 FROM {cms_tables.TC_FOLDERS} "
+            f"WHERE project_id = ? AND {parent_clause} AND name = ?"
+        )
+
+        if exclude_id is not None:
+            query += " AND id != ?"
+            params.append(exclude_id)
+
+        query += " LIMIT 1"
+
+        row = await self._db.run_query(query, tuple(params), fetch_one=True)
+        return bool(row)
+
+    async def add_folder(self,
+                         project_id: int,
+                         parent_id: Optional[int],
+                         name: str) -> int:
+        """Insert a new folder and return its ID.
+
+        Args:
+            project_id: Project the folder belongs to.
+            parent_id:  Parent folder ID, or None for a root-level folder.
+            name:       Folder name.
+
+        Returns:
+            The ID of the newly inserted folder row.
+
+        Raises:
+            SqliteInterfaceException: If the database insert fails.
+        """
+        query = (
+            f"INSERT INTO {cms_tables.TC_FOLDERS} "
+            "(project_id, parent_id, name) VALUES (?, ?, ?)"
+        )
+        return await self._db.insert_query(
+            query, (project_id, parent_id, name))
+
+    async def update_folder_name(self, folder_id: int, name: str) -> None:
+        """Rename an existing folder.
+
+        Args:
+            folder_id: ID of the folder to rename.
+            name:      New folder name.
+
+        Raises:
+            SqliteInterfaceException: If the database update fails.
+        """
+        query = f"UPDATE {cms_tables.TC_FOLDERS} SET name = ? WHERE id = ?"
+        await self._db.run_query(query, (name, folder_id), commit=True)
+
+    async def delete_folder(self, folder_id: int) -> None:
+        """Permanently delete a folder from the database.
+
+        Child folders and their test cases are removed automatically via
+        ``ON DELETE CASCADE``.
+
+        Args:
+            folder_id: ID of the folder to delete.
+
+        Raises:
+            SqliteInterfaceException: If the database delete fails.
+        """
+        query = f"DELETE FROM {cms_tables.TC_FOLDERS} WHERE id = ?"
+        await self._db.run_query(query, (folder_id,), commit=True)

--- a/items/services/items_cms/routes/__init__.py
+++ b/items/services/items_cms/routes/__init__.py
@@ -18,6 +18,7 @@ import quart
 from items.shared.service_state import ServiceState
 from items.services.items_cms.cms_configuration import CMSConfiguration
 from .projects import create_projects_routes
+from .folders import create_folders_routes
 from .testcases import create_testcases_routes
 from .testcase_custom_fields import create_testcase_custom_fields_routes
 from .system import create_system_routes
@@ -44,6 +45,9 @@ def create_routes(logger: logging.Logger,
     routes_bp.register_blueprint(create_projects_routes(logger,
                                                         state,
                                                         configuration))
+    routes_bp.register_blueprint(create_folders_routes(logger,
+                                                       state,
+                                                       configuration))
     routes_bp.register_blueprint(create_testcases_routes(logger,
                                                          state,
                                                          configuration))

--- a/items/services/items_cms/routes/folders/__init__.py
+++ b/items/services/items_cms/routes/folders/__init__.py
@@ -1,0 +1,105 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from quart import Blueprint
+from items.shared.service_state import ServiceState
+from items.services.items_cms.cms_configuration import CMSConfiguration
+from items.services.items_cms.repositories.folder_repository import (
+    FolderRepository)
+from items.services.items_cms.services.folder_service import FolderService
+from .get_folder_handler import GetFolderHandler
+from .list_folders_handler import ListFoldersHandler
+from .add_folder_handler import AddFolderHandler
+from .modify_folder_handler import ModifyFolderHandler
+from .delete_folder_handler import DeleteFolderHandler
+
+
+def create_folders_routes(logger: logging.Logger,
+                          service_state: ServiceState,
+                          config: CMSConfiguration) -> Blueprint:
+    """Create and return the folders API Blueprint.
+
+    Instantiates the folder repository and service once, wires them
+    into individual route handlers, and registers all folder endpoints
+    with a Quart Blueprint.
+
+    Args:
+        logger:        Parent logger instance.
+        service_state: Shared service operational state.
+        config:        CMS service configuration, used to locate the
+                       database file.
+
+    Returns:
+        A configured Blueprint with all folder routes registered.
+    """
+    # pylint: disable=too-many-locals
+
+    folders_routes = Blueprint("folders_routes", __name__)
+
+    repository = FolderRepository(logger, config)
+    service = FolderService(logger, service_state, repository)
+
+    get_handler = GetFolderHandler(logger, service)
+    list_handler = ListFoldersHandler(logger, service)
+    add_handler = AddFolderHandler(logger, service)
+    modify_handler = ModifyFolderHandler(logger, service)
+    delete_handler = DeleteFolderHandler(logger, service)
+
+    logger.debug("--- Registering Folders API routes ---")
+
+    # Get details of a specific folder.
+    logger.debug("=> %s GET /folders/<int:folder_id>",
+                 "Get folder details".ljust(40))
+
+    @folders_routes.route('/folders/<int:folder_id>', methods=['GET'])
+    async def get_folder(folder_id: int):
+        return await get_handler.get_folder(folder_id)
+
+    # List all folders for a project.
+    logger.debug("=> %s GET /folders?project_id=<id>",
+                 "List folders for project".ljust(40))
+
+    @folders_routes.route('/folders', methods=['GET'])
+    async def list_folders():
+        return await list_handler.list_folders()
+
+    # Create a folder.
+    logger.debug("=> %s POST /folders",
+                 "Create new folder".ljust(40))
+
+    @folders_routes.route('/folders', methods=['POST'])
+    async def add_folder():
+        # pylint: disable=no-value-for-parameter
+        return await add_handler.add_folder()
+
+    # Rename a folder.
+    logger.debug("=> %s PATCH /folders/<int:folder_id>",
+                 "Rename folder".ljust(40))
+
+    @folders_routes.route('/folders/<int:folder_id>', methods=['PATCH'])
+    async def modify_folder(folder_id: int):
+        # pylint: disable=no-value-for-parameter
+        return await modify_handler.modify_folder(folder_id)
+
+    # Delete a folder.
+    logger.debug("=> %s DELETE /folders/<int:folder_id>",
+                 "Delete a folder".ljust(40))
+
+    @folders_routes.route('/folders/<int:folder_id>', methods=['DELETE'])
+    async def delete_folder(folder_id: int):
+        return await delete_handler.delete_folder(folder_id)
+
+    return folders_routes

--- a/items/services/items_cms/routes/folders/add_folder_handler.py
+++ b/items/services/items_cms/routes/folders/add_folder_handler.py
@@ -1,0 +1,94 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_cms.services.folder_service import FolderService
+
+SCHEMA_ADD_FOLDER_REQUEST: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "project_id": {"type": "integer"},
+        "parent_id": {"type": ["integer", "null"]},
+        "name": {"type": "string", "minLength": 1}
+    },
+    "required": ["project_id", "parent_id", "name"]
+}
+
+
+class AddFolderHandler(BaseApiRoute):
+    """Handles POST /folders requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: FolderService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Folder service used to create folders.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    @validate_json(SCHEMA_ADD_FOLDER_REQUEST)
+    async def add_folder(self, request_msg: ApiResponse) -> Response:
+        """Create a new testcase folder.
+
+        Request body (JSON):
+            project_id (int):        Project the folder belongs to.
+            parent_id (int | null):  Parent folder ID, or null for a
+                                     root-level folder.
+            name (str):              Folder name. Must be unique among
+                                     its siblings.
+
+        Returns:
+            200 with ``{"folder_id": <int>}`` on success.
+            400 if the request body is invalid.
+            404 if the project or parent folder does not exist.
+            409 if the name is already taken by a sibling folder.
+            500 on an internal database error.
+        """
+        body = request_msg.body
+        result = await self._service.create_folder(
+            project_id=body["project_id"],
+            parent_id=body["parent_id"],
+            name=body["name"])
+
+        if not result.success:
+            if result.is_internal:
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+            elif result.not_found:
+                status = HTTPStatus.NOT_FOUND
+            elif result.is_conflict:
+                status = HTTPStatus.CONFLICT
+            else:
+                status = HTTPStatus.BAD_REQUEST
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"folder_id": result.data}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/folders/delete_folder_handler.py
+++ b/items/services/items_cms/routes/folders/delete_folder_handler.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_cms.services.folder_service import FolderService
+
+
+class DeleteFolderHandler(BaseApiRoute):
+    """Handles DELETE /folders/<folder_id> requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: FolderService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Folder service used to delete folders.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    async def delete_folder(self, folder_id: int) -> Response:
+        """Delete a folder.
+
+        Child folders and their test cases are removed automatically via
+        the database's cascading delete constraints.
+
+        Args:
+            folder_id: ID of the folder to delete, taken from the URL path.
+
+        Returns:
+            200 with ``{}`` on success.
+            404 if no folder exists with the given ID.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        result = await self._service.delete_folder(folder_id)
+
+        if not result.success:
+            status = (HTTPStatus.INTERNAL_SERVER_ERROR
+                      if result.is_internal else HTTPStatus.NOT_FOUND)
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/folders/get_folder_handler.py
+++ b/items/services/items_cms/routes/folders/get_folder_handler.py
@@ -1,0 +1,66 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_cms.services.folder_service import FolderService
+
+
+class GetFolderHandler(BaseApiRoute):
+    """Handles GET /folders/<folder_id> requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: FolderService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Folder service used to retrieve folder data.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    async def get_folder(self, folder_id: int) -> Response:
+        """Retrieve full details for a single folder.
+
+        Args:
+            folder_id: ID of the folder to retrieve, taken from the
+                       URL path.
+
+        Returns:
+            200 with the folder details dict on success.
+            404 if no folder exists with the given ID.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        result = await self._service.get_folder(folder_id)
+
+        if not result.success:
+            status = (HTTPStatus.INTERNAL_SERVER_ERROR
+                      if result.is_internal else HTTPStatus.NOT_FOUND)
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps(result.data),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/folders/list_folders_handler.py
+++ b/items/services/items_cms/routes/folders/list_folders_handler.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+import quart
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_cms.services.folder_service import FolderService
+
+
+class ListFoldersHandler(BaseApiRoute):
+    """Handles GET /folders requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: FolderService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Folder service used to retrieve folder data.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    async def list_folders(self) -> Response:
+        """Retrieve every folder for a project.
+
+        Query parameters:
+            project_id (int): ID of the project to list folders for.
+                              Required.
+
+        Returns:
+            200 with ``{"folders": [...]}`` on success.
+            400 if ``project_id`` is missing or not an integer.
+            404 if ``project_id`` does not refer to an existing project.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        project_id_param = quart.request.args.get("project_id")
+
+        if project_id_param is None:
+            return Response(
+                json.dumps({"error": "project_id is required"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        try:
+            project_id = int(project_id_param)
+        except ValueError:
+            return Response(
+                json.dumps({"error": "project_id must be an integer"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        result = await self._service.list_folders(project_id)
+
+        if not result.success:
+            status = (HTTPStatus.INTERNAL_SERVER_ERROR
+                      if result.is_internal else HTTPStatus.NOT_FOUND)
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"folders": result.data}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/folders/modify_folder_handler.py
+++ b/items/services/items_cms/routes/folders/modify_folder_handler.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_cms.services.folder_service import FolderService
+
+SCHEMA_MODIFY_FOLDER_REQUEST: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string", "minLength": 1}
+    },
+    "required": ["name"]
+}
+
+
+class ModifyFolderHandler(BaseApiRoute):
+    """Handles PATCH /folders/<folder_id> requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: FolderService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Folder service used to rename folders.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    @validate_json(SCHEMA_MODIFY_FOLDER_REQUEST)
+    async def modify_folder(self,
+                            request_msg: ApiResponse,
+                            folder_id: int) -> Response:
+        """Rename an existing folder.
+
+        Args:
+            folder_id: ID of the folder to rename, taken from the URL path.
+
+        Request body (JSON):
+            name (str): New folder name. Must be unique among siblings.
+
+        Returns:
+            200 with ``{"status": 1}`` on success.
+            400 if the request body is invalid.
+            404 if no folder exists with the given ID.
+            409 if the name is already taken by a sibling folder.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        result = await self._service.update_folder(
+            folder_id=folder_id, name=request_msg.body["name"])
+
+        if not result.success:
+            if result.is_internal:
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+            elif result.not_found:
+                status = HTTPStatus.NOT_FOUND
+            elif result.is_conflict:
+                status = HTTPStatus.CONFLICT
+            else:
+                status = HTTPStatus.BAD_REQUEST
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": 1}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/services/folder_service.py
+++ b/items/services/items_cms/services/folder_service.py
@@ -1,0 +1,340 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from dataclasses import dataclass, field
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_cms.services.service_result import ServiceResult
+from items.shared.service_state import ServiceState
+from items.services.items_cms.repositories.folder_repository import (
+    FolderRepository)
+
+
+@dataclass(slots=True)
+class FolderResult(ServiceResult):
+    """Outcome of a folder service operation.
+
+    Extends ServiceResult with an ``is_conflict`` flag to distinguish
+    resource-conflict failures (HTTP 409, e.g. a duplicate sibling name)
+    from generic client errors (HTTP 400).
+    """
+    is_conflict: bool = field(default=False)
+
+
+class FolderService:
+    """
+    Business logic for the testcase folders domain.
+
+    Mediates between route handlers and the folder repository. All
+    database exceptions are caught here; callers receive a FolderResult
+    describing success or failure without needing to know about the
+    underlying storage layer.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 state: ServiceState,
+                 repository: FolderRepository) -> None:
+        self._logger = logger.getChild(__name__)
+        self._state = state
+        self._repository = repository
+
+    # ------------------------------------------------------------------
+    # Read operations
+    # ------------------------------------------------------------------
+
+    async def get_folder(self, folder_id: int) -> FolderResult:
+        """Retrieve full details for a single folder.
+
+        Args:
+            folder_id: ID of the folder to retrieve.
+
+        Returns:
+            FolderResult with data set to the folder dict on success,
+            or an appropriate error result if not found or a DB failure
+            occurs.
+        """
+        if not self._state.is_available():
+            return FolderResult(success=False,
+                                error_msg="Service unavailable",
+                                is_internal=True)
+
+        try:
+            folder = await self._repository.get_folder(folder_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving folder %d: %s", folder_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if folder is None:
+            return FolderResult(success=False,
+                                error_msg="Folder not found",
+                                not_found=True)
+
+        return FolderResult(success=True, data=folder)
+
+    async def list_folders(self, project_id: int) -> FolderResult:
+        """Retrieve every folder belonging to a project.
+
+        Args:
+            project_id: ID of the project to query.
+
+        Returns:
+            FolderResult with data set to a list of folder dicts on
+            success, a not-found error if the project doesn't exist, or
+            an internal error on DB failure.
+        """
+        if not self._state.is_available():
+            return FolderResult(success=False,
+                                error_msg="Service unavailable",
+                                is_internal=True)
+
+        try:
+            exists = await self._repository.is_valid_project_id(project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure validating project %d: %s", project_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if not exists:
+            return FolderResult(success=False,
+                                error_msg="Project id is invalid",
+                                not_found=True)
+
+        try:
+            folders = await self._repository.get_folders(project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure listing folders for project %d: %s",
+                project_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        return FolderResult(success=True, data=folders)
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    async def create_folder(self,
+                            project_id: int,
+                            parent_id: Optional[int],
+                            name: str) -> FolderResult:
+        """Create a new folder.
+
+        Args:
+            project_id: Project the folder belongs to.
+            parent_id:  Parent folder ID, or None for a root-level folder.
+            name:       Folder name. Must be unique among siblings.
+
+        Returns:
+            FolderResult with data set to the new folder ID on success, a
+            not-found error if the project or parent folder doesn't
+            exist, a conflict error if the name is taken, or an internal
+            error on DB failure.
+        """
+        # pylint: disable=too-many-return-statements
+
+        if not self._state.is_available():
+            return FolderResult(success=False,
+                                error_msg="Service unavailable",
+                                is_internal=True)
+
+        try:
+            project_exists = await self._repository.is_valid_project_id(
+                project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure validating project %d: %s", project_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if not project_exists:
+            return FolderResult(success=False,
+                                error_msg="Project id is invalid",
+                                not_found=True)
+
+        if parent_id is not None:
+            try:
+                parent = await self._repository.get_folder(parent_id)
+            except SqliteInterfaceException as ex:
+                self._logger.exception(
+                    "Database failure validating parent folder %d: %s",
+                    parent_id, ex)
+                self._state.mark_database_failed()
+                return FolderResult(success=False,
+                                    error_msg="Internal error in CMS",
+                                    is_internal=True)
+
+            if parent is None:
+                return FolderResult(success=False,
+                                    error_msg="Parent folder id is invalid",
+                                    not_found=True)
+
+            if parent["project_id"] != project_id:
+                return FolderResult(
+                    success=False,
+                    error_msg="Parent folder does not belong to the "
+                             "specified project")
+
+        try:
+            name_taken = await self._repository.folder_name_exists(
+                project_id, parent_id, name)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure checking folder name: %s", ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if name_taken:
+            return FolderResult(success=False,
+                                error_msg="Folder name already exists",
+                                is_conflict=True)
+
+        try:
+            new_id = await self._repository.add_folder(
+                project_id, parent_id, name)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure creating folder: %s", ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal SQL error in CMS",
+                                is_internal=True)
+
+        return FolderResult(success=True, data=new_id)
+
+    async def update_folder(self, folder_id: int, name: str) -> FolderResult:
+        """Rename an existing folder.
+
+        Args:
+            folder_id: ID of the folder to rename.
+            name:      New folder name. Must be unique among siblings.
+
+        Returns:
+            FolderResult indicating success, a not-found error if the
+            folder doesn't exist, a conflict error if the name is taken
+            by a sibling, or an internal error on DB failure.
+        """
+        # pylint: disable=too-many-return-statements
+
+        if not self._state.is_available():
+            return FolderResult(success=False,
+                                error_msg="Service unavailable",
+                                is_internal=True)
+
+        try:
+            existing = await self._repository.get_folder(folder_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving folder %d for update: %s",
+                folder_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if existing is None:
+            return FolderResult(success=False,
+                                error_msg="Folder not found",
+                                not_found=True)
+
+        if name != existing["name"]:
+            try:
+                name_taken = await self._repository.folder_name_exists(
+                    existing["project_id"], existing["parent_id"], name,
+                    exclude_id=folder_id)
+            except SqliteInterfaceException as ex:
+                self._logger.exception(
+                    "Database failure checking folder name: %s", ex)
+                self._state.mark_database_failed()
+                return FolderResult(success=False,
+                                    error_msg="Internal error in CMS",
+                                    is_internal=True)
+
+            if name_taken:
+                return FolderResult(success=False,
+                                    error_msg="Folder name already exists",
+                                    is_conflict=True)
+
+        try:
+            await self._repository.update_folder_name(folder_id, name)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure renaming folder %d: %s", folder_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error modifying folder",
+                                is_internal=True)
+
+        return FolderResult(success=True)
+
+    async def delete_folder(self, folder_id: int) -> FolderResult:
+        """Delete a folder.
+
+        Child folders and their test cases are removed automatically via
+        the database's ``ON DELETE CASCADE`` constraints.
+
+        Args:
+            folder_id: ID of the folder to delete.
+
+        Returns:
+            FolderResult indicating success, a not-found error if the
+            folder doesn't exist, or an internal error on DB failure.
+        """
+        if not self._state.is_available():
+            return FolderResult(success=False,
+                                error_msg="Service unavailable",
+                                is_internal=True)
+
+        try:
+            exists = await self._repository.get_folder(folder_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure checking folder %d: %s", folder_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        if exists is None:
+            return FolderResult(success=False,
+                                error_msg="Folder not found",
+                                not_found=True)
+
+        try:
+            await self._repository.delete_folder(folder_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure deleting folder %d: %s", folder_id, ex)
+            self._state.mark_database_failed()
+            return FolderResult(success=False,
+                                error_msg="Internal error in CMS",
+                                is_internal=True)
+
+        return FolderResult(success=True)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -142,6 +142,123 @@
           ]
         },
         {
+          "name": "Folders",
+          "item": [
+            {
+              "name": "List Folders",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/folders?project_id=1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "folders"
+                  ],
+                  "query": [
+                    {
+                      "key": "project_id",
+                      "value": "1"
+                    }
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get Folder",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/folders/1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "folders",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Create Folder",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"project_id\": 1,\n    \"parent_id\": null,\n    \"name\": \"Regression\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/folders",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "folders"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Modify Folder",
+              "request": {
+                "method": "PATCH",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Regression Renamed\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/folders/1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "folders",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Delete Folder",
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/folders/1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "folders",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
           "name": "Testcases",
           "item": [
             {

--- a/unit_tests/items_cms/main.py
+++ b/unit_tests/items_cms/main.py
@@ -9,6 +9,15 @@ from test_project_handlers import (
     TestDeleteProjectHandler,
 )
 from test_project_service import TestProjectService
+from test_folder_handlers import (
+    TestGetFolderHandler,
+    TestListFoldersHandler,
+    TestAddFolderHandler,
+    TestModifyFolderHandler,
+    TestDeleteFolderHandler,
+)
+from test_folder_service import TestFolderService
+from test_folder_repository import TestFolderRepository
 from test_testcase_handlers import (
     TestGetTestcaseHandler,
     TestListTestcasesHandler,

--- a/unit_tests/items_cms/test_folder_handlers.py
+++ b/unit_tests/items_cms/test_folder_handlers.py
@@ -1,0 +1,310 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from items.services.items_cms.routes.folders.get_folder_handler import (
+    GetFolderHandler,
+)
+from items.services.items_cms.routes.folders.list_folders_handler import (
+    ListFoldersHandler,
+)
+from items.services.items_cms.routes.folders.add_folder_handler import (
+    AddFolderHandler,
+)
+from items.services.items_cms.routes.folders.modify_folder_handler import (
+    ModifyFolderHandler,
+)
+from items.services.items_cms.routes.folders.delete_folder_handler import (
+    DeleteFolderHandler,
+)
+from items.services.items_cms.services.folder_service import (
+    FolderService,
+    FolderResult,
+)
+
+_LOGGER = MagicMock()
+
+_VALID_ADD_BODY = {"project_id": 5, "parent_id": None, "name": "Root"}
+
+
+def _ok(**kwargs):
+    return FolderResult(success=True, **kwargs)
+
+
+def _internal():
+    return FolderResult(success=False, error_msg="err", is_internal=True)
+
+
+def _not_found(msg="not found"):
+    return FolderResult(success=False, error_msg=msg, not_found=True)
+
+
+def _conflict(msg="already exists"):
+    return FolderResult(success=False, error_msg=msg, is_conflict=True)
+
+
+def _bad_request(msg="bad"):
+    return FolderResult(success=False, error_msg=msg)
+
+
+# ------------------------------------------------------------------
+# GetFolderHandler
+# ------------------------------------------------------------------
+
+class TestGetFolderHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=FolderService)
+        handler = GetFolderHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/folders/<int:folder_id>")
+        async def get_folder(folder_id):
+            return await handler.get_folder(folder_id)
+
+        self.client = app.test_client()
+
+    async def test_success_returns_200(self):
+        self.mock_service.get_folder.return_value = _ok(
+            data={"id": 1, "name": "Root"})
+        async with self.client as c:
+            response = await c.get("/folders/1")
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["name"], "Root")
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.get_folder.return_value = _not_found()
+        async with self.client as c:
+            response = await c.get("/folders/99")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.get_folder.return_value = _internal()
+        async with self.client as c:
+            response = await c.get("/folders/1")
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# ListFoldersHandler
+# ------------------------------------------------------------------
+
+class TestListFoldersHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=FolderService)
+        handler = ListFoldersHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/folders")
+        async def list_folders():
+            return await handler.list_folders()
+
+        self.client = app.test_client()
+
+    async def test_missing_project_id_returns_400(self):
+        async with self.client as c:
+            response = await c.get("/folders")
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.list_folders.assert_not_called()
+
+    async def test_non_integer_project_id_returns_400(self):
+        async with self.client as c:
+            response = await c.get("/folders?project_id=abc")
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.list_folders.assert_not_called()
+
+    async def test_success_returns_200(self):
+        self.mock_service.list_folders.return_value = _ok(
+            data=[{"id": 1, "name": "Root"}])
+        async with self.client as c:
+            response = await c.get("/folders?project_id=5")
+        self.assertEqual(response.status_code, 200)
+        self.mock_service.list_folders.assert_called_once_with(5)
+        data = await response.get_json()
+        self.assertEqual(data["folders"][0]["name"], "Root")
+
+    async def test_project_not_found_returns_404(self):
+        self.mock_service.list_folders.return_value = _not_found()
+        async with self.client as c:
+            response = await c.get("/folders?project_id=999")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.list_folders.return_value = _internal()
+        async with self.client as c:
+            response = await c.get("/folders?project_id=5")
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# AddFolderHandler
+# ------------------------------------------------------------------
+
+class TestAddFolderHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=FolderService)
+        handler = AddFolderHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/folders", methods=["POST"])
+        async def add_folder():
+            return await handler.add_folder()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/folders", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_service.create_folder.return_value = _ok(data=7)
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["folder_id"], 7)
+        self.mock_service.create_folder.assert_called_once_with(
+            project_id=5, parent_id=None, name="Root")
+
+    async def test_missing_field_returns_400(self):
+        response = await self._post({"project_id": 5, "name": "Root"})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.create_folder.assert_not_called()
+
+    async def test_project_not_found_returns_404(self):
+        self.mock_service.create_folder.return_value = _not_found(
+            "Project id is invalid")
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 404)
+
+    async def test_conflict_returns_409(self):
+        self.mock_service.create_folder.return_value = _conflict()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 409)
+
+    async def test_bad_request_returns_400(self):
+        self.mock_service.create_folder.return_value = _bad_request()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 400)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.create_folder.return_value = _internal()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# ModifyFolderHandler
+# ------------------------------------------------------------------
+
+class TestModifyFolderHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=FolderService)
+        handler = ModifyFolderHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/folders/<int:folder_id>", methods=["PATCH"])
+        async def modify_folder(folder_id):
+            return await handler.modify_folder(folder_id)
+
+        self.client = app.test_client()
+
+    async def _patch(self, folder_id, body):
+        async with self.client as c:
+            return await c.patch(f"/folders/{folder_id}", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_service.update_folder.return_value = _ok()
+        response = await self._patch(1, {"name": "New"})
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["status"], 1)
+        self.mock_service.update_folder.assert_called_once_with(
+            folder_id=1, name="New")
+
+    async def test_missing_field_returns_400(self):
+        response = await self._patch(1, {})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.update_folder.assert_not_called()
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.update_folder.return_value = _not_found()
+        response = await self._patch(99, {"name": "New"})
+        self.assertEqual(response.status_code, 404)
+
+    async def test_conflict_returns_409(self):
+        self.mock_service.update_folder.return_value = _conflict()
+        response = await self._patch(1, {"name": "New"})
+        self.assertEqual(response.status_code, 409)
+
+    async def test_bad_request_returns_400(self):
+        self.mock_service.update_folder.return_value = _bad_request()
+        response = await self._patch(1, {"name": "New"})
+        self.assertEqual(response.status_code, 400)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.update_folder.return_value = _internal()
+        response = await self._patch(1, {"name": "New"})
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# DeleteFolderHandler
+# ------------------------------------------------------------------
+
+class TestDeleteFolderHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=FolderService)
+        handler = DeleteFolderHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/folders/<int:folder_id>", methods=["DELETE"])
+        async def delete_folder(folder_id):
+            return await handler.delete_folder(folder_id)
+
+        self.client = app.test_client()
+
+    async def test_success_returns_200(self):
+        self.mock_service.delete_folder.return_value = _ok()
+        async with self.client as c:
+            response = await c.delete("/folders/1")
+        self.assertEqual(response.status_code, 200)
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.delete_folder.return_value = _not_found()
+        async with self.client as c:
+            response = await c.delete("/folders/99")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.delete_folder.return_value = _internal()
+        async with self.client as c:
+            response = await c.delete("/folders/1")
+        self.assertEqual(response.status_code, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_folder_repository.py
+++ b/unit_tests/items_cms/test_folder_repository.py
@@ -1,0 +1,233 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+from items.services.items_cms.repositories.folder_repository import (
+    FolderRepository)
+from items.services.items_cms.cms_configuration import CMSConfiguration
+
+_SCHEMA_SQL = """
+CREATE TABLE prj_projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+CREATE TABLE tc_folders (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    parent_id INTEGER NULL,
+    name TEXT NOT NULL,
+    FOREIGN KEY (project_id) REFERENCES prj_projects(id) ON DELETE CASCADE,
+    FOREIGN KEY (parent_id) REFERENCES tc_folders(id) ON DELETE CASCADE,
+    UNIQUE (project_id, parent_id, name)
+);
+"""
+
+
+class TestFolderRepository(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for FolderRepository against a real SQLite DB."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        conn = sqlite3.connect(self.db_path)
+        conn.executescript(_SCHEMA_SQL)
+        conn.close()
+
+        mock_config = MagicMock(spec=CMSConfiguration)
+        mock_config.backend_db_filename = self.db_path
+        self.repo = FolderRepository(MagicMock(), mock_config)
+
+        self.project_id = self._insert_project("Alpha")
+
+    async def asyncTearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _insert_project(self, name):
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.execute(
+            "INSERT INTO prj_projects (name) VALUES (?)", (name,))
+        row_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        return row_id
+
+    def _insert_folder(self, project_id, parent_id, name):
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.execute(
+            "INSERT INTO tc_folders (project_id, parent_id, name) "
+            "VALUES (?, ?, ?)", (project_id, parent_id, name))
+        row_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        return row_id
+
+    def _query(self, sql, params=()):
+        conn = sqlite3.connect(self.db_path)
+        rows = conn.execute(sql, params).fetchall()
+        conn.close()
+        return rows
+
+    # ------------------------------------------------------------------
+    # is_valid_project_id
+    # ------------------------------------------------------------------
+
+    async def test_is_valid_project_id_returns_true_when_found(self):
+        result = await self.repo.is_valid_project_id(self.project_id)
+        self.assertTrue(result)
+
+    async def test_is_valid_project_id_returns_false_when_not_found(self):
+        result = await self.repo.is_valid_project_id(999)
+        self.assertFalse(result)
+
+    # ------------------------------------------------------------------
+    # get_folder
+    # ------------------------------------------------------------------
+
+    async def test_get_folder_returns_none_when_not_found(self):
+        result = await self.repo.get_folder(999)
+        self.assertIsNone(result)
+
+    async def test_get_folder_returns_dict_when_found(self):
+        fid = self._insert_folder(self.project_id, None, "Root")
+        result = await self.repo.get_folder(fid)
+        self.assertEqual(result, {
+            "id": fid,
+            "project_id": self.project_id,
+            "parent_id": None,
+            "name": "Root"
+        })
+
+    # ------------------------------------------------------------------
+    # get_folders
+    # ------------------------------------------------------------------
+
+    async def test_get_folders_returns_empty_list_when_none(self):
+        result = await self.repo.get_folders(self.project_id)
+        self.assertEqual(result, [])
+
+    async def test_get_folders_returns_flat_list(self):
+        root_id = self._insert_folder(self.project_id, None, "Root")
+        child_id = self._insert_folder(self.project_id, root_id, "Child")
+        result = await self.repo.get_folders(self.project_id)
+        self.assertEqual(result, [
+            {"id": root_id, "parent_id": None, "name": "Root"},
+            {"id": child_id, "parent_id": root_id, "name": "Child"},
+        ])
+
+    async def test_get_folders_scoped_to_project(self):
+        other_project_id = self._insert_project("Beta")
+        self._insert_folder(self.project_id, None, "MineOnly")
+        self._insert_folder(other_project_id, None, "NotMine")
+        result = await self.repo.get_folders(self.project_id)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "MineOnly")
+
+    # ------------------------------------------------------------------
+    # folder_name_exists
+    # ------------------------------------------------------------------
+
+    async def test_name_exists_returns_false_when_empty(self):
+        result = await self.repo.folder_name_exists(
+            self.project_id, None, "Root")
+        self.assertFalse(result)
+
+    async def test_name_exists_returns_true_for_root_level_match(self):
+        self._insert_folder(self.project_id, None, "Root")
+        result = await self.repo.folder_name_exists(
+            self.project_id, None, "Root")
+        self.assertTrue(result)
+
+    async def test_name_exists_returns_true_for_nested_match(self):
+        root_id = self._insert_folder(self.project_id, None, "Root")
+        self._insert_folder(self.project_id, root_id, "Child")
+        result = await self.repo.folder_name_exists(
+            self.project_id, root_id, "Child")
+        self.assertTrue(result)
+
+    async def test_name_exists_does_not_match_different_parent(self):
+        root_a = self._insert_folder(self.project_id, None, "RootA")
+        root_b = self._insert_folder(self.project_id, None, "RootB")
+        self._insert_folder(self.project_id, root_a, "Child")
+        result = await self.repo.folder_name_exists(
+            self.project_id, root_b, "Child")
+        self.assertFalse(result)
+
+    async def test_name_exists_returns_false_with_own_exclude_id(self):
+        fid = self._insert_folder(self.project_id, None, "Root")
+        result = await self.repo.folder_name_exists(
+            self.project_id, None, "Root", exclude_id=fid)
+        self.assertFalse(result)
+
+    # ------------------------------------------------------------------
+    # add_folder
+    # ------------------------------------------------------------------
+
+    async def test_add_folder_returns_new_id(self):
+        result = await self.repo.add_folder(self.project_id, None, "Root")
+        self.assertIsInstance(result, int)
+        rows = self._query(
+            "SELECT name, parent_id FROM tc_folders WHERE id = ?", (result,))
+        self.assertEqual(rows[0], ("Root", None))
+
+    async def test_add_folder_with_parent(self):
+        root_id = self._insert_folder(self.project_id, None, "Root")
+        result = await self.repo.add_folder(self.project_id, root_id, "Child")
+        rows = self._query(
+            "SELECT parent_id FROM tc_folders WHERE id = ?", (result,))
+        self.assertEqual(rows[0][0], root_id)
+
+    # ------------------------------------------------------------------
+    # update_folder_name
+    # ------------------------------------------------------------------
+
+    async def test_update_folder_name_renames(self):
+        fid = self._insert_folder(self.project_id, None, "Old")
+        await self.repo.update_folder_name(fid, "New")
+        rows = self._query("SELECT name FROM tc_folders WHERE id = ?", (fid,))
+        self.assertEqual(rows[0][0], "New")
+
+    # ------------------------------------------------------------------
+    # delete_folder
+    # ------------------------------------------------------------------
+
+    async def test_delete_folder_removes_row(self):
+        fid = self._insert_folder(self.project_id, None, "Root")
+        await self.repo.delete_folder(fid)
+        rows = self._query("SELECT id FROM tc_folders WHERE id = ?", (fid,))
+        self.assertEqual(rows, [])
+
+    async def test_delete_folder_cascades_to_children(self):
+        root_id = self._insert_folder(self.project_id, None, "Root")
+        child_id = self._insert_folder(self.project_id, root_id, "Child")
+        await self.repo.delete_folder(root_id)
+        rows = self._query(
+            "SELECT id FROM tc_folders WHERE id IN (?, ?)",
+            (root_id, child_id))
+        self.assertEqual(rows, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_folder_service.py
+++ b/unit_tests/items_cms/test_folder_service.py
@@ -1,0 +1,294 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_cms.services.folder_service import (
+    FolderService, FolderResult)
+from items.services.items_cms.repositories.folder_repository import (
+    FolderRepository)
+from items.shared.service_state import ServiceState
+
+_FOLDER = {"id": 1, "project_id": 5, "parent_id": None, "name": "Root"}
+
+
+class TestFolderService(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for FolderService."""
+
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock()
+        self.mock_state = MagicMock(spec=ServiceState)
+        self.mock_state.is_available.return_value = True
+        self.mock_repo = AsyncMock(spec=FolderRepository)
+        self.service = FolderService(
+            self.mock_logger, self.mock_state, self.mock_repo)
+
+    # ------------------------------------------------------------------
+    # get_folder
+    # ------------------------------------------------------------------
+
+    async def test_get_folder_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.get_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_get_folder_db_exception(self):
+        self.mock_repo.get_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.get_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_get_folder_not_found(self):
+        self.mock_repo.get_folder.return_value = None
+        result = await self.service.get_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_get_folder_success(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        result = await self.service.get_folder(1)
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, _FOLDER)
+
+    # ------------------------------------------------------------------
+    # list_folders
+    # ------------------------------------------------------------------
+
+    async def test_list_folders_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.list_folders(5)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_list_folders_invalid_project_db_exception(self):
+        self.mock_repo.is_valid_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.list_folders(5)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_list_folders_invalid_project_not_found(self):
+        self.mock_repo.is_valid_project_id.return_value = False
+        result = await self.service.list_folders(5)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+        self.mock_repo.get_folders.assert_not_called()
+
+    async def test_list_folders_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folders.side_effect = SqliteInterfaceException("err")
+        result = await self.service.list_folders(5)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_list_folders_success(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folders.return_value = [_FOLDER]
+        result = await self.service.list_folders(5)
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, [_FOLDER])
+
+    # ------------------------------------------------------------------
+    # create_folder
+    # ------------------------------------------------------------------
+
+    async def test_create_folder_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_folder_project_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_create_folder_invalid_project(self):
+        self.mock_repo.is_valid_project_id.return_value = False
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_create_folder_parent_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.create_folder(5, 1, "Child")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_folder_invalid_parent(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder.return_value = None
+        result = await self.service.create_folder(5, 999, "Child")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+        self.assertIn("Parent folder", result.error_msg)
+
+    async def test_create_folder_parent_belongs_to_different_project(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder.return_value = {
+            **_FOLDER, "project_id": 999}
+        result = await self.service.create_folder(5, 1, "Child")
+        self.assertFalse(result.success)
+        self.assertFalse(result.not_found)
+        self.assertFalse(result.is_internal)
+        self.assertFalse(result.is_conflict)
+
+    async def test_create_folder_name_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.folder_name_exists.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_folder_name_conflict(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.folder_name_exists.return_value = True
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_conflict)
+
+    async def test_create_folder_insert_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.folder_name_exists.return_value = False
+        self.mock_repo.add_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_folder_success_root_level(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.folder_name_exists.return_value = False
+        self.mock_repo.add_folder.return_value = 42
+        result = await self.service.create_folder(5, None, "Root")
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, 42)
+        self.mock_repo.get_folder.assert_not_called()
+
+    async def test_create_folder_success_with_valid_parent(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.folder_name_exists.return_value = False
+        self.mock_repo.add_folder.return_value = 43
+        result = await self.service.create_folder(
+            _FOLDER["project_id"], 1, "Child")
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, 43)
+
+    # ------------------------------------------------------------------
+    # update_folder
+    # ------------------------------------------------------------------
+
+    async def test_update_folder_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_folder_lookup_db_exception(self):
+        self.mock_repo.get_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_folder_not_found(self):
+        self.mock_repo.get_folder.return_value = None
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_update_folder_same_name_skips_conflict_check(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        result = await self.service.update_folder(1, _FOLDER["name"])
+        self.assertTrue(result.success)
+        self.mock_repo.folder_name_exists.assert_not_called()
+
+    async def test_update_folder_name_check_db_exception(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.folder_name_exists.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_folder_name_conflict(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.folder_name_exists.return_value = True
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_conflict)
+
+    async def test_update_folder_rename_db_exception(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.folder_name_exists.return_value = False
+        self.mock_repo.update_folder_name.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.update_folder(1, "New")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_folder_success(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.folder_name_exists.return_value = False
+        result = await self.service.update_folder(1, "New")
+        self.assertTrue(result.success)
+        self.mock_repo.update_folder_name.assert_called_once_with(1, "New")
+
+    # ------------------------------------------------------------------
+    # delete_folder
+    # ------------------------------------------------------------------
+
+    async def test_delete_folder_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.delete_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_delete_folder_lookup_db_exception(self):
+        self.mock_repo.get_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.delete_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_delete_folder_not_found(self):
+        self.mock_repo.get_folder.return_value = None
+        result = await self.service.delete_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_delete_folder_db_exception(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        self.mock_repo.delete_folder.side_effect = SqliteInterfaceException("err")
+        result = await self.service.delete_folder(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_delete_folder_success(self):
+        self.mock_repo.get_folder.return_value = _FOLDER
+        result = await self.service.delete_folder(1)
+        self.assertTrue(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_route_factories.py
+++ b/unit_tests/items_cms/test_route_factories.py
@@ -119,6 +119,12 @@ _VALID_PROJECT_BODY = {
     "announcement_on_overview": False,
 }
 
+_VALID_FOLDER_BODY = {
+    "project_id": 1,
+    "parent_id": None,
+    "name": "WiringFolder",
+}
+
 _VALID_FIELD_BODY = {
     "field_name": "Wiring Field",
     "description": "",
@@ -205,6 +211,35 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     async def test_delete_project_route_is_reachable(self):
         async with self.client as c:
             response = await c.delete("/projects/999")
+        self.assertNotEqual(response.status_code, 405)
+
+    # ------------------------------------------------------------------
+    # Folder routes  (routes/folders/__init__.py)
+    # ------------------------------------------------------------------
+
+    async def test_list_folders_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/folders?project_id=1")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_get_folder_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/folders/999")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_add_folder_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/folders", json=_VALID_FOLDER_BODY)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_modify_folder_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.patch("/folders/999", json={"name": "New"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_delete_folder_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.delete("/folders/999")
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

# CMS: testcase folder CRUD

**Branch:** `cms_test_folders` → `main`
**Stats:** 1 commit, 14 files changed, +1938

## Summary

Adds full CRUD (create/get/list/modify/delete) for testcase folders to the
CMS service, following the same repository/service/route-handler pattern
already established by `projects` (plain CRUD shape) and
`testcase_custom_fields` (the `is_conflict` → 409 pattern). This is
deliberately scoped to CMS only — no Gateway or web portal exposure yet,
matching how `testcase_custom_fields` was rolled out incrementally across
separate PRs. Test case creation/modification (which also needs to handle
per-test-case custom field values) is a separate, larger piece of work to
follow.

## New: folder repository
`items/services/items_cms/repositories/folder_repository.py`

- `get_folder`, `get_folders` (flat list per project), `folder_name_exists`,
  `add_folder`, `update_folder_name`, `delete_folder`.
- `folder_name_exists` explicitly branches on `parent_id IS NULL` vs
  `parent_id = ?` — SQL `NULL` never equals `NULL`, so the table's
  `UNIQUE(project_id, parent_id, name)` constraint silently does **not**
  catch duplicate names among root-level folders. The service-side
  uniqueness check this method backs is the only real enforcement for those.

## New: folder service
`items/services/items_cms/services/folder_service.py`

- `FolderResult` extends `ServiceResult` with `is_conflict` (mirrors
  `TestcaseCustomFieldResult`).
- `create_folder`: validates the project exists, validates the parent folder
  (if given) exists *and* belongs to the same project, checks sibling-name
  uniqueness, then inserts.
- `update_folder`: **rename only** — re-parenting was deliberately left out
  of scope (would need cycle detection to stop a folder being moved under its
  own descendant; can come later if actually needed).
- `delete_folder`: relies on `ON DELETE CASCADE` for both children and test
  cases — folder deletion is not a "must be empty first" operation.

## New: folder routes
`items/services/items_cms/routes/folders/`

| Method | Path | Notes |
|---|---|---|
| GET | `/folders/<int:folder_id>` | 404 if missing |
| GET | `/folders?project_id=<id>` | 404 if project doesn't exist |
| POST | `/folders` | body: `project_id`, `parent_id` (nullable), `name`; 409 on name conflict |
| PATCH | `/folders/<int:folder_id>` | body: `name` only; 409 on name conflict |
| DELETE | `/folders/<int:folder_id>` | cascades to children/test cases |

Wired into `routes/__init__.py` alongside the existing `projects`,
`testcases`, and `testcase_custom_fields` blueprints.

## Test coverage

Repository tests run against a real SQLite fixture (including a cascade-
delete-to-children test); service tests mock the repository and cover every
branch (service unavailable, DB exceptions, not-found, conflict, success);
handler tests mock the service and assert every status code; route-wiring
tests confirm every endpoint is reachable through the real blueprint tree.

**100% line coverage maintained across the entire CMS suite** (1472/1472
statements, 335 tests) — not just the new files. Pylint: 10.00/10.

## Note on the foreign key fix

The `tc_folders`/`tc_test_cases` → `prj_projects` foreign key typo
(`REFERENCES projects(id)` instead of `REFERENCES prj_projects(id)`, meaning
project deletion never actually cascaded to folders/test cases) was found and
fixed while researching this feature, but landed directly on `main`
(`15d74b2`) rather than through this PR — `cms_test_folders` already had that
commit as an ancestor when branched, so it doesn't show up in this diff.
Nothing to reconcile; just noting it here since it was part of the same
investigation.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
