### PR TITLE
[CMS] Testcase CRUD - Basic

### DIFF
--- a/items/services/items_cms/repositories/testcase_repository.py
+++ b/items/services/items_cms/repositories/testcase_repository.py
@@ -135,3 +135,128 @@ class TestcaseRepository:
             'name': name,
             'description': description
         }
+
+    async def get_folder_project_id(self, folder_id: int) -> Optional[int]:
+        """Return the project ID owning a folder, if the folder exists.
+
+        Args:
+            folder_id: ID of the folder to check.
+
+        Returns:
+            The folder's project_id if it exists, or None if no folder
+            matches.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT project_id FROM {cms_tables.TC_FOLDERS} WHERE id = ?"
+        )
+        row = await self._db.run_query(query, (folder_id,), fetch_one=True)
+        return row[0] if row else None
+
+    async def testcase_name_exists(self,
+                                   project_id: int,
+                                   folder_id: Optional[int],
+                                   name: str,
+                                   exclude_id: Optional[int] = None) -> bool:
+        """Return True if a sibling test case with the given name exists.
+
+        Case-sensitive match against test cases sharing the same project
+        and folder. SQL ``NULL`` never equals ``NULL``, so root-level test
+        cases (``folder_id IS NULL``) are compared with an explicit
+        ``IS NULL`` clause rather than ``= ?``.
+
+        Args:
+            project_id:  Project the test case belongs to.
+            folder_id:   Folder ID, or None for a root-level test case.
+            name:        Test case name to check.
+            exclude_id:  ID of the test case being updated (excluded from
+                         the check), or None when creating a new test case.
+
+        Returns:
+            True if the name is already taken by a sibling test case.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        folder_clause = "folder_id IS NULL" if folder_id is None \
+            else "folder_id = ?"
+        params: list = [project_id]
+        if folder_id is not None:
+            params.append(folder_id)
+        params.append(name)
+
+        query = (
+            f"SELECT 1 FROM {cms_tables.TC_TEST_CASES} "
+            f"WHERE project_id = ? AND {folder_clause} AND name = ?"
+        )
+
+        if exclude_id is not None:
+            query += " AND id != ?"
+            params.append(exclude_id)
+
+        query += " LIMIT 1"
+
+        row = await self._db.run_query(query, tuple(params), fetch_one=True)
+        return bool(row)
+
+    async def add_testcase(self,
+                           project_id: int,
+                           folder_id: Optional[int],
+                           name: str,
+                           description: str) -> int:
+        """Insert a new test case and return its ID.
+
+        Args:
+            project_id:  Project the test case belongs to.
+            folder_id:   Folder ID, or None for a root-level test case.
+            name:        Test case name.
+            description: Test case description.
+
+        Returns:
+            The ID of the newly inserted test case row.
+
+        Raises:
+            SqliteInterfaceException: If the database insert fails.
+        """
+        query = (
+            f"INSERT INTO {cms_tables.TC_TEST_CASES} "
+            "(project_id, folder_id, name, description) "
+            "VALUES (?, ?, ?, ?)"
+        )
+        return await self._db.insert_query(
+            query, (project_id, folder_id, name, description))
+
+    async def update_testcase(self,
+                              case_id: int,
+                              name: str,
+                              description: str) -> None:
+        """Rename and/or update the description of an existing test case.
+
+        Args:
+            case_id:     ID of the test case to update.
+            name:        New test case name.
+            description: New test case description.
+
+        Raises:
+            SqliteInterfaceException: If the database update fails.
+        """
+        query = (
+            f"UPDATE {cms_tables.TC_TEST_CASES} "
+            "SET name = ?, description = ? WHERE id = ?"
+        )
+        await self._db.run_query(
+            query, (name, description, case_id), commit=True)
+
+    async def delete_testcase(self, case_id: int) -> None:
+        """Permanently delete a test case from the database.
+
+        Args:
+            case_id: ID of the test case to delete.
+
+        Raises:
+            SqliteInterfaceException: If the database delete fails.
+        """
+        query = f"DELETE FROM {cms_tables.TC_TEST_CASES} WHERE id = ?"
+        await self._db.run_query(query, (case_id,), commit=True)

--- a/items/services/items_cms/routes/testcases/__init__.py
+++ b/items/services/items_cms/routes/testcases/__init__.py
@@ -21,6 +21,9 @@ from items.services.items_cms.repositories.testcase_repository import TestcaseRe
 from items.services.items_cms.services.testcase_service import TestcaseService
 from .list_testcases_handler import ListTestcasesHandler
 from .get_testcase_handler import GetTestcaseHandler
