### PR TITLE
[CMS] Testcases Per Field

### DIFF
--- a/items/services/items_cms/repositories/testcase_field_values_repository.py
+++ b/items/services/items_cms/repositories/testcase_field_values_repository.py
@@ -1,0 +1,214 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterface
+from items.services.items_cms.cms_configuration import CMSConfiguration
+import items.services.items_cms.cms_db_tables as cms_tables
+
+
+class TestcaseFieldValuesRepository:
+    """
+    Persistence operations for per-test-case custom field value data.
+
+    Encapsulates all database access for the testcase field values domain.
+    Raises SqliteInterfaceException on database failures; callers are
+    responsible for handling those exceptions and updating service state
+    accordingly.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: CMSConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._db = SqliteInterface(self._logger, config.backend_db_filename)
+
+    async def get_testcase_project_id(self, case_id: int) -> Optional[int]:
+        """Return the project ID owning a test case, if it exists.
+
+        Args:
+            case_id: ID of the test case to check.
+
+        Returns:
+            The test case's project_id if it exists, or None if no test
+            case matches.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT project_id FROM {cms_tables.TC_TEST_CASES} WHERE id = ?"
+        )
+        row = await self._db.run_query(query, (case_id,), fetch_one=True)
+        return row[0] if row else None
+
+    async def get_applicable_fields(self, project_id: int) -> list[dict]:
+        """Retrieve every custom field definition applicable to a project.
+
+        A field is applicable if it applies to all projects, or is
+        explicitly linked to this project.
+
+        Args:
+            project_id: ID of the project to query.
+
+        Returns:
+            A list of dicts with ``id``, ``field_name``, ``field_type``,
+            ``is_required``, ``default_value``, and ``position``, ordered
+            by position.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = f"""
+            SELECT
+                cf.id,
+                cf.field_name,
+                ft.name AS field_type_name,
+                cf.is_required,
+                cf.default_value,
+                cf.position
+            FROM {cms_tables.TC_CUSTOM_FIELDS} AS cf
+            LEFT JOIN {cms_tables.TC_CUSTOM_FIELD_TYPES} AS ft
+                ON cf.field_type_id = ft.id
+            LEFT JOIN {cms_tables.TC_CUSTOM_FIELD_PROJECTS} AS cfp
+                ON cf.id = cfp.field_id AND cfp.project_id = ?
+            WHERE cf.applies_to_all_projects = 1 OR cfp.project_id IS NOT NULL
+            ORDER BY cf.position
+        """
+        rows = await self._db.run_query(query, (project_id,))
+        return [
+            {
+                'id': field_id,
+                'field_name': field_name,
+                'field_type': field_type,
+                'is_required': bool(is_required),
+                'default_value': default_value,
+                'position': position,
+            }
+            for field_id, field_name, field_type, is_required,
+            default_value, position in (rows or [])
+        ]
+
+    async def get_field_values(self, case_id: int) -> dict[int, str]:
+        """Retrieve every stored custom field value for a test case.
+
+        Args:
+            case_id: ID of the test case to query.
+
+        Returns:
+            A dict mapping field_id to its stored value string.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT field_id, value FROM {cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} "
+            "WHERE test_case_id = ?"
+        )
+        rows = await self._db.run_query(query, (case_id,))
+        return dict(rows or [])
+
+    async def get_field_values_for_testcases(
+            self, case_ids: list[int]) -> dict[int, dict[int, str]]:
+        """Retrieve stored custom field values for multiple test cases.
+
+        Args:
+            case_ids: IDs of the test cases to query.
+
+        Returns:
+            A dict mapping test_case_id to a dict of {field_id: value}.
+            Test cases with no stored values are omitted.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        if not case_ids:
+            return {}
+
+        placeholders = ",".join("?" * len(case_ids))
+        query = (
+            "SELECT test_case_id, field_id, value FROM "
+            f"{cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} "
+            f"WHERE test_case_id IN ({placeholders})"
+        )
+        rows = await self._db.run_query(query, tuple(case_ids))
+
+        result: dict[int, dict[int, str]] = {}
+        for test_case_id, field_id, value in (rows or []):
+            result.setdefault(test_case_id, {})[field_id] = value
+        return result
+
+    async def value_row_exists(self, case_id: int, field_id: int) -> bool:
+        """Return True if a stored value already exists for this pair.
+
+        Args:
+            case_id:  ID of the test case.
+            field_id: ID of the custom field.
+
+        Returns:
+            True if a value row already exists.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = (
+            f"SELECT 1 FROM {cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} "
+            "WHERE test_case_id = ? AND field_id = ? LIMIT 1"
+        )
+        row = await self._db.run_query(
+            query, (case_id, field_id), fetch_one=True)
+        return bool(row)
+
+    async def insert_field_value(self,
+                                 case_id: int,
+                                 field_id: int,
+                                 value: str) -> None:
+        """Insert a new custom field value row for a test case.
+
+        Args:
+            case_id:  ID of the test case.
+            field_id: ID of the custom field.
+            value:    Value to store.
+
+        Raises:
+            SqliteInterfaceException: If the database insert fails.
+        """
+        query = (
+            f"INSERT INTO {cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} "
+            "(test_case_id, field_id, value) VALUES (?, ?, ?)"
+        )
+        await self._db.insert_query(query, (case_id, field_id, value))
+
+    async def update_field_value(self,
+                                 case_id: int,
+                                 field_id: int,
+                                 value: str) -> None:
+        """Update an existing custom field value row for a test case.
+
+        Args:
+            case_id:  ID of the test case.
+            field_id: ID of the custom field.
+            value:    New value to store.
+
+        Raises:
+            SqliteInterfaceException: If the database update fails.
+        """
+        query = (
+            f"UPDATE {cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} "
+            "SET value = ? WHERE test_case_id = ? AND field_id = ?"
+        )
+        await self._db.run_query(
+            query, (value, case_id, field_id), commit=True)