+from .add_testcase_handler import AddTestcaseHandler
+from .modify_testcase_handler import ModifyTestcaseHandler
+from .delete_testcase_handler import DeleteTestcaseHandler
 
 
 def create_testcases_routes(logger: logging.Logger,
@@ -41,6 +44,8 @@ def create_testcases_routes(logger: logging.Logger,
     Returns:
         A configured Blueprint with all testcase routes registered.
     """
+    # pylint: disable=too-many-locals
+
     testcases_routes = Blueprint("testcases_routes", __name__)
 
     repository = TestcaseRepository(logger, config)
@@ -48,6 +53,9 @@ def create_testcases_routes(logger: logging.Logger,
 
     list_handler = ListTestcasesHandler(logger, service)
     get_handler = GetTestcaseHandler(logger, service)
+    add_handler = AddTestcaseHandler(logger, service)
+    modify_handler = ModifyTestcaseHandler(logger, service)
+    delete_handler = DeleteTestcaseHandler(logger, service)
 
     logger.debug("--- Registering Testcases API routes ---")
 
@@ -66,5 +74,31 @@ def create_testcases_routes(logger: logging.Logger,
     @testcases_routes.route('/testcases/<int:case_id>', methods=['GET'])
     async def get_testcase(case_id: int):
         return await get_handler.get_testcase(case_id)
+
+    # Create a test case.
+    logger.debug("=> %s POST /testcases",
+                 "Create new testcase".ljust(40))
+
+    @testcases_routes.route('/testcases', methods=['POST'])
+    async def add_testcase():
+        # pylint: disable=no-value-for-parameter
+        return await add_handler.add_testcase()
+
+    # Rename/update the description of a test case.
+    logger.debug("=> %s PATCH /testcases/<int:case_id>",
+                 "Modify testcase".ljust(40))
+
+    @testcases_routes.route('/testcases/<int:case_id>', methods=['PATCH'])
+    async def modify_testcase(case_id: int):
+        # pylint: disable=no-value-for-parameter
+        return await modify_handler.modify_testcase(case_id)
+
+    # Delete a test case.
+    logger.debug("=> %s DELETE /testcases/<int:case_id>",
+                 "Delete a testcase".ljust(40))
+
+    @testcases_routes.route('/testcases/<int:case_id>', methods=['DELETE'])
+    async def delete_testcase(case_id: int):
+        return await delete_handler.delete_testcase(case_id)
 
     return testcases_routes

--- a/items/services/items_cms/routes/testcases/add_testcase_handler.py
+++ b/items/services/items_cms/routes/testcases/add_testcase_handler.py
@@ -1,0 +1,97 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_cms.services.testcase_service import TestcaseService
+
+SCHEMA_ADD_TESTCASE_REQUEST: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "project_id": {"type": "integer"},
+        "folder_id": {"type": ["integer", "null"]},
+        "name": {"type": "string", "minLength": 1},
+        "description": {"type": "string"}
+    },
+    "required": ["project_id", "folder_id", "name", "description"]
+}
+
+
+class AddTestcaseHandler(BaseApiRoute):
+    """Handles POST /testcases requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: TestcaseService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Testcase service used to create test cases.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    @validate_json(SCHEMA_ADD_TESTCASE_REQUEST)
+    async def add_testcase(self, request_msg: ApiResponse) -> Response:
+        """Create a new test case.
+
+        Request body (JSON):
+            project_id (int):        Project the test case belongs to.
+            folder_id (int | null):  Folder ID, or null for a root-level
+                                     test case.
+            name (str):              Test case name. Must be unique among
+                                     its siblings.
+            description (str):       Test case description.
+
+        Returns:
+            200 with ``{"testcase_id": <int>}`` on success.
+            400 if the request body is invalid.
+            404 if the project or folder does not exist.
+            409 if the name is already taken by a sibling test case.
+            500 on an internal database error.
+        """
+        body = request_msg.body
+        result = await self._service.create_testcase(
+            project_id=body["project_id"],
+            folder_id=body["folder_id"],
+            name=body["name"],
+            description=body["description"])
+
+        if not result.success:
+            if result.is_internal:
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+            elif result.not_found:
+                status = HTTPStatus.NOT_FOUND
+            elif result.is_conflict:
+                status = HTTPStatus.CONFLICT
+            else:
+                status = HTTPStatus.BAD_REQUEST
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"testcase_id": result.data}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/testcases/delete_testcase_handler.py
+++ b/items/services/items_cms/routes/testcases/delete_testcase_handler.py
@@ -1,0 +1,66 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_cms.services.testcase_service import TestcaseService
+
+
+class DeleteTestcaseHandler(BaseApiRoute):
+    """Handles DELETE /testcases/<case_id> requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: TestcaseService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Testcase service used to delete test cases.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    async def delete_testcase(self, case_id: int) -> Response:
+        """Delete a test case.
+
+        Args:
+            case_id: ID of the test case to delete, taken from the URL
+                     path.
+
+        Returns:
+            200 with ``{}`` on success.
+            404 if no test case exists with the given ID.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        result = await self._service.delete_testcase(case_id)
+
+        if not result.success:
+            status = (HTTPStatus.INTERNAL_SERVER_ERROR
+                      if result.is_internal else HTTPStatus.NOT_FOUND)
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/testcases/modify_testcase_handler.py
+++ b/items/services/items_cms/routes/testcases/modify_testcase_handler.py
@@ -1,0 +1,101 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_cms.services.testcase_service import TestcaseService
+
+SCHEMA_MODIFY_TESTCASE_REQUEST: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "description": {"type": "string"}
+    },
+    "required": ["name", "description"]
+}
+
+
+class ModifyTestcaseHandler(BaseApiRoute):
+    """Handles PATCH /testcases/<case_id> requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: TestcaseService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Testcase service used to update test cases.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    @validate_json(SCHEMA_MODIFY_TESTCASE_REQUEST)
+    async def modify_testcase(self,
+                              request_msg: ApiResponse,
+                              case_id: int) -> Response:
+        """Rename and/or update the description of an existing test case.
+
+        Note: this does not support moving a test case between folders.
+
+        Args:
+            case_id: ID of the test case to update, taken from the URL
+                     path.
+
+        Request body (JSON):
+            name (str):        New test case name. Must be unique among
+                               siblings.
+            description (str): New test case description.
+
+        Returns:
+            200 with ``{"status": 1}`` on success.
+            400 if the request body is invalid.
+            404 if no test case exists with the given ID.
+            409 if the name is already taken by a sibling test case.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        body = request_msg.body
+        result = await self._service.update_testcase(
+            case_id=case_id,
+            name=body["name"],
+            description=body["description"])
+
+        if not result.success:
+            if result.is_internal:
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+            elif result.not_found:
+                status = HTTPStatus.NOT_FOUND
+            elif result.is_conflict:
+                status = HTTPStatus.CONFLICT
+            else:
+                status = HTTPStatus.BAD_REQUEST
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": 1}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/services/testcase_service.py
+++ b/items/services/items_cms/services/testcase_service.py
@@ -14,7 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Optional
 from weaver_framework.database.sqlite_interface import SqliteInterfaceException
 from items.services.items_cms.services.service_result import ServiceResult
 from items.shared.service_state import ServiceState
@@ -25,9 +26,11 @@ from items.services.items_cms.repositories.testcase_repository import TestcaseRe
 class TestcaseResult(ServiceResult):
     """Outcome of a testcase service operation.
 
-    Extends ServiceResult to represent the outcome of operations within
-    the testcases domain.
+    Extends ServiceResult with an ``is_conflict`` flag to distinguish
+    resource-conflict failures (HTTP 409, e.g. a duplicate sibling name)
+    from generic client errors (HTTP 400).
     """
+    is_conflict: bool = field(default=False)
 
 
 class TestcaseService:
@@ -124,3 +127,216 @@ class TestcaseService:
                                   not_found=True)
 
         return TestcaseResult(success=True, data=testcase)
+
+    # ------------------------------------------------------------------
+    # Write operations
+    # ------------------------------------------------------------------
+
+    async def create_testcase(self,
+                              project_id: int,
+                              folder_id: Optional[int],
+                              name: str,
+                              description: str) -> TestcaseResult:
+        """Create a new test case.
+
+        Args:
+            project_id:  Project the test case belongs to.
+            folder_id:   Folder ID, or None for a root-level test case.
+            name:        Test case name. Must be unique among siblings.
+            description: Test case description.
+
+        Returns:
+            TestcaseResult with data set to the new test case ID on
+            success, a not-found error if the project or folder doesn't
+            exist, a conflict error if the name is taken, or an internal
+            error on DB failure.
+        """
+        # pylint: disable=too-many-return-statements
+
+        if not self._state.is_available():
+            return TestcaseResult(success=False,
+                                  error_msg="Service unavailable",
+                                  is_internal=True)
+
+        try:
+            project_exists = await self._repository.is_valid_project_id(
+                project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure validating project %d: %s", project_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error in CMS",
+                                  is_internal=True)
+
+        if not project_exists:
+            return TestcaseResult(success=False,
+                                  error_msg="Project id is invalid",
+                                  not_found=True)
+
+        if folder_id is not None:
+            try:
+                folder_project_id = \
+                    await self._repository.get_folder_project_id(folder_id)
+            except SqliteInterfaceException as ex:
+                self._logger.exception(
+                    "Database failure validating folder %d: %s",
+                    folder_id, ex)
+                self._state.mark_database_failed()
+                return TestcaseResult(success=False,
+                                      error_msg="Internal error in CMS",
+                                      is_internal=True)
+
+            if folder_project_id is None:
+                return TestcaseResult(success=False,
+                                      error_msg="Folder id is invalid",
+                                      not_found=True)
+
+            if folder_project_id != project_id:
+                return TestcaseResult(
+                    success=False,
+                    error_msg="Folder does not belong to the specified "
+                             "project")
+
+        try:
+            name_taken = await self._repository.testcase_name_exists(
+                project_id, folder_id, name)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure checking testcase name: %s", ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error in CMS",
+                                  is_internal=True)
+
+        if name_taken:
+            return TestcaseResult(success=False,
+                                  error_msg="Test case name already exists",
+                                  is_conflict=True)
+
+        try:
+            new_id = await self._repository.add_testcase(
+                project_id, folder_id, name, description)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure creating testcase: %s", ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal SQL error in CMS",
+                                  is_internal=True)
+
+        return TestcaseResult(success=True, data=new_id)
+
+    async def update_testcase(self,
+                              case_id: int,
+                              name: str,
+                              description: str) -> TestcaseResult:
+        """Rename and/or update the description of an existing test case.
+
+        Args:
+            case_id:     ID of the test case to update.
+            name:        New test case name. Must be unique among siblings.
+            description: New test case description.
+
+        Returns:
+            TestcaseResult indicating success, a not-found error if the
+            test case doesn't exist, a conflict error if the name is
+            taken by a sibling, or an internal error on DB failure.
+        """
+        # pylint: disable=too-many-return-statements
+
+        if not self._state.is_available():
+            return TestcaseResult(success=False,
+                                  error_msg="Service unavailable",
+                                  is_internal=True)
+
+        try:
+            existing = await self._repository.get_testcase(case_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving testcase %d for update: %s",
+                case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error in CMS",
+                                  is_internal=True)
+
+        if existing is None:
+            return TestcaseResult(success=False,
+                                  error_msg="Test case not found",
+                                  not_found=True)
+
+        if name != existing["name"]:
+            try:
+                name_taken = await self._repository.testcase_name_exists(
+                    existing["project_id"], existing["folder_id"], name,
+                    exclude_id=case_id)
+            except SqliteInterfaceException as ex:
+                self._logger.exception(
+                    "Database failure checking testcase name: %s", ex)
+                self._state.mark_database_failed()
+                return TestcaseResult(success=False,
+                                      error_msg="Internal error in CMS",
+                                      is_internal=True)
+
+            if name_taken:
+                return TestcaseResult(
+                    success=False,
+                    error_msg="Test case name already exists",
+                    is_conflict=True)
+
+        try:
+            await self._repository.update_testcase(
+                case_id, name, description)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure updating testcase %d: %s", case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error modifying "
+                                           "testcase",
+                                  is_internal=True)
+
+        return TestcaseResult(success=True)
+
+    async def delete_testcase(self, case_id: int) -> TestcaseResult:
+        """Delete a test case.
+
+        Args:
+            case_id: ID of the test case to delete.
+
+        Returns:
+            TestcaseResult indicating success, a not-found error if the
+            test case doesn't exist, or an internal error on DB failure.
+        """
+        if not self._state.is_available():
+            return TestcaseResult(success=False,
+                                  error_msg="Service unavailable",
+                                  is_internal=True)
+
+        try:
+            exists = await self._repository.get_testcase(case_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure checking testcase %d: %s", case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error in CMS",
+                                  is_internal=True)
+
+        if exists is None:
+            return TestcaseResult(success=False,
+                                  error_msg="Test case not found",
+                                  not_found=True)
+
+        try:
+            await self._repository.delete_testcase(case_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure deleting testcase %d: %s", case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseResult(success=False,
+                                  error_msg="Internal error in CMS",
+                                  is_internal=True)
+
+        return TestcaseResult(success=True)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -301,6 +301,77 @@
                 }
               },
               "response": []