--- a/items/services/items_cms/repositories/testcase_repository.py
+++ b/items/services/items_cms/repositories/testcase_repository.py
@@ -54,8 +54,10 @@ class TestcaseRepository:
     async def get_testcases(self, project_id: int) -> dict:
         """Retrieve folders and test case stubs for a project.
 
-        Builds the full folder hierarchy via a recursive CTE, then
-        fetches all test case IDs and names for the project.
+        Builds the full folder hierarchy via a recursive CTE, fetches all
+        test case IDs and names for the project, and attaches each test
+        case's custom field values inline so a grid/list view doesn't need
+        a separate call per test case to render its custom field columns.
 
         Args:
             project_id: ID of the project to query.
@@ -64,11 +66,13 @@ class TestcaseRepository:
             A dict with two keys:
               - ``folders``: list of ``{id, name, parent_id}`` dicts ordered
                 by parent then id.
-              - ``test_cases``: list of ``{id, folder_id, name}`` dicts
-                ordered by folder then id.
+              - ``test_cases``: list of ``{id, folder_id, name,
+                custom_fields}`` dicts ordered by folder then id, where
+                ``custom_fields`` is a list of ``{field_id, field_name,
+                field_type, position, value}`` dicts ordered by position.
 
         Raises:
-            SqliteInterfaceException: If either database query fails.
+            SqliteInterfaceException: If any database query fails.
         """
         folders_query = f"""
             WITH RECURSIVE folder_hierarchy AS (
@@ -94,6 +98,7 @@ class TestcaseRepository:
 
         folder_rows = await self._db.run_query(folders_query, (project_id,))
         cases_rows = await self._db.run_query(cases_query, (project_id,))
+        values_by_case = await self._get_custom_field_values(project_id)
 
         return {
             'folders': [
@@ -101,10 +106,72 @@ class TestcaseRepository:
                 for folder_id, parent_id, name in (folder_rows or [])
             ],
             'test_cases': [
-                {'id': test_id, 'folder_id': folder_id, 'name': name}
+                {
+                    'id': test_id,
+                    'folder_id': folder_id,
+                    'name': name,
+                    'custom_fields': values_by_case.get(test_id, []),
+                }
                 for test_id, folder_id, name in (cases_rows or [])
             ]
         }
+
+    async def _get_custom_field_values(
+            self, project_id: int) -> dict[int, list[dict]]:
+        """Retrieve every test case's custom field values for a project.
+
+        A field is included for a test case if it applies to all projects,
+        or is explicitly linked to the test case's project. A test case's
+        value for a field falls back to that field's default value when no
+        value has been stored yet — same fallback used when reading a
+        single test case's values.
+
+        Args:
+            project_id: ID of the project to query.
+
+        Returns:
+            A dict mapping test_case_id to a list of ``{field_id,
+            field_name, field_type, position, value}`` dicts, ordered by
+            position.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        query = f"""
+            SELECT
+                tc.id AS test_case_id,
+                cf.id AS field_id,
+                cf.field_name,
+                ft.name AS field_type_name,
+                cf.position,
+                COALESCE(v.value, cf.default_value) AS value
+            FROM {cms_tables.TC_TEST_CASES} AS tc
+            JOIN {cms_tables.TC_CUSTOM_FIELDS} AS cf
+                ON cf.applies_to_all_projects = 1
+                OR EXISTS (
+                    SELECT 1 FROM {cms_tables.TC_CUSTOM_FIELD_PROJECTS} AS cfp
+                    WHERE cfp.field_id = cf.id AND cfp.project_id = tc.project_id
+                )
+            LEFT JOIN {cms_tables.TC_CUSTOM_FIELD_TYPES} AS ft
+                ON cf.field_type_id = ft.id
+            LEFT JOIN {cms_tables.TC_CUSTOM_FIELD_OPTION_VALUES} AS v
+                ON v.test_case_id = tc.id AND v.field_id = cf.id
+            WHERE tc.project_id = ?
+            ORDER BY tc.id, cf.position
+        """
+        rows = await self._db.run_query(query, (project_id,))
+
+        values_by_case: dict[int, list[dict]] = {}
+        for test_case_id, field_id, field_name, field_type, position, value \
+                in (rows or []):
+            values_by_case.setdefault(test_case_id, []).append({
+                'field_id': field_id,
+                'field_name': field_name,
+                'field_type': field_type,
+                'position': position,
+                'value': value,
+            })
+        return values_by_case
 
     async def get_testcase(self, case_id: int) -> Optional[dict]:
         """Retrieve full details for a single test case.

--- a/items/services/items_cms/routes/__init__.py
+++ b/items/services/items_cms/routes/__init__.py
@@ -21,6 +21,7 @@ from .projects import create_projects_routes
 from .folders import create_folders_routes
 from .testcases import create_testcases_routes
 from .testcase_custom_fields import create_testcase_custom_fields_routes
+from .testcase_field_values import create_testcase_field_values_routes
 from .system import create_system_routes
 
 
@@ -52,6 +53,8 @@ def create_routes(logger: logging.Logger,
                                                          state,
                                                          configuration))
     routes_bp.register_blueprint(create_testcase_custom_fields_routes(
+        logger, state, configuration))
+    routes_bp.register_blueprint(create_testcase_field_values_routes(
         logger, state, configuration))
     routes_bp.register_blueprint(create_system_routes(logger, state))
 

--- a/items/services/items_cms/routes/testcase_field_values/__init__.py
+++ b/items/services/items_cms/routes/testcase_field_values/__init__.py
@@ -1,0 +1,79 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from quart import Blueprint
+from items.shared.service_state import ServiceState
+from items.services.items_cms.cms_configuration import CMSConfiguration
+from items.services.items_cms.repositories.testcase_field_values_repository import (
+    TestcaseFieldValuesRepository,
+)
+from items.services.items_cms.services.testcase_field_values_service import (
+    TestcaseFieldValuesService,
+)
+from .get_testcase_field_values_handler import GetTestcaseFieldValuesHandler
+from .set_testcase_field_values_handler import SetTestcaseFieldValuesHandler
+
+
+def create_testcase_field_values_routes(
+        logger: logging.Logger,
+        service_state: ServiceState,
+        config: CMSConfiguration) -> Blueprint:
+    """Create and return the testcase field values API Blueprint.
+
+    Instantiates the field values repository and service once, wires them
+    into individual route handlers, and registers all field value
+    endpoints with a Quart Blueprint.
+
+    Args:
+        logger:        Parent logger instance.
+        service_state: Shared service operational state.
+        config:        CMS service configuration, used to locate the
+                       database file.
+
+    Returns:
+        A configured Blueprint with all testcase field value routes
+        registered.
+    """
+    field_values_routes = Blueprint("testcase_field_values_routes", __name__)
+
+    repository = TestcaseFieldValuesRepository(logger, config)
+    service = TestcaseFieldValuesService(logger, service_state, repository)
+
+    get_handler = GetTestcaseFieldValuesHandler(logger, service)
+    set_handler = SetTestcaseFieldValuesHandler(logger, service)
+
+    logger.debug("--- Registering Testcase Field Values API routes ---")
+
+    # Get every applicable custom field and its value for a test case.
+    logger.debug("=> %s GET /testcases/<int:case_id>/custom_fields",
+                 "Get testcase field values".ljust(40))
+
+    @field_values_routes.route(
+        '/testcases/<int:case_id>/custom_fields', methods=['GET'])
+    async def get_field_values(case_id: int):
+        return await get_handler.get_field_values(case_id)
+
+    # Set one or more custom field values for a test case.
+    logger.debug("=> %s PUT /testcases/<int:case_id>/custom_fields",
+                 "Set testcase field values".ljust(40))
+
+    @field_values_routes.route(
+        '/testcases/<int:case_id>/custom_fields', methods=['PUT'])
+    async def set_field_values(case_id: int):
+        # pylint: disable=no-value-for-parameter
+        return await set_handler.set_field_values(case_id)
+
+    return field_values_routes

--- a/items/services/items_cms/routes/testcase_field_values/get_testcase_field_values_handler.py
+++ b/items/services/items_cms/routes/testcase_field_values/get_testcase_field_values_handler.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_cms.services.testcase_field_values_service import (
+    TestcaseFieldValuesService,
+)
+
+
+class GetTestcaseFieldValuesHandler(BaseApiRoute):
+    """Handles GET /testcases/<case_id>/custom_fields requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: TestcaseFieldValuesService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Testcase field values service used to retrieve values.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    async def get_field_values(self, case_id: int) -> Response:
+        """Retrieve every applicable custom field and its value.
+
+        Args:
+            case_id: ID of the test case to retrieve values for, taken
+                     from the URL path.
+
+        Returns:
+            200 with a list of ``{field_id, field_name, field_type,
+            position, is_required, value}`` dicts, ordered by position, on
+            success.
+            404 if no test case exists with the given ID.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        result = await self._service.get_field_values(case_id)
+
+        if not result.success:
+            status = (HTTPStatus.INTERNAL_SERVER_ERROR
+                      if result.is_internal else HTTPStatus.NOT_FOUND)
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps(result.data),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/routes/testcase_field_values/set_testcase_field_values_handler.py
+++ b/items/services/items_cms/routes/testcase_field_values/set_testcase_field_values_handler.py
@@ -1,0 +1,111 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import logging
+from http import HTTPStatus
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_cms.services.testcase_field_values_service import (
+    TestcaseFieldValuesService,
+)
+
+SCHEMA_SET_FIELD_VALUES_REQUEST: dict = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "values": {
+            "type": "object",
+            "additionalProperties": {"type": "string"}
+        }
+    },
+    "required": ["values"]
+}
+
+
+class SetTestcaseFieldValuesHandler(BaseApiRoute):
+    """Handles PUT /testcases/<case_id>/custom_fields requests."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service: TestcaseFieldValuesService) -> None:
+        """Initialise the handler.
+
+        Args:
+            logger:  Parent logger instance.
+            service: Testcase field values service used to set values.
+        """
+        self._logger = logger.getChild(__name__)
+        self._service = service
+
+    @validate_json(SCHEMA_SET_FIELD_VALUES_REQUEST)
+    async def set_field_values(self,
+                               request_msg: ApiResponse,
+                               case_id: int) -> Response:
+        """Set one or more custom field values for a test case.
+
+        Only the fields present in the request body are affected — omitted
+        fields keep whatever value (or default) they already had.
+
+        Args:
+            case_id: ID of the test case to update, taken from the URL
+                     path.
+
+        Request body (JSON):
+            values (dict): Mapping of field_id (as a string key) to the
+                           new value string.
+
+        Returns:
+            200 with ``{"status": 1}`` on success.
+            400 if the request body is invalid, a field_id key is not
+            numeric, a field does not apply to the test case's project,
+            or a value fails validation.
+            404 if no test case exists with the given ID.
+            500 on an internal database error.
+        """
+        # pylint: disable=duplicate-code
+
+        raw_values: dict = request_msg.body["values"]
+
+        try:
+            values = {int(field_id): value
+                      for field_id, value in raw_values.items()}
+        except ValueError:
+            return Response(
+                json.dumps({"error": "values keys must be numeric field ids"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        result = await self._service.set_field_values(case_id, values)
+
+        if not result.success:
+            if result.is_internal:
+                status = HTTPStatus.INTERNAL_SERVER_ERROR
+            elif result.not_found:
+                status = HTTPStatus.NOT_FOUND
+            else:
+                status = HTTPStatus.BAD_REQUEST
+            return Response(
+                json.dumps({"error": result.error_msg}),
+                status=status,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": 1}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_cms/services/testcase_field_value_validation.py
+++ b/items/services/items_cms/services/testcase_field_value_validation.py
@@ -1,0 +1,83 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from datetime import date
+from typing import Optional
+from urllib.parse import urlparse
+
+_CHECKBOX_VALUES = {"true", "false", "1", "0"}
+
+
+def _validate_integer(value: str) -> Optional[str]:
+    try:
+        int(value)
+    except ValueError:
+        return "Value must be an integer"
+    return None
+
+
+def _validate_checkbox(value: str) -> Optional[str]:
+    if value.lower() not in _CHECKBOX_VALUES:
+        return "Value must be a boolean (true/false)"
+    return None
+
+
+def _validate_date(value: str) -> Optional[str]:
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return "Value must be a date in YYYY-MM-DD format"
+    return None
+
+
+def _validate_url(value: str) -> Optional[str]:
+    parsed = urlparse(value)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return "Value must be a valid http(s) URL"
+    return None
+
+
+_VALIDATORS = {
+    "Integer": _validate_integer,
+    "Checkbox": _validate_checkbox,
+    "Date": _validate_date,
+    "Url (Link)": _validate_url,
+}
+
+
+def validate_value(field_type: str, value: str) -> Optional[str]:
+    """Validate a custom field value string against its field type.
+
+    Types with a well-defined, unambiguous format (Integer, Checkbox, Date,
+    Url (Link)) are checked accordingly. All other types (Dropdown, String,
+    Text, User) accept any string — Dropdown in particular has no way to
+    define its valid choices yet (the option-kind tables exist in the
+    schema but nothing currently populates them), so it cannot be
+    meaningfully validated beyond presence, which callers handle separately
+    via each field's ``is_required`` flag.
+
+    Args:
+        field_type: Name of the field's type (e.g. "Integer", "Dropdown").
+        value:      Value string to validate.
+
+    Returns:
+        A human-readable error message if the value is invalid for the
+        given type, or None if it is valid (or the type has no specific
+        format to check).
+    """
+    validator = _VALIDATORS.get(field_type)
+    if validator is None:
+        return None
+    return validator(value)

--- a/items/services/items_cms/services/testcase_field_values_service.py
+++ b/items/services/items_cms/services/testcase_field_values_service.py
@@ -1,0 +1,245 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from dataclasses import dataclass
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_cms.services.service_result import ServiceResult
+from items.services.items_cms.services.testcase_field_value_validation import (
+    validate_value,
+)
+from items.shared.service_state import ServiceState
+from items.services.items_cms.repositories.testcase_field_values_repository import (
+    TestcaseFieldValuesRepository,
+)
+
+
+@dataclass(slots=True)
+class TestcaseFieldValuesResult(ServiceResult):
+    """Outcome of a testcase field values service operation.
+
+    Extends ServiceResult to represent the outcome of operations within
+    the testcase field values domain.
+    """
+
+
+class TestcaseFieldValuesService:
+    """
+    Business logic for the per-test-case custom field values domain.
+
+    Mediates between route handlers and the field values repository. All
+    database exceptions are caught here; callers receive a
+    TestcaseFieldValuesResult describing success or failure without needing
+    to know about the underlying storage layer.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 state: ServiceState,
+                 repository: TestcaseFieldValuesRepository) -> None:
+        self._logger = logger.getChild(__name__)
+        self._state = state
+        self._repository = repository
+
+    async def get_field_values(self, case_id: int) -> TestcaseFieldValuesResult:
+        """Retrieve every applicable custom field and its value for a test case.
+
+        Fields with no stored value fall back to their configured default
+        value. Results are ordered by each field's display position.
+
+        Args:
+            case_id: ID of the test case to retrieve values for.
+
+        Returns:
+            TestcaseFieldValuesResult with data set to a list of
+            ``{field_id, field_name, field_type, position, is_required,
+            value}`` dicts on success, a not-found error if the test case
+            doesn't exist, or an internal error on DB failure.
+        """
+        if not self._state.is_available():
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Service unavailable",
+                                             is_internal=True)
+
+        project_id = await self._get_testcase_project_id(case_id)
+        if isinstance(project_id, TestcaseFieldValuesResult):
+            return project_id
+
+        try:
+            fields = await self._repository.get_applicable_fields(project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving fields for project %d: %s",
+                project_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        try:
+            stored = await self._repository.get_field_values(case_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving field values for testcase "
+                "%d: %s", case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        data = [
+            {
+                "field_id": field["id"],
+                "field_name": field["field_name"],
+                "field_type": field["field_type"],
+                "position": field["position"],
+                "is_required": field["is_required"],
+                "value": stored.get(field["id"], field["default_value"]),
+            }
+            for field in fields
+        ]
+
+        return TestcaseFieldValuesResult(success=True, data=data)
+
+    async def set_field_values(
+            self,
+            case_id: int,
+            values: dict[int, str]) -> TestcaseFieldValuesResult:
+        """Set one or more custom field values for a test case.
+
+        Only the fields present in ``values`` are affected — omitted fields
+        keep whatever value (or default) they already had. Each field must
+        be applicable to the test case's project; values are checked
+        against the field's ``is_required`` flag and, where the field type
+        has a well-defined format (Integer, Checkbox, Date, Url (Link)),
+        against that format too. All values are validated before any
+        writes happen.
+
+        Args:
+            case_id: ID of the test case to update.
+            values:  Mapping of field_id to the new value string.
+
+        Returns:
+            TestcaseFieldValuesResult indicating success, a not-found error
+            if the test case doesn't exist, a bad-request error if any
+            field is inapplicable or fails validation, or an internal
+            error on DB failure.
+        """
+        if not self._state.is_available():
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Service unavailable",
+                                             is_internal=True)
+
+        project_id = await self._get_testcase_project_id(case_id)
+        if isinstance(project_id, TestcaseFieldValuesResult):
+            return project_id
+
+        try:
+            fields = await self._repository.get_applicable_fields(project_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving fields for project %d: %s",
+                project_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        fields_by_id = {field["id"]: field for field in fields}
+
+        validation_error = self._validate_values(fields_by_id, values)
+        if validation_error is not None:
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg=validation_error)
+
+        try:
+            for field_id, value in values.items():
+                exists = await self._repository.value_row_exists(
+                    case_id, field_id)
+                if exists:
+                    await self._repository.update_field_value(
+                        case_id, field_id, value)
+                else:
+                    await self._repository.insert_field_value(
+                        case_id, field_id, value)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure writing field values for testcase %d: %s",
+                case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        return TestcaseFieldValuesResult(success=True)
+
+    @staticmethod
+    def _validate_values(fields_by_id: dict[int, dict],
+                         values: dict[int, str]) -> Optional[str]:
+        """Validate every field_id/value pair before any writes happen.
+
+        Args:
+            fields_by_id: Field definitions applicable to the test case's
+                          project, keyed by field_id.
+            values:       Mapping of field_id to the new value string.
+
+        Returns:
+            A human-readable error message for the first invalid entry
+            found, or None if every entry is valid.
+        """
+        for field_id, value in values.items():
+            field = fields_by_id.get(field_id)
+            if field is None:
+                return (f"Field {field_id} does not apply to this test "
+                        "case's project")
+
+            if field["is_required"] and not value.strip():
+                return f"{field['field_name']} is required"
+
+            if value.strip():
+                error = validate_value(field["field_type"], value)
+                if error is not None:
+                    return f"{field['field_name']}: {error}"
+
+        return None
+
+    async def _get_testcase_project_id(self, case_id: int):
+        """Look up a test case's project ID, wrapping failures as a result.
+
+        Args:
+            case_id: ID of the test case to look up.
+
+        Returns:
+            The project ID (int) on success, or a TestcaseFieldValuesResult
+            describing the failure (not-found or internal error).
+        """
+        try:
+            project_id = await self._repository.get_testcase_project_id(
+                case_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving testcase %d: %s", case_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        if project_id is None:
+            return TestcaseFieldValuesResult(success=False,
+                                             error_msg="Test case not found",
+                                             not_found=True)
+
+        return project_id

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -372,6 +372,53 @@
                 }
               },
               "response": []
+            },
+            {
+              "name": "Get Testcase Custom Field Values",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/testcases/1/custom_fields",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "testcases",
+                    "1",
+                    "custom_fields"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Set Testcase Custom Field Values",
+              "request": {
+                "method": "PUT",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"values\": {\n        \"1\": \"High\"\n    }\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{CMS_SVC_URL}}/testcases/1/custom_fields",
+                  "host": [
+                    "{{CMS_SVC_URL}}"
+                  ],
+                  "path": [
+                    "testcases",
+                    "1",
+                    "custom_fields"
+                  ]
+                }
+              },
+              "response": []
             }
           ]
         },

--- a/unit_tests/items_cms/main.py
+++ b/unit_tests/items_cms/main.py
@@ -25,6 +25,15 @@ from test_testcase_handlers import (
     TestModifyTestcaseHandler,
     TestDeleteTestcaseHandler,
 )
+from test_testcase_field_values_handlers import (
+    TestGetTestcaseFieldValuesHandler,
+    TestSetTestcaseFieldValuesHandler,
+)
+from test_testcase_field_values_service import TestTestcaseFieldValuesService
+from test_testcase_field_values_repository import (
+    TestTestcaseFieldValuesRepository,
+)
+from test_testcase_field_value_validation import TestValidateValue
 from test_testcase_custom_field_handlers import (
     TestGetCustomFieldHandler,
     TestGetCustomFieldsHandler,

--- a/unit_tests/items_cms/test_route_factories.py
+++ b/unit_tests/items_cms/test_route_factories.py
@@ -280,6 +280,21 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
+    # Testcase field value routes  (routes/testcase_field_values/__init__.py)
+    # ------------------------------------------------------------------
+
+    async def test_get_testcase_field_values_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/testcases/999/custom_fields")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_set_testcase_field_values_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.put(
+                "/testcases/999/custom_fields", json={"values": {"1": "x"}})
+        self.assertNotEqual(response.status_code, 405)
+
+    # ------------------------------------------------------------------
     # Custom-field routes  (routes/testcase_custom_fields/__init__.py)
     # ------------------------------------------------------------------
 

--- a/unit_tests/items_cms/test_testcase_field_value_validation.py
+++ b/unit_tests/items_cms/test_testcase_field_value_validation.py
@@ -1,0 +1,108 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from items.services.items_cms.services.testcase_field_value_validation import (
+    validate_value,
+)
+
+
+class TestValidateValue(unittest.TestCase):
+    """Unit tests for validate_value."""
+
+    # ------------------------------------------------------------------
+    # Integer
+    # ------------------------------------------------------------------
+
+    def test_integer_accepts_valid_integer(self):
+        self.assertIsNone(validate_value("Integer", "42"))
+
+    def test_integer_accepts_negative_integer(self):
+        self.assertIsNone(validate_value("Integer", "-7"))
+
+    def test_integer_rejects_non_numeric(self):
+        self.assertIsNotNone(validate_value("Integer", "abc"))
+
+    def test_integer_rejects_decimal(self):
+        self.assertIsNotNone(validate_value("Integer", "3.14"))
+
+    # ------------------------------------------------------------------
+    # Checkbox
+    # ------------------------------------------------------------------
+
+    def test_checkbox_accepts_true(self):
+        self.assertIsNone(validate_value("Checkbox", "true"))
+
+    def test_checkbox_accepts_false_case_insensitive(self):
+        self.assertIsNone(validate_value("Checkbox", "False"))
+
+    def test_checkbox_accepts_zero_and_one(self):
+        self.assertIsNone(validate_value("Checkbox", "0"))
+        self.assertIsNone(validate_value("Checkbox", "1"))
+
+    def test_checkbox_rejects_other_values(self):
+        self.assertIsNotNone(validate_value("Checkbox", "maybe"))
+
+    # ------------------------------------------------------------------
+    # Date
+    # ------------------------------------------------------------------
+
+    def test_date_accepts_iso_format(self):
+        self.assertIsNone(validate_value("Date", "2026-07-25"))
+
+    def test_date_rejects_invalid_format(self):
+        self.assertIsNotNone(validate_value("Date", "25/07/2026"))
+
+    def test_date_rejects_garbage(self):
+        self.assertIsNotNone(validate_value("Date", "not-a-date"))
+
+    # ------------------------------------------------------------------
+    # Url (Link)
+    # ------------------------------------------------------------------
+
+    def test_url_accepts_https(self):
+        self.assertIsNone(validate_value("Url (Link)", "https://example.com"))
+
+    def test_url_accepts_http(self):
+        self.assertIsNone(validate_value("Url (Link)", "http://example.com"))
+
+    def test_url_rejects_missing_scheme(self):
+        self.assertIsNotNone(validate_value("Url (Link)", "example.com"))
+
+    def test_url_rejects_unsupported_scheme(self):
+        self.assertIsNotNone(validate_value("Url (Link)", "ftp://example.com"))
+
+    # ------------------------------------------------------------------
+    # Types with no specific format
+    # ------------------------------------------------------------------
+
+    def test_dropdown_accepts_any_string(self):
+        self.assertIsNone(validate_value("Dropdown", "anything"))
+
+    def test_string_accepts_any_string(self):
+        self.assertIsNone(validate_value("String", "anything"))
+
+    def test_text_accepts_any_string(self):
+        self.assertIsNone(validate_value("Text", "anything"))
+
+    def test_user_accepts_any_string(self):
+        self.assertIsNone(validate_value("User", "anything"))
+
+    def test_unknown_type_accepts_any_string(self):
+        self.assertIsNone(validate_value("SomeFutureType", "anything"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_testcase_field_values_handlers.py
+++ b/unit_tests/items_cms/test_testcase_field_values_handlers.py
@@ -1,0 +1,149 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from items.services.items_cms.routes.testcase_field_values.get_testcase_field_values_handler import (
+    GetTestcaseFieldValuesHandler,
+)
+from items.services.items_cms.routes.testcase_field_values.set_testcase_field_values_handler import (
+    SetTestcaseFieldValuesHandler,
+)
+from items.services.items_cms.services.testcase_field_values_service import (
+    TestcaseFieldValuesService,
+    TestcaseFieldValuesResult,
+)
+
+_LOGGER = MagicMock()
+
+
+def _ok(**kwargs):
+    return TestcaseFieldValuesResult(success=True, **kwargs)
+
+
+def _internal():
+    return TestcaseFieldValuesResult(
+        success=False, error_msg="err", is_internal=True)
+
+
+def _not_found():
+    return TestcaseFieldValuesResult(
+        success=False, error_msg="not found", not_found=True)
+
+
+def _bad_request(msg="bad"):
+    return TestcaseFieldValuesResult(success=False, error_msg=msg)
+
+
+# ------------------------------------------------------------------
+# GetTestcaseFieldValuesHandler
+# ------------------------------------------------------------------
+
+class TestGetTestcaseFieldValuesHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=TestcaseFieldValuesService)
+        handler = GetTestcaseFieldValuesHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/testcases/<int:case_id>/custom_fields")
+        async def get_field_values(case_id):
+            return await handler.get_field_values(case_id)
+
+        self.client = app.test_client()
+
+    async def test_success_returns_200(self):
+        payload = [{"field_id": 1, "field_name": "Priority", "value": "High"}]
+        self.mock_service.get_field_values.return_value = _ok(data=payload)
+        async with self.client as c:
+            response = await c.get("/testcases/1/custom_fields")
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data[0]["field_name"], "Priority")
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.get_field_values.return_value = _not_found()
+        async with self.client as c:
+            response = await c.get("/testcases/99/custom_fields")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.get_field_values.return_value = _internal()
+        async with self.client as c:
+            response = await c.get("/testcases/1/custom_fields")
+        self.assertEqual(response.status_code, 500)
+
+
+# ------------------------------------------------------------------
+# SetTestcaseFieldValuesHandler
+# ------------------------------------------------------------------
+
+class TestSetTestcaseFieldValuesHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_service = AsyncMock(spec=TestcaseFieldValuesService)
+        handler = SetTestcaseFieldValuesHandler(_LOGGER, self.mock_service)
+
+        app = Quart(__name__)
+
+        @app.route("/testcases/<int:case_id>/custom_fields", methods=["PUT"])
+        async def set_field_values(case_id):
+            return await handler.set_field_values(case_id)
+
+        self.client = app.test_client()
+
+    async def _put(self, case_id, body):
+        async with self.client as c:
+            return await c.put(f"/testcases/{case_id}/custom_fields", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_service.set_field_values.return_value = _ok()
+        response = await self._put(1, {"values": {"1": "High"}})
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["status"], 1)
+        self.mock_service.set_field_values.assert_called_once_with(
+            1, {1: "High"})
+
+    async def test_missing_values_key_returns_400(self):
+        response = await self._put(1, {})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.set_field_values.assert_not_called()
+
+    async def test_non_numeric_field_id_key_returns_400(self):
+        response = await self._put(1, {"values": {"not-a-number": "High"}})
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.set_field_values.assert_not_called()
+
+    async def test_not_found_returns_404(self):
+        self.mock_service.set_field_values.return_value = _not_found()
+        response = await self._put(99, {"values": {"1": "High"}})
+        self.assertEqual(response.status_code, 404)
+
+    async def test_bad_request_returns_400(self):
+        self.mock_service.set_field_values.return_value = _bad_request()
+        response = await self._put(1, {"values": {"1": "High"}})
+        self.assertEqual(response.status_code, 400)
+
+    async def test_internal_error_returns_500(self):
+        self.mock_service.set_field_values.return_value = _internal()
+        response = await self._put(1, {"values": {"1": "High"}})
+        self.assertEqual(response.status_code, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_testcase_field_values_repository.py
+++ b/unit_tests/items_cms/test_testcase_field_values_repository.py
@@ -1,0 +1,291 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import os
+import sqlite3
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+from items.services.items_cms.repositories.testcase_field_values_repository import (
+    TestcaseFieldValuesRepository,
+)
+from items.services.items_cms.cms_configuration import CMSConfiguration
+
+_SCHEMA_SQL = """
+CREATE TABLE prj_projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL UNIQUE
+);
+CREATE TABLE tc_test_cases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id INTEGER NOT NULL,
+    folder_id INTEGER NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    FOREIGN KEY (project_id) REFERENCES prj_projects(id) ON DELETE CASCADE
+);
+CREATE TABLE tc_custom_field_types (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT UNIQUE NOT NULL,
+    supports_default_value BOOLEAN NOT NULL DEFAULT 0,
+    supports_is_required BOOLEAN NOT NULL DEFAULT 0
+);
+CREATE TABLE tc_custom_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    system_name TEXT NOT NULL UNIQUE,
+    field_type_id INTEGER NOT NULL,
+    entry_type TEXT NOT NULL CHECK(entry_type IN ('system', 'user')),
+    enabled BOOLEAN NOT NULL,
+    position INTEGER NOT NULL,
+    is_required BOOLEAN NOT NULL DEFAULT 0,
+    default_value TEXT NOT NULL DEFAULT '',
+    applies_to_all_projects BOOLEAN NOT NULL DEFAULT 0,
+    FOREIGN KEY (field_type_id) REFERENCES tc_custom_field_types(id)
+);
+CREATE TABLE tc_custom_field_projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    FOREIGN KEY (field_id) REFERENCES tc_custom_fields(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES prj_projects(id) ON DELETE CASCADE
+);
+CREATE TABLE tc_custom_field_option_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    test_case_id INTEGER NOT NULL,
+    field_id INTEGER NOT NULL,
+    value TEXT NOT NULL,
+    FOREIGN KEY (test_case_id) REFERENCES tc_test_cases(id) ON DELETE CASCADE,
+    FOREIGN KEY (field_id) REFERENCES tc_custom_fields(id) ON DELETE CASCADE,
+    UNIQUE(test_case_id, field_id)
+);
+INSERT INTO tc_custom_field_types (name, supports_default_value, supports_is_required)
+VALUES ('String', 1, 1), ('Integer', 1, 1);
+"""
+
+_STRING_TYPE_ID = 1
+
+
+class TestTestcaseFieldValuesRepository(unittest.IsolatedAsyncioTestCase):
+    """Integration tests for TestcaseFieldValuesRepository against a real SQLite DB."""
+
+    async def asyncSetUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        conn = sqlite3.connect(self.db_path)
+        conn.executescript(_SCHEMA_SQL)
+        conn.close()
+
+        mock_config = MagicMock(spec=CMSConfiguration)
+        mock_config.backend_db_filename = self.db_path
+        self.repo = TestcaseFieldValuesRepository(MagicMock(), mock_config)
+
+        self.project_id = self._insert_project("Alpha")
+        self.case_id = self._insert_testcase(self.project_id, "Login Test")
+
+    async def asyncTearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _db_insert(self, sql, params=()):
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.execute(sql, params)
+        row_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        return row_id
+
+    def _db_query(self, sql, params=()):
+        conn = sqlite3.connect(self.db_path)
+        rows = conn.execute(sql, params).fetchall()
+        conn.close()
+        return rows
+
+    def _insert_project(self, name):
+        return self._db_insert(
+            "INSERT INTO prj_projects (name) VALUES (?)", (name,))
+
+    def _insert_testcase(self, project_id, name):
+        return self._db_insert(
+            "INSERT INTO tc_test_cases (project_id, name) VALUES (?, ?)",
+            (project_id, name))
+
+    def _insert_field(self, field_name, system_name, position,
+                      field_type_id=_STRING_TYPE_ID, is_required=False,
+                      default_value="", applies_to_all=True):
+        return self._db_insert(
+            "INSERT INTO tc_custom_fields "
+            "(field_name, description, system_name, field_type_id, "
+            "entry_type, enabled, position, is_required, default_value, "
+            "applies_to_all_projects) "
+            "VALUES (?, '', ?, ?, 'user', 1, ?, ?, ?, ?)",
+            (field_name, system_name, field_type_id, position,
+             is_required, default_value, applies_to_all))
+
+    def _link_field_to_project(self, field_id, project_id):
+        self._db_insert(
+            "INSERT INTO tc_custom_field_projects (field_id, project_id) "
+            "VALUES (?, ?)", (field_id, project_id))
+
+    def _insert_value(self, case_id, field_id, value):
+        return self._db_insert(
+            "INSERT INTO tc_custom_field_option_values "
+            "(test_case_id, field_id, value) VALUES (?, ?, ?)",
+            (case_id, field_id, value))
+
+    # ------------------------------------------------------------------
+    # get_testcase_project_id
+    # ------------------------------------------------------------------
+
+    async def test_get_testcase_project_id_returns_none_when_not_found(self):
+        result = await self.repo.get_testcase_project_id(999)
+        self.assertIsNone(result)
+
+    async def test_get_testcase_project_id_returns_id_when_found(self):
+        result = await self.repo.get_testcase_project_id(self.case_id)
+        self.assertEqual(result, self.project_id)
+
+    # ------------------------------------------------------------------
+    # get_applicable_fields
+    # ------------------------------------------------------------------
+
+    async def test_get_applicable_fields_returns_empty_when_none(self):
+        result = await self.repo.get_applicable_fields(self.project_id)
+        self.assertEqual(result, [])
+
+    async def test_get_applicable_fields_includes_global_fields(self):
+        self._insert_field("Priority", "priority", position=1,
+                           applies_to_all=True)
+        result = await self.repo.get_applicable_fields(self.project_id)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["field_name"], "Priority")
+        self.assertEqual(result[0]["field_type"], "String")
+        self.assertFalse(result[0]["is_required"])
+
+    async def test_get_applicable_fields_includes_linked_fields(self):
+        field_id = self._insert_field("Severity", "severity", position=1,
+                                      applies_to_all=False)
+        self._link_field_to_project(field_id, self.project_id)
+        result = await self.repo.get_applicable_fields(self.project_id)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["field_name"], "Severity")
+
+    async def test_get_applicable_fields_excludes_unlinked_fields(self):
+        self._insert_field("OtherProjectOnly", "other", position=1,
+                           applies_to_all=False)
+        result = await self.repo.get_applicable_fields(self.project_id)
+        self.assertEqual(result, [])
+
+    async def test_get_applicable_fields_ordered_by_position(self):
+        self._insert_field("Second", "second", position=2)
+        self._insert_field("First", "first", position=1)
+        result = await self.repo.get_applicable_fields(self.project_id)
+        self.assertEqual([f["field_name"] for f in result],
+                         ["First", "Second"])
+
+    # ------------------------------------------------------------------
+    # get_field_values
+    # ------------------------------------------------------------------
+
+    async def test_get_field_values_returns_empty_when_none(self):
+        result = await self.repo.get_field_values(self.case_id)
+        self.assertEqual(result, {})
+
+    async def test_get_field_values_returns_stored_values(self):
+        field_id = self._insert_field("Priority", "priority", position=1)
+        self._insert_value(self.case_id, field_id, "High")
+        result = await self.repo.get_field_values(self.case_id)
+        self.assertEqual(result, {field_id: "High"})
+
+    # ------------------------------------------------------------------
+    # get_field_values_for_testcases
+    # ------------------------------------------------------------------
+
+    async def test_get_field_values_for_testcases_returns_empty_for_empty_input(self):
+        result = await self.repo.get_field_values_for_testcases([])
+        self.assertEqual(result, {})
+
+    async def test_get_field_values_for_testcases_groups_by_case(self):
+        other_case_id = self._insert_testcase(self.project_id, "Other Test")
+        field_id = self._insert_field("Priority", "priority", position=1)
+        self._insert_value(self.case_id, field_id, "High")
+        self._insert_value(other_case_id, field_id, "Low")
+
+        result = await self.repo.get_field_values_for_testcases(
+            [self.case_id, other_case_id])
+
+        self.assertEqual(result, {
+            self.case_id: {field_id: "High"},
+            other_case_id: {field_id: "Low"},
+        })
+
+    async def test_get_field_values_for_testcases_omits_cases_without_values(self):
+        other_case_id = self._insert_testcase(self.project_id, "Other Test")
+        field_id = self._insert_field("Priority", "priority", position=1)
+        self._insert_value(self.case_id, field_id, "High")
+
+        result = await self.repo.get_field_values_for_testcases(
+            [self.case_id, other_case_id])
+
+        self.assertEqual(result, {self.case_id: {field_id: "High"}})
+
+    # ------------------------------------------------------------------
+    # value_row_exists
+    # ------------------------------------------------------------------
+
+    async def test_value_row_exists_returns_false_when_absent(self):
+        field_id = self._insert_field("Priority", "priority", position=1)
+        result = await self.repo.value_row_exists(self.case_id, field_id)
+        self.assertFalse(result)
+
+    async def test_value_row_exists_returns_true_when_present(self):
+        field_id = self._insert_field("Priority", "priority", position=1)
+        self._insert_value(self.case_id, field_id, "High")
+        result = await self.repo.value_row_exists(self.case_id, field_id)
+        self.assertTrue(result)
+
+    # ------------------------------------------------------------------
+    # insert_field_value / update_field_value
+    # ------------------------------------------------------------------
+
+    async def test_insert_field_value_creates_row(self):
+        field_id = self._insert_field("Priority", "priority", position=1)
+        await self.repo.insert_field_value(self.case_id, field_id, "High")
+        rows = self._db_query(
+            "SELECT value FROM tc_custom_field_option_values "
+            "WHERE test_case_id = ? AND field_id = ?",
+            (self.case_id, field_id))
+        self.assertEqual(rows[0][0], "High")
+
+    async def test_update_field_value_changes_existing_row(self):
+        field_id = self._insert_field("Priority", "priority", position=1)
+        self._insert_value(self.case_id, field_id, "High")
+        await self.repo.update_field_value(self.case_id, field_id, "Low")
+        rows = self._db_query(
+            "SELECT value FROM tc_custom_field_option_values "
+            "WHERE test_case_id = ? AND field_id = ?",
+            (self.case_id, field_id))
+        self.assertEqual(rows[0][0], "Low")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_testcase_field_values_service.py
+++ b/unit_tests/items_cms/test_testcase_field_values_service.py
@@ -1,0 +1,196 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_cms.services.testcase_field_values_service import (
+    TestcaseFieldValuesService,
+)
+from items.services.items_cms.repositories.testcase_field_values_repository import (
+    TestcaseFieldValuesRepository,
+)
+from items.shared.service_state import ServiceState
+
+_PRIORITY_FIELD = {
+    "id": 1,
+    "field_name": "Priority",
+    "field_type": "String",
+    "is_required": False,
+    "default_value": "Medium",
+    "position": 1,
+}
+
+_SEVERITY_FIELD = {
+    "id": 2,
+    "field_name": "Severity",
+    "field_type": "Integer",
+    "is_required": True,
+    "default_value": "",
+    "position": 2,
+}
+
+
+class TestTestcaseFieldValuesService(unittest.IsolatedAsyncioTestCase):
+    """Unit tests for TestcaseFieldValuesService."""
+
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock()
+        self.mock_state = MagicMock(spec=ServiceState)
+        self.mock_state.is_available.return_value = True
+        self.mock_repo = AsyncMock(spec=TestcaseFieldValuesRepository)
+        self.mock_repo.get_testcase_project_id.return_value = 5
+        self.service = TestcaseFieldValuesService(
+            self.mock_logger, self.mock_state, self.mock_repo)
+
+    # ------------------------------------------------------------------
+    # get_field_values
+    # ------------------------------------------------------------------
+
+    async def test_get_field_values_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.get_field_values(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_get_field_values_project_lookup_db_exception(self):
+        self.mock_repo.get_testcase_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.get_field_values(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_get_field_values_testcase_not_found(self):
+        self.mock_repo.get_testcase_project_id.return_value = None
+        result = await self.service.get_field_values(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_get_field_values_fields_db_exception(self):
+        self.mock_repo.get_applicable_fields.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.get_field_values(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_get_field_values_values_db_exception(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.get_field_values.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.get_field_values(1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_get_field_values_uses_default_when_unset(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.get_field_values.return_value = {}
+        result = await self.service.get_field_values(1)
+        self.assertTrue(result.success)
+        self.assertEqual(result.data[0]["value"], "Medium")
+
+    async def test_get_field_values_uses_stored_value_when_set(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.get_field_values.return_value = {1: "High"}
+        result = await self.service.get_field_values(1)
+        self.assertTrue(result.success)
+        self.assertEqual(result.data[0]["value"], "High")
+        self.assertEqual(result.data[0]["position"], 1)
+
+    # ------------------------------------------------------------------
+    # set_field_values
+    # ------------------------------------------------------------------
+
+    async def test_set_field_values_service_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_set_field_values_project_lookup_db_exception(self):
+        self.mock_repo.get_testcase_project_id.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_set_field_values_testcase_not_found(self):
+        self.mock_repo.get_testcase_project_id.return_value = None
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
+    async def test_set_field_values_fields_db_exception(self):
+        self.mock_repo.get_applicable_fields.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+
+    async def test_set_field_values_unknown_field_rejected(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        result = await self.service.set_field_values(1, {999: "High"})
+        self.assertFalse(result.success)
+        self.assertFalse(result.is_internal)
+        self.assertFalse(result.not_found)
+        self.assertIn("999", result.error_msg)
+        self.mock_repo.insert_field_value.assert_not_called()
+
+    async def test_set_field_values_required_field_empty_rejected(self):
+        self.mock_repo.get_applicable_fields.return_value = [_SEVERITY_FIELD]
+        result = await self.service.set_field_values(1, {2: "   "})
+        self.assertFalse(result.success)
+        self.assertIn("Severity", result.error_msg)
+
+    async def test_set_field_values_type_validation_failure_rejected(self):
+        self.mock_repo.get_applicable_fields.return_value = [_SEVERITY_FIELD]
+        result = await self.service.set_field_values(1, {2: "not-a-number"})
+        self.assertFalse(result.success)
+        self.assertIn("Severity", result.error_msg)
+
+    async def test_set_field_values_optional_empty_value_allowed(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.value_row_exists.return_value = False
+        result = await self.service.set_field_values(1, {1: ""})
+        self.assertTrue(result.success)
+
+    async def test_set_field_values_write_db_exception(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.value_row_exists.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_set_field_values_inserts_when_no_existing_row(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.value_row_exists.return_value = False
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertTrue(result.success)
+        self.mock_repo.insert_field_value.assert_called_once_with(1, 1, "High")
+        self.mock_repo.update_field_value.assert_not_called()
+
+    async def test_set_field_values_updates_when_existing_row(self):
+        self.mock_repo.get_applicable_fields.return_value = [_PRIORITY_FIELD]
+        self.mock_repo.value_row_exists.return_value = True
+        result = await self.service.set_field_values(1, {1: "High"})
+        self.assertTrue(result.success)
+        self.mock_repo.update_field_value.assert_called_once_with(1, 1, "High")
+        self.mock_repo.insert_field_value.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_cms/test_testcase_repository.py
+++ b/unit_tests/items_cms/test_testcase_repository.py
@@ -49,7 +49,47 @@ CREATE TABLE tc_test_cases (
     FOREIGN KEY (folder_id) REFERENCES tc_folders(id) ON DELETE CASCADE,
     UNIQUE (project_id, folder_id, name)
 );
+CREATE TABLE tc_custom_field_types (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT UNIQUE NOT NULL,
+    supports_default_value BOOLEAN NOT NULL DEFAULT 0,
+    supports_is_required BOOLEAN NOT NULL DEFAULT 0
+);
+CREATE TABLE tc_custom_fields (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_name TEXT NOT NULL UNIQUE,
+    description TEXT NOT NULL DEFAULT '',
+    system_name TEXT NOT NULL UNIQUE,
+    field_type_id INTEGER NOT NULL,
+    entry_type TEXT NOT NULL CHECK(entry_type IN ('system', 'user')),
+    enabled BOOLEAN NOT NULL,
+    position INTEGER NOT NULL,
+    is_required BOOLEAN NOT NULL DEFAULT 0,
+    default_value TEXT NOT NULL DEFAULT '',
+    applies_to_all_projects BOOLEAN NOT NULL DEFAULT 0,
+    FOREIGN KEY (field_type_id) REFERENCES tc_custom_field_types(id)
+);
+CREATE TABLE tc_custom_field_projects (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    field_id INTEGER NOT NULL,
+    project_id INTEGER NOT NULL,
+    FOREIGN KEY (field_id) REFERENCES tc_custom_fields(id) ON DELETE CASCADE,
+    FOREIGN KEY (project_id) REFERENCES prj_projects(id) ON DELETE CASCADE
+);
+CREATE TABLE tc_custom_field_option_values (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    test_case_id INTEGER NOT NULL,
+    field_id INTEGER NOT NULL,
+    value TEXT NOT NULL,
+    FOREIGN KEY (test_case_id) REFERENCES tc_test_cases(id) ON DELETE CASCADE,
+    FOREIGN KEY (field_id) REFERENCES tc_custom_fields(id) ON DELETE CASCADE,
+    UNIQUE(test_case_id, field_id)
+);
+INSERT INTO tc_custom_field_types (name, supports_default_value, supports_is_required)
+VALUES ('String', 1, 1);
 """