+            },
+            {
+              "name": "Create Test Case",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"project_id\": 1,\n    \"folder_id\": null,\n    \"name\": \"Login with valid credentials\",\n    \"description\": \"Verify a user can log in with valid credentials\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/testcases",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "testcases"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Modify Test Case",
+              "request": {
+                "method": "PATCH",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Login with valid credentials (renamed)\",\n    \"description\": \"Updated description\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/testcases/1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "testcases",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Delete Test Case",
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/testcases/1",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "testcases",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
             }
           ]
         },

--- a/unit_tests/items_cms/main.py
+++ b/unit_tests/items_cms/main.py
@@ -21,6 +21,9 @@ from test_folder_repository import TestFolderRepository
 from test_testcase_handlers import (
     TestGetTestcaseHandler,
     TestListTestcasesHandler,
+    TestAddTestcaseHandler,
+    TestModifyTestcaseHandler,
+    TestDeleteTestcaseHandler,
 )
 from test_testcase_custom_field_handlers import (
     TestGetCustomFieldHandler,

--- a/unit_tests/items_cms/test_route_factories.py
+++ b/unit_tests/items_cms/test_route_factories.py
@@ -125,6 +125,13 @@ _VALID_FOLDER_BODY = {
     "name": "WiringFolder",
 }
 
+_VALID_TESTCASE_BODY = {
+    "project_id": 1,
+    "folder_id": None,
+    "name": "WiringTestcase",
+    "description": "",
+}
+
 _VALID_FIELD_BODY = {
     "field_name": "Wiring Field",
     "description": "",
@@ -254,6 +261,22 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     async def test_get_testcase_route_is_reachable(self):
         async with self.client as c:
             response = await c.get("/testcases/999")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_add_testcase_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/testcases", json=_VALID_TESTCASE_BODY)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_modify_testcase_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.patch(
+                "/testcases/999", json={"name": "New", "description": ""})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_delete_testcase_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.delete("/testcases/999")
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------

--- a/unit_tests/items_cms/test_testcase_handlers.py
+++ b/unit_tests/items_cms/test_testcase_handlers.py
@@ -22,12 +22,24 @@ from items.services.items_cms.routes.testcases.get_testcase_handler import (
 from items.services.items_cms.routes.testcases.list_testcases_handler import (
     ListTestcasesHandler,
 )
+from items.services.items_cms.routes.testcases.add_testcase_handler import (
+    AddTestcaseHandler,
+)
+from items.services.items_cms.routes.testcases.modify_testcase_handler import (
+    ModifyTestcaseHandler,
+)
+from items.services.items_cms.routes.testcases.delete_testcase_handler import (
+    DeleteTestcaseHandler,
+)
 from items.services.items_cms.services.testcase_service import (
     TestcaseService,
     TestcaseResult,
 )
 
 _LOGGER = MagicMock()
+
+_VALID_ADD_BODY = {"project_id": 5, "folder_id": None, "name": "Login",
+                    "description": "Verify login"}
 
 
 def _ok(**kwargs):
@@ -38,8 +50,16 @@ def _internal():
     return TestcaseResult(success=False, error_msg="err", is_internal=True)
 
 
-def _not_found():
-    return TestcaseResult(success=False, error_msg="not found", not_found=True)
+def _not_found(msg="not found"):
+    return TestcaseResult(success=False, error_msg=msg, not_found=True)
+
+
+def _conflict(msg="already exists"):
+    return TestcaseResult(success=False, error_msg=msg, is_conflict=True)
+
+
+def _bad_request(msg="bad"):
+    return TestcaseResult(success=False, error_msg=msg)
 
 
 # ------------------------------------------------------------------
@@ -134,6 +154,164 @@ class TestListTestcasesHandler(unittest.IsolatedAsyncioTestCase):
         async with self.client as c:
             response = await c.get("/testcases?project_id=3")
         self.assertEqual(response.status_code, 404)
+
+
+# ------------------------------------------------------------------
+# AddTestcaseHandler
+# ------------------------------------------------------------------
+
+class TestAddTestcaseHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=TestcaseService)
+        handler = AddTestcaseHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/testcases", methods=["POST"])
+        async def add_testcase():
+            return await handler.add_testcase()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/testcases", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_service.create_testcase.return_value = _ok(data=7)
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["testcase_id"], 7)
+        self.mock_service.create_testcase.assert_called_once_with(
+            project_id=5, folder_id=None, name="Login",
+            description="Verify login")
+
+    async def test_missing_field_returns_400(self):
+        response = await self._post({"project_id": 5, "name": "Login"})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.create_testcase.assert_not_called()
+
+    async def test_project_not_found_returns_404(self):
+        self.mock_service.create_testcase.return_value = _not_found(
+            "Project id is invalid")
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 404)
+
+    async def test_conflict_returns_409(self):
+        self.mock_service.create_testcase.return_value = _conflict()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 409)
+
+    async def test_bad_request_returns_400(self):
+        self.mock_service.create_testcase.return_value = _bad_request()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 400)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.create_testcase.return_value = _internal()
+        response = await self._post(_VALID_ADD_BODY)
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# ModifyTestcaseHandler
+# ------------------------------------------------------------------
+
+class TestModifyTestcaseHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=TestcaseService)
+        handler = ModifyTestcaseHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/testcases/<int:case_id>", methods=["PATCH"])
+        async def modify_testcase(case_id):
+            return await handler.modify_testcase(case_id)
+
+        self.client = app.test_client()
+
+    async def _patch(self, case_id, body):
+        async with self.client as c:
+            return await c.patch(f"/testcases/{case_id}", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_service.update_testcase.return_value = _ok()
+        response = await self._patch(
+            1, {"name": "New", "description": "New desc"})
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["status"], 1)
+        self.mock_service.update_testcase.assert_called_once_with(
+            case_id=1, name="New", description="New desc")
+
+    async def test_missing_field_returns_400(self):
+        response = await self._patch(1, {"name": "New"})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.update_testcase.assert_not_called()
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.update_testcase.return_value = _not_found()
+        response = await self._patch(
+            99, {"name": "New", "description": ""})
+        self.assertEqual(response.status_code, 404)
+
+    async def test_conflict_returns_409(self):
+        self.mock_service.update_testcase.return_value = _conflict()
+        response = await self._patch(
+            1, {"name": "New", "description": ""})
+        self.assertEqual(response.status_code, 409)
+
+    async def test_bad_request_returns_400(self):
+        self.mock_service.update_testcase.return_value = _bad_request()
+        response = await self._patch(
+            1, {"name": "New", "description": ""})
+        self.assertEqual(response.status_code, 400)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.update_testcase.return_value = _internal()
+        response = await self._patch(
+            1, {"name": "New", "description": ""})
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# DeleteTestcaseHandler
+# ------------------------------------------------------------------
+
+class TestDeleteTestcaseHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=TestcaseService)
+        handler = DeleteTestcaseHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/testcases/<int:case_id>", methods=["DELETE"])
+        async def delete_testcase(case_id):
+            return await handler.delete_testcase(case_id)
+
+        self.client = app.test_client()
+
+    async def test_success_returns_200(self):
+        self.mock_service.delete_testcase.return_value = _ok()
+        async with self.client as c:
+            response = await c.delete("/testcases/1")
+        self.assertEqual(response.status_code, 200)
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.delete_testcase.return_value = _not_found()
+        async with self.client as c:
+            response = await c.delete("/testcases/99")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.delete_testcase.return_value = _internal()
+        async with self.client as c:
+            response = await c.delete("/testcases/1")
+        self.assertEqual(response.status_code, 500)
 
 
 if __name__ == "__main__":