+
+_STRING_TYPE_ID = 1
 
 
 class TestTestcaseRepository(unittest.IsolatedAsyncioTestCase):
@@ -104,6 +144,39 @@ class TestTestcaseRepository(unittest.IsolatedAsyncioTestCase):
         conn.commit()
         conn.close()
         return row_id
+
+    def _insert_field(self, field_name, system_name, position,
+                      default_value="", applies_to_all=True):
+        conn = sqlite3.connect(self.db_path)
+        cur = conn.execute(
+            "INSERT INTO tc_custom_fields "
+            "(field_name, description, system_name, field_type_id, "
+            "entry_type, enabled, position, is_required, default_value, "
+            "applies_to_all_projects) "
+            "VALUES (?, '', ?, ?, 'user', 1, ?, 0, ?, ?)",
+            (field_name, system_name, _STRING_TYPE_ID, position,
+             default_value, applies_to_all))
+        row_id = cur.lastrowid
+        conn.commit()
+        conn.close()
+        return row_id
+
+    def _link_field_to_project(self, field_id, project_id):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO tc_custom_field_projects (field_id, project_id) "
+            "VALUES (?, ?)", (field_id, project_id))
+        conn.commit()
+        conn.close()
+
+    def _insert_field_value(self, case_id, field_id, value):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO tc_custom_field_option_values "
+            "(test_case_id, field_id, value) VALUES (?, ?, ?)",
+            (case_id, field_id, value))
+        conn.commit()
+        conn.close()
 
     # ------------------------------------------------------------------
     # is_valid_project_id
@@ -162,6 +235,66 @@ class TestTestcaseRepository(unittest.IsolatedAsyncioTestCase):
         self._insert_testcase(pid2, "Beta Test")
         result = await self.repo.get_testcases(pid1)
         self.assertEqual(result["test_cases"], [])
+
+    async def test_get_testcases_includes_no_custom_fields_when_none_defined(self):
+        pid = self._insert_project("Alpha")
+        self._insert_testcase(pid, "Login Test")
+        result = await self.repo.get_testcases(pid)
+        self.assertEqual(result["test_cases"][0]["custom_fields"], [])
+
+    async def test_get_testcases_includes_global_field_with_default_value(self):
+        pid = self._insert_project("Alpha")
+        self._insert_testcase(pid, "Login Test")
+        self._insert_field("Priority", "priority", position=1,
+                           default_value="Medium")
+        result = await self.repo.get_testcases(pid)
+        fields = result["test_cases"][0]["custom_fields"]
+        self.assertEqual(len(fields), 1)
+        self.assertEqual(fields[0]["field_name"], "Priority")
+        self.assertEqual(fields[0]["field_type"], "String")
+        self.assertEqual(fields[0]["value"], "Medium")
+        self.assertEqual(fields[0]["position"], 1)
+
+    async def test_get_testcases_uses_stored_value_over_default(self):
+        pid = self._insert_project("Alpha")
+        tc_id = self._insert_testcase(pid, "Login Test")
+        field_id = self._insert_field("Priority", "priority", position=1,
+                                      default_value="Medium")
+        self._insert_field_value(tc_id, field_id, "High")
+        result = await self.repo.get_testcases(pid)
+        fields = result["test_cases"][0]["custom_fields"]
+        self.assertEqual(fields[0]["value"], "High")
+
+    async def test_get_testcases_excludes_fields_linked_to_other_projects(self):
+        pid1 = self._insert_project("Alpha")
+        pid2 = self._insert_project("Beta")
+        self._insert_testcase(pid1, "Login Test")
+        field_id = self._insert_field("Beta Only", "beta_only", position=1,
+                                      applies_to_all=False)
+        self._link_field_to_project(field_id, pid2)
+        result = await self.repo.get_testcases(pid1)
+        self.assertEqual(result["test_cases"][0]["custom_fields"], [])
+
+    async def test_get_testcases_includes_linked_field(self):
+        pid = self._insert_project("Alpha")
+        self._insert_testcase(pid, "Login Test")
+        field_id = self._insert_field("Severity", "severity", position=1,
+                                      applies_to_all=False)
+        self._link_field_to_project(field_id, pid)
+        result = await self.repo.get_testcases(pid)
+        fields = result["test_cases"][0]["custom_fields"]
+        self.assertEqual(len(fields), 1)
+        self.assertEqual(fields[0]["field_name"], "Severity")
+
+    async def test_get_testcases_orders_fields_by_position(self):
+        pid = self._insert_project("Alpha")
+        self._insert_testcase(pid, "Login Test")
+        self._insert_field("Second", "second", position=2)
+        self._insert_field("First", "first", position=1)
+        result = await self.repo.get_testcases(pid)
+        fields = result["test_cases"][0]["custom_fields"]
+        self.assertEqual([f["field_name"] for f in fields],
+                         ["First", "Second"])
 
     # ------------------------------------------------------------------
     # get_testcase