--- a/unit_tests/items_cms/test_testcase_repository.py
+++ b/unit_tests/items_cms/test_testcase_repository.py
@@ -181,6 +181,114 @@ class TestTestcaseRepository(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["description"], "Verify login")
         self.assertIsNone(result["folder_id"])
 
+    # ------------------------------------------------------------------
+    # get_folder_project_id
+    # ------------------------------------------------------------------
+
+    async def test_get_folder_project_id_returns_none_when_not_found(self):
+        result = await self.repo.get_folder_project_id(999)
+        self.assertIsNone(result)
+
+    async def test_get_folder_project_id_returns_project_id_when_found(self):
+        pid = self._insert_project("Alpha")
+        fid = self._insert_folder(pid, "Suite A")
+        result = await self.repo.get_folder_project_id(fid)
+        self.assertEqual(result, pid)
+
+    # ------------------------------------------------------------------
+    # testcase_name_exists
+    # ------------------------------------------------------------------
+
+    async def test_name_exists_returns_false_when_empty(self):
+        pid = self._insert_project("Alpha")
+        result = await self.repo.testcase_name_exists(pid, None, "Login Test")
+        self.assertFalse(result)
+
+    async def test_name_exists_returns_true_for_root_level_match(self):
+        pid = self._insert_project("Alpha")
+        self._insert_testcase(pid, "Login Test")
+        result = await self.repo.testcase_name_exists(pid, None, "Login Test")
+        self.assertTrue(result)
+
+    async def test_name_exists_returns_true_for_folder_match(self):
+        pid = self._insert_project("Alpha")
+        fid = self._insert_folder(pid, "Suite A")
+        self._insert_testcase(pid, "Login Test", folder_id=fid)
+        result = await self.repo.testcase_name_exists(pid, fid, "Login Test")
+        self.assertTrue(result)
+
+    async def test_name_exists_does_not_match_different_folder(self):
+        pid = self._insert_project("Alpha")
+        fid_a = self._insert_folder(pid, "Suite A")
+        fid_b = self._insert_folder(pid, "Suite B")
+        self._insert_testcase(pid, "Login Test", folder_id=fid_a)
+        result = await self.repo.testcase_name_exists(pid, fid_b, "Login Test")
+        self.assertFalse(result)
+
+    async def test_name_exists_returns_false_with_own_exclude_id(self):
+        pid = self._insert_project("Alpha")
+        tc_id = self._insert_testcase(pid, "Login Test")
+        result = await self.repo.testcase_name_exists(
+            pid, None, "Login Test", exclude_id=tc_id)
+        self.assertFalse(result)
+
+    # ------------------------------------------------------------------
+    # add_testcase
+    # ------------------------------------------------------------------
+
+    async def test_add_testcase_returns_new_id(self):
+        pid = self._insert_project("Alpha")
+        result = await self.repo.add_testcase(
+            pid, None, "Login Test", "Verify login")
+        self.assertIsInstance(result, int)
+        conn = sqlite3.connect(self.db_path)
+        row = conn.execute(
+            "SELECT name, description, folder_id FROM tc_test_cases "
+            "WHERE id = ?", (result,)).fetchone()
+        conn.close()
+        self.assertEqual(row, ("Login Test", "Verify login", None))
+
+    async def test_add_testcase_with_folder(self):
+        pid = self._insert_project("Alpha")
+        fid = self._insert_folder(pid, "Suite A")
+        result = await self.repo.add_testcase(
+            pid, fid, "Login Test", "")
+        conn = sqlite3.connect(self.db_path)
+        row = conn.execute(
+            "SELECT folder_id FROM tc_test_cases WHERE id = ?",
+            (result,)).fetchone()
+        conn.close()
+        self.assertEqual(row[0], fid)
+
+    # ------------------------------------------------------------------
+    # update_testcase
+    # ------------------------------------------------------------------
+
+    async def test_update_testcase_renames_and_updates_description(self):
+        pid = self._insert_project("Alpha")
+        tc_id = self._insert_testcase(pid, "Old", description="Old desc")
+        await self.repo.update_testcase(tc_id, "New", "New desc")
+        conn = sqlite3.connect(self.db_path)
+        row = conn.execute(
+            "SELECT name, description FROM tc_test_cases WHERE id = ?",
+            (tc_id,)).fetchone()
+        conn.close()
+        self.assertEqual(row, ("New", "New desc"))
+
+    # ------------------------------------------------------------------
+    # delete_testcase
+    # ------------------------------------------------------------------
+
+    async def test_delete_testcase_removes_row(self):
+        pid = self._insert_project("Alpha")
+        tc_id = self._insert_testcase(pid, "Login Test")
+        await self.repo.delete_testcase(tc_id)
+        conn = sqlite3.connect(self.db_path)
+        rows = conn.execute(
+            "SELECT id FROM tc_test_cases WHERE id = ?", (tc_id,)).fetchall()
+        conn.close()
+        self.assertEqual(rows, [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/items_cms/test_testcase_service.py
+++ b/unit_tests/items_cms/test_testcase_service.py
@@ -22,6 +22,9 @@ from items.services.items_cms.repositories.testcase_repository import (
 )
 from items.shared.service_state import ServiceState
 
+_TESTCASE = {"id": 1, "project_id": 5, "folder_id": None, "name": "Login test",
+             "description": "Verify login"}
+
 
 class TestTestcaseService(unittest.IsolatedAsyncioTestCase):
     """Unit tests for TestcaseService."""
@@ -111,6 +114,196 @@ class TestTestcaseService(unittest.IsolatedAsyncioTestCase):
         result = await self.service.get_testcase(42)
         self.assertTrue(result.success)
         self.assertEqual(result.data, tc)
+
+    # ------------------------------------------------------------------
+    # create_testcase
+    # ------------------------------------------------------------------
+
+    async def test_create_testcase_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_testcase_project_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_create_testcase_invalid_project(self):
+        self.mock_repo.is_valid_project_id.return_value = False
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_create_testcase_folder_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_testcase(5, 1, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_testcase_invalid_folder(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder_project_id.return_value = None
+        result = await self.service.create_testcase(5, 999, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+        self.assertIn("Folder", result.error_msg)
+
+    async def test_create_testcase_folder_belongs_to_different_project(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder_project_id.return_value = 999
+        result = await self.service.create_testcase(5, 1, "Login", "")
+        self.assertFalse(result.success)
+        self.assertFalse(result.not_found)
+        self.assertFalse(result.is_internal)
+        self.assertFalse(result.is_conflict)
+
+    async def test_create_testcase_name_check_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.testcase_name_exists.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_testcase_name_conflict(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.testcase_name_exists.return_value = True
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_conflict)
+
+    async def test_create_testcase_insert_db_exception(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.testcase_name_exists.return_value = False
+        self.mock_repo.add_testcase.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_create_testcase_success_root_level(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.testcase_name_exists.return_value = False
+        self.mock_repo.add_testcase.return_value = 42
+        result = await self.service.create_testcase(5, None, "Login", "")
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, 42)
+        self.mock_repo.get_folder_project_id.assert_not_called()
+
+    async def test_create_testcase_success_with_valid_folder(self):
+        self.mock_repo.is_valid_project_id.return_value = True
+        self.mock_repo.get_folder_project_id.return_value = 5
+        self.mock_repo.testcase_name_exists.return_value = False
+        self.mock_repo.add_testcase.return_value = 43
+        result = await self.service.create_testcase(5, 1, "Login", "")
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, 43)
+
+    # ------------------------------------------------------------------
+    # update_testcase
+    # ------------------------------------------------------------------
+
+    async def test_update_testcase_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_testcase_lookup_db_exception(self):
+        self.mock_repo.get_testcase.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_testcase_not_found(self):
+        self.mock_repo.get_testcase.return_value = None
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_update_testcase_same_name_skips_conflict_check(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        result = await self.service.update_testcase(
+            1, _TESTCASE["name"], "New desc")
+        self.assertTrue(result.success)
+        self.mock_repo.testcase_name_exists.assert_not_called()
+
+    async def test_update_testcase_name_check_db_exception(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        self.mock_repo.testcase_name_exists.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_testcase_name_conflict(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        self.mock_repo.testcase_name_exists.return_value = True
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_conflict)
+
+    async def test_update_testcase_update_db_exception(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        self.mock_repo.testcase_name_exists.return_value = False
+        self.mock_repo.update_testcase.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_update_testcase_success(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        self.mock_repo.testcase_name_exists.return_value = False
+        result = await self.service.update_testcase(1, "New", "New desc")
+        self.assertTrue(result.success)
+        self.mock_repo.update_testcase.assert_called_once_with(
+            1, "New", "New desc")
+
+    # ------------------------------------------------------------------
+    # delete_testcase
+    # ------------------------------------------------------------------
+
+    async def test_delete_testcase_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.delete_testcase(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_delete_testcase_lookup_db_exception(self):
+        self.mock_repo.get_testcase.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.delete_testcase(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_delete_testcase_not_found(self):
+        self.mock_repo.get_testcase.return_value = None
+        result = await self.service.delete_testcase(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_delete_testcase_db_exception(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        self.mock_repo.delete_testcase.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.delete_testcase(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_delete_testcase_success(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        result = await self.service.delete_testcase(1)
+        self.assertTrue(result.success)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

# CMS: basic testcase CRUD

**Branch:** `cms_testcases_basic` → `main`
**Stats:** 2 commits, 12 files changed, +1220/-5

## Summary

Adds create/modify/delete for test cases to the CMS service, completing the
CRUD set alongside the existing get/list endpoints. This is the first of
what will likely be several PRs for test case support — custom field values
per test case (tying into the existing `testcase_custom_fields` domain) are
a separate, larger piece of work to follow, matching how folder CRUD was
split out onto its own branch.

Follows the same repository/service/route-handler pattern established by
`folders`: plain CRUD shape, `is_conflict` → 409 for duplicate names.

## Repository
`items/services/items_cms/repositories/testcase_repository.py`

- `add_testcase`, `update_testcase` (name + description), `delete_testcase`.
- `testcase_name_exists` mirrors `folder_name_exists` — explicit
  `folder_id IS NULL` vs `folder_id = ?` branching, since SQL `NULL` never
  equals `NULL` and root-level test cases need the same care root-level
  folders did.
- `get_folder_project_id` — used to validate a `folder_id` passed into
  `create_testcase` both exists and belongs to the same project, same check
  folder creation already does for `parent_id`.

## Service
`items/services/items_cms/services/testcase_service.py`

- `TestcaseResult` gains `is_conflict` (previously only used by
  `get`/`list`, which don't need it).
- `create_testcase`: validates the project exists, validates the folder (if
  given) exists *and* belongs to the same project, checks sibling-name
  uniqueness (scoped to `project_id` + `folder_id`, same as folders), then
  inserts.
- `update_testcase`: **rename + description only** — moving a test case
  between folders was deliberately left out of scope. If needed later it
  should be its own dedicated endpoint (e.g. `POST /testcases/<id>/move`),
  matching the existing precedent of `testcase_custom_fields` having its own
  move endpoint rather than folding position changes into a generic PATCH.
- `delete_testcase`: hard delete only, no cascade concerns since test cases
  are leaf nodes.

## Routes
`items/services/items_cms/routes/testcases/`

| Method | Path | Notes |
|---|---|---|
| GET | `/testcases/<int:case_id>` | existing |
| GET | `/testcases?project_id=<id>` | existing |
| POST | `/testcases` | body: `project_id`, `folder_id` (nullable), `name`, `description`; 409 on name conflict |
| PATCH | `/testcases/<int:case_id>` | body: `name`, `description` only; 409 on name conflict |
| DELETE | `/testcases/<int:case_id>` | hard delete |

## Postman collection
`postman/ITEMS.postman_collection.json`

Added **Create Test Case**, **Modify Test Case**, **Delete Test Case** to
the existing `CMS Service → Testcases` folder, alongside the existing
List/Get requests.

## Test coverage

Repository tests run against a real SQLite fixture; service tests mock the
repository and cover every branch (service unavailable, DB exceptions,
not-found, conflict, success); handler tests mock the service and assert
every status code; route-wiring tests confirm every endpoint is reachable
through the real blueprint tree.

**100% line coverage maintained across the entire CMS suite** (1670/1670
statements, 388 tests) — not just the new files. Pylint: 10.00/10.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