### PR DESCRIPTION
## What does this PR do?

# CMS: per-test-case custom field values

**Branch:** `cms_testcases_per_field` → `main`
**Stats:** 2 commits, 16 files changed, +1826/-6

## Summary

Adds read/write support for per-test-case custom field values — the
"hardest bit" of test case support, since a test case is its core fields
(name/description, done in `cms_testcases_basic`) plus whatever values it
holds for the project's custom field definitions (`testcase_custom_fields`,
done previously). This branch is what actually ties a test case to those
field definitions.

Two access patterns are covered:
- A dedicated single-test-case endpoint for reading/writing values (edit
  view use case).
- Values inlined into the existing test case list endpoint, so a grid view
  showing custom field columns doesn't need one call per test case.

Field *ordering* stays global (`tc_custom_fields.position`, unchanged) —
matches how TestRail's own field customization screen works, and a
per-project order would be a much bigger schema change (position would
need to move into the `tc_custom_field_projects` link table). Not needed
for this branch.

## New: field values repository
`items/services/items_cms/repositories/testcase_field_values_repository.py`

- `get_testcase_project_id`, `get_applicable_fields` (fields that either
  apply to all projects or are explicitly linked to this one, ordered by
  position), `get_field_values`, `get_field_values_for_testcases` (bulk,
  used by the list endpoint), `value_row_exists`, `insert_field_value`,
  `update_field_value`.
- Writes go into `tc_custom_field_option_values` — a table that already
  existed in the schema but had nothing populating it until now.

## New: type-aware value validation
`items/services/items_cms/services/testcase_field_value_validation.py`

- `validate_value(field_type, value)` — real format checks for **Integer**
  (numeric), **Checkbox** (true/false/0/1), **Date** (ISO `YYYY-MM-DD`),
  and **Url (Link)** (must be a valid http/https URL).
- **Dropdown**, **String**, **Text**, and **User** accept any string.
  Dropdown in particular has no way to define its valid choices yet — the
  option-kind tables (`tc_custom_field_type_options`,
  `tc_custom_field_type_option_values`, `tc_custom_field_option_kinds`)
  exist in the schema but nothing anywhere writes to them. Validating
  against a fixed list isn't possible until that's built.

## New: field values service
`items/services/items_cms/services/testcase_field_values_service.py`

- `get_field_values`: merges each applicable field's definition with its
  stored value, falling back to the field's `default_value` when unset.
  Returned ordered by `position`.
- `set_field_values`: **partial update** — only the field_ids present in
  the request are touched; omitted fields keep whatever they already had.
  Validates every field_id/value pair before writing anything (field
  applies to this project → `is_required` → type format), so a bad value
  in a batch never leaves a partial write behind.

## New: field values routes
`items/services/items_cms/routes/testcase_field_values/`

| Method | Path | Notes |
|---|---|---|
| GET | `/testcases/<int:case_id>/custom_fields` | 404 if test case missing |
| PUT | `/testcases/<int:case_id>/custom_fields` | body: `{"values": {"<field_id>": "<value>", ...}}`; 400 on invalid field/value, 404 if test case missing |

Wired into `routes/__init__.py` alongside the existing blueprints.

## Changed: testcase list endpoint
`items/services/items_cms/repositories/testcase_repository.py`

`get_testcases` (backing `GET /testcases?project_id=<id>`) now attaches a
`custom_fields` array to each test case — same shape as the dedicated
endpoint (`field_id`, `field_name`, `field_type`, `position`, `value`),
built with one extra joined query rather than N follow-up calls per test
case.

## Postman collection
`postman/ITEMS.postman_collection.json`

Added **Get Testcase Custom Field Values** and **Set Testcase Custom Field
Values** to the existing `CMS Service → Testcases` folder.

## Test coverage

Repository tests run against a real SQLite fixture; service tests mock the
repository and cover every branch (service unavailable, DB exceptions,
not-found, unknown field, required-empty, type-validation failure, insert
vs. update paths); handler tests mock the service and assert every status
code, including the non-numeric `values` key case; the validator has direct
unit tests per type; route-wiring and list-endpoint tests confirm
everything is reachable and merges correctly through the real blueprint
tree.

**100% line coverage maintained across the entire CMS suite** (1906/1906
statements, 459 tests) — not just the new files. Pylint: 10.00/10.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
