### PR TITLE
[Portal] Testcase Custom Fields Page

### DIFF
--- a/future.md
+++ b/future.md
@@ -1,0 +1,54 @@
+# Future work
+
+Running list of known, deliberately-deferred items — not urgent, but worth
+tracking so they don't get lost.
+
+## CMS: `linked_projects` encoding is ambiguous
+
+**Where:** `items_cms.repositories.testcase_custom_fields_repository`'s
+`get_custom_field`/`get_all_fields`/`get_fields_for_project` queries build a
+field's linked-projects list via
+`GROUP_CONCAT(p.id || ':' || p.name)`, producing a single string like
+`"1:Alpha,2:Beta"`.
+
+**Problem:** there's no escaping. If a project name itself contains a
+comma (e.g. `"Acme, Inc"`), the resulting string is genuinely ambiguous —
+there's no way, from the string alone, to tell whether `"1:Acme, Inc,2:Beta"`
+means projects `"Acme, Inc"` and `"Beta"`, or `"Acme"` and `"Inc,2:Beta"`.
+No amount of clever parsing on the consuming side (web portal or otherwise)
+can recover the correct answer once that ambiguity exists.
+
+**Fix:** CMS needs to return `linked_projects` as structured data (a JSON
+array of `{id, name}`, or a nested field in the response) instead of a
+flattened, comma-joined string. Found while building the Case Fields admin
+page in the web portal
+(`admin_customisations_page_handler.py::_row_to_field`), which currently
+does its best with the string it's given and documents the limitation in a
+code comment there.
+
+## CMS: system custom fields can't have partial updates
+
+**Where:** `items_cms.repositories.testcase_custom_fields_repository.
+update_custom_field` rejects *any* update to a field with
+`entry_type == "system"` outright:
+
+```python
+if entry_type == "system":
+    return None
+```
+
+**Context:** the web portal's Case Fields admin page
+(`admin_customisations_page_handler.py`) already has UI and payload-building
+logic (`case_field_modify`, `_build_system_field_payload`) written on the
+assumption that a system field's `enabled` (active) state and project
+assignment *can* be changed, while every other attribute (name, system
+name, type, description, default value, required) stays locked. Right now
+every such request fails with `400 "System custom fields cannot be
+modified"` — the portal UI shows the error correctly, but the feature
+itself can't succeed yet.
+
+**Fix:** a teammate is picking this up as a separate CMS-side PR — allow
+`update_custom_field` to accept changes to `enabled` and project
+assignment for system fields specifically, while continuing to reject
+changes to the immutable attributes. The portal side is already built to
+match this contract and shouldn't need further changes once CMS supports it.

--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -114,6 +114,47 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
     async def admin_customisations_request():
         return await handler_customisations.customisations()
 
+    # Admin page | Case field add: POST '/admin/customisations/case_fields'
+    injections.logger.debug("=> %s POST /admin/customisations/case_fields",
+                            "Admin add case field".ljust(40))
+
+    @routes.route('/customisations/case_fields', methods=['POST'])
+    async def admin_customisations_case_field_add_request():
+        return await handler_customisations.case_field_add()
+
+    # Admin page | Case field modify:
+    # POST '/admin/customisations/case_fields/<id>/modify'
+    injections.logger.debug(
+        "=> %s POST /admin/customisations/case_fields/<id>/modify",
+        "Admin modify case field".ljust(40))
+
+    @routes.route('/customisations/case_fields/<int:field_id>/modify',
+                  methods=['POST'])
+    async def admin_customisations_case_field_modify_request(field_id: int):
+        return await handler_customisations.case_field_modify(field_id)
+
+    # Admin page | Case field move:
+    # POST '/admin/customisations/case_fields/<id>/move'
+    injections.logger.debug(
+        "=> %s POST /admin/customisations/case_fields/<id>/move",
+        "Admin move case field".ljust(40))
+
+    @routes.route('/customisations/case_fields/<int:field_id>/move',
+                  methods=['POST'])
+    async def admin_customisations_case_field_move_request(field_id: int):
+        return await handler_customisations.case_field_move(field_id)
+
+    # Admin page | Case field delete:
+    # POST '/admin/customisations/case_fields/<id>/delete'
+    injections.logger.debug(
+        "=> %s POST /admin/customisations/case_fields/<id>/delete",
+        "Admin delete case field".ljust(40))
+
+    @routes.route('/customisations/case_fields/<int:field_id>/delete',
+                  methods=['POST'])
+    async def admin_customisations_case_field_delete_request(field_id: int):
+        return await handler_customisations.case_field_delete(field_id)
+
     # Admin page | Integrations (read): '/admin/integrations'
     injections.logger.debug("=> %s GET /admin/integrations",
                             "Admin integrations page (read)".ljust(40))

--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -55,6 +55,8 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
         Blueprint: A configured Quart blueprint containing all
         administrative page routes.
     """
+    # pylint: disable=too-many-locals
+
     routes = Blueprint('admin_pages_routes', __name__)
 
     injections.logger.debug(" Admin Pages Handlers:")

--- a/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from http import HTTPStatus
+import json
 import logging
 from typing import Optional
 from quart import request
@@ -372,7 +373,13 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
         linked = row[_COL_LINKED_PROJECTS]
         project_names: list[str] = []
         if linked:
-            # Encoded as "id:name,id:name" by the CMS query.
+            # Encoded as "id:name,id:name" by the CMS query (GROUP_CONCAT
+            # with no escaping). This is inherently ambiguous if a project
+            # name contains a comma - there is no way to tell, from the
+            # string alone, whether "1:A,B,2:C" means projects "A,B" and
+            # "C", or "A" and "B,2:C". Fixing that needs CMS to return
+            # structured data instead of a flattened string; not attempted
+            # here.
             for entry in str(linked).split(","):
                 _, _, name = entry.partition(":")
                 if name:
@@ -392,4 +399,8 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
             "default_value": row[_COL_DEFAULT_VALUE] or "",
             "applies_to_all_projects": bool(row[_COL_APPLIES_TO_ALL]),
             "linked_projects": project_names,
+            # JSON-encoded for the edit modal's data-projects attribute -
+            # a comma-joined string would misparse any project name that
+            # itself contains a comma.
+            "linked_projects_json": json.dumps(project_names),
         }

--- a/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
@@ -14,7 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from http import HTTPStatus
 import logging
+from typing import Optional
+from quart import request
+from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
 from items.services.items_web_portal.decorators import require_session
@@ -23,12 +27,41 @@ import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
 
+# Field types accepted by the custom-fields API (must match the gateway's
+# add/modify request schema enum).
+CASE_FIELD_TYPES: list[str] = [
+    "Checkbox",
+    "Date",
+    "Dropdown",
+    "Integer",
+    "String",
+    "Text",
+    "Url (Link)",
+    "User",
+]
+
+# Ordered column indices for a case-field row as returned by
+# GET /web/testcase_custom_fields (see the CMS get_all_fields query).
+_COL_ID = 0
+_COL_FIELD_NAME = 1
+_COL_DESCRIPTION = 2
+_COL_SYSTEM_NAME = 3
+_COL_FIELD_TYPE = 4
+_COL_ENTRY_TYPE = 5
+_COL_ENABLED = 6
+_COL_POSITION = 7
+_COL_IS_REQUIRED = 8
+_COL_DEFAULT_VALUE = 9
+_COL_APPLIES_TO_ALL = 10
+_COL_LINKED_PROJECTS = 11
+
 
 class AdminCustomisationsPageHandler(PortalPageHandler):
     """Handles requests for the administration customisations page.
 
-    This handler renders the administration page used to view and manage
-    instance customisations.
+    Renders the customisations admin page and provides create, read, update,
+    delete and reorder operations for testcase custom (case) fields via the
+    gateway ``/web/testcase_custom_fields`` API.
     """
 
     def __init__(self,
@@ -47,15 +80,316 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
     @require_session
     async def customisations(self):
         """Render the administration customisations page.
 
         Returns:
-            The rendered administration customisations page response.
+            The rendered customisations page response.
         """
+        return await self._render_customisations()
+
+    # ------------------------------------------------------------------
+    # Write: case fields
+    # ------------------------------------------------------------------
+
+    @require_session
+    async def case_field_add(self):
+        """Create a new case field from the submitted form.
+
+        Returns:
+            The re-rendered customisations page, showing an error banner if
+            the gateway rejects the request.
+        """
+        payload = await self._build_field_payload()
+
+        base_url: str = self._config.apis_gateway_svc
+        url: str = f"{base_url}web/testcase_custom_fields/"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=payload)
+
+        return await self._render_after_write(response, "add")
+
+    @require_session
+    async def case_field_modify(self, field_id: int):
+        """Update an existing case field from the submitted form.
+
+        System fields may only have their active state and project assignment
+        changed. For those, the payload's immutable attributes (name, system
+        name, type, description, default value, required) are taken from the
+        field's current stored values rather than the form, so they cannot be
+        altered from the portal regardless of what is submitted.
+
+        Args:
+            field_id: ID of the case field to modify.
+
+        Returns:
+            The re-rendered customisations page, showing an error banner if
+            the gateway rejects the request.
+        """
+        current = await self._get_case_field(field_id)
+
+        if current is not None and current["is_system"]:
+            payload = await self._build_system_field_payload(current)
+        else:
+            payload = await self._build_field_payload()
+
+        base_url: str = self._config.apis_gateway_svc
+        url: str = f"{base_url}web/testcase_custom_fields/{field_id}"
+        response: ApiResponse = await self._rest_client.put(
+            url, json_data=payload)
+
+        return await self._render_after_write(response, "modify")
+
+    @require_session
+    async def case_field_delete(self, field_id: int):
+        """Delete a case field.
+
+        Args:
+            field_id: ID of the case field to delete.
+
+        Returns:
+            The re-rendered customisations page, showing an error banner if
+            the gateway rejects the request.
+        """
+        base_url: str = self._config.apis_gateway_svc
+        url: str = f"{base_url}web/testcase_custom_fields/{field_id}"
+        response: ApiResponse = await self._rest_client.delete(url)
+
+        return await self._render_after_write(response, "delete")
+
+    @require_session
+    async def case_field_move(self, field_id: int):
+        """Move a case field up or down in the ordered list.
+
+        Args:
+            field_id: ID of the case field to move.
+
+        Returns:
+            The re-rendered customisations page, showing an error banner if
+            the gateway rejects the request.
+        """
+        form = await request.form
+        direction = form.get("direction", "")
+
+        base_url: str = self._config.apis_gateway_svc
+        url: str = f"{base_url}web/testcase_custom_fields/{field_id}"
+        response: ApiResponse = await self._rest_client.patch(
+            url, json_data={"direction": direction})
+
+        return await self._render_after_write(response, "move")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _build_field_payload(self) -> dict:
+        """Build a case-field request body from the submitted form.
+
+        Checkboxes are absent from the form when unticked, so their presence
+        is treated as ``True``. When the field does not apply to all projects,
+        the selected project names are included.
+
+        Returns:
+            A dict matching the gateway add/modify request schema.
+        """
+        form = await request.form
+
+        applies_to_all = form.get("applies_to_all_projects") == "on"
+        payload: dict = {
+            "field_name": (form.get("field_name") or "").strip(),
+            "description": form.get("description") or "",
+            "system_name": (form.get("system_name") or "").strip(),
+            "field_type": form.get("field_type") or "",
+            "enabled": form.get("enabled") == "on",
+            "is_required": form.get("is_required") == "on",
+            "default_value": form.get("default_value") or "",
+            "applies_to_all_projects": applies_to_all,
+        }
+
+        if not applies_to_all:
+            payload["projects"] = form.getlist("projects")
+
+        return payload
+
+    async def _build_system_field_payload(self, current: dict) -> dict:
+        """Build a modify payload for a system field.
+
+        Only the active state and project assignment are taken from the
+        submitted form; every other attribute is taken from the field's
+        current stored values so it cannot be changed from the portal.
+
+        Args:
+            current: The field's current values (from ``_get_case_field``).
+
+        Returns:
+            A dict matching the gateway modify request schema.
+        """
+        form = await request.form
+
+        applies_to_all = form.get("applies_to_all_projects") == "on"
+        payload: dict = {
+            "field_name": current["field_name"],
+            "description": current["description"],
+            "system_name": current["system_name"],
+            "field_type": current["field_type"],
+            "enabled": form.get("enabled") == "on",
+            "is_required": current["is_required"],
+            "default_value": current["default_value"],
+            "applies_to_all_projects": applies_to_all,
+        }
+
+        if not applies_to_all:
+            payload["projects"] = form.getlist("projects")
+
+        return payload
+
+    async def _get_case_field(self, field_id: int) -> Optional[dict]:
+        """Fetch a single case field's current values.
+
+        Args:
+            field_id: ID of the field to retrieve.
+
+        Returns:
+            The mapped field dict, or None if it could not be retrieved.
+        """
+        base_url: str = self._config.apis_gateway_svc
+        response: ApiResponse = await self._rest_client.get(
+            f"{base_url}web/testcase_custom_fields/{field_id}")
+
+        if response.status_code != HTTPStatus.OK or not response.body:
+            self._logger.warning(
+                "Unable to fetch case field %s (status %s)",
+                field_id, response.status_code)
+            return None
+
+        return self._row_to_field(response.body)
+
+    async def _render_after_write(self, response: ApiResponse,
+                                  action: str):
+        """Re-render the page after a write, surfacing any gateway error.
+
+        Args:
+            response: The gateway response for the write operation.
+            action: Short action name used in the error message ("add",
+                "modify", "delete", "move").
+
+        Returns:
+            The re-rendered customisations page.
+        """
+        error_message: Optional[str] = None
+
+        if response.status_code != HTTPStatus.OK:
+            error_message = self._extract_error(response)
+            self._logger.warning(
+                "Case field %s failed (status %s): %s",
+                action, response.status_code, error_message)
+
+        return await self._render_customisations(error_message=error_message)
+
+    @staticmethod
+    def _extract_error(response: ApiResponse) -> str:
+        """Extract a human-readable error message from a gateway response."""
+        if isinstance(response.body, dict) and response.body.get("error"):
+            return str(response.body["error"])
+        return "The request could not be completed. Please try again."
+
+    async def _render_customisations(self,
+                                     error_message: Optional[str] = None):
+        """Fetch case fields and projects, then render the page.
+
+        Args:
+            error_message: Optional error banner to display on the page.
+
+        Returns:
+            The rendered customisations page, or the internal error page if
+            the case fields cannot be retrieved.
+        """
+        base_url: str = self._config.apis_gateway_svc
+
+        response: ApiResponse = await self._rest_client.get(
+            f"{base_url}web/testcase_custom_fields/")
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.critical(
+                "Gateway svc request invalid - Reason: %s",
+                response.exception_msg)
+            return await self._render_page(pages.TEMPLATE_INTERNAL_ERROR_PAGE)
+
+        case_fields = [self._row_to_field(row) for row in (response.body or [])]
+
         return await self._render_page(
             pages.PAGE_INSTANCE_ADMIN_CUSTOMISATIONS,
             instance_name=self._metadata_settings.instance_name,
             active_page="administration",
-            active_admin_page="admin_page_customisations")
+            active_admin_page="admin_page_customisations",
+            case_fields=case_fields,
+            case_field_types=CASE_FIELD_TYPES,
+            projects=await self._fetch_project_names(),
+            error_message=error_message)
+
+    async def _fetch_project_names(self) -> list[str]:
+        """Fetch the list of project names for the per-project selector.
+
+        A failure here is non-fatal: the selector is simply rendered empty so
+        the rest of the page still works.
+
+        Returns:
+            A sorted list of project names, or an empty list on failure.
+        """
+        base_url: str = self._config.apis_gateway_svc
+        try:
+            response: ApiResponse = await self._rest_client.get(
+                f"{base_url}web/projects?value_fields=name")
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch projects for selector")
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch projects for selector (status %s)",
+                response.status_code)
+            return []
+
+        projects = (response.body or {}).get("projects", [])
+        names = [p.get("name") for p in projects if p.get("name")]
+        return sorted(names)
+
+    @staticmethod
+    def _row_to_field(row: list) -> dict:
+        """Map a positional case-field row from the API to a named dict.
+
+        Args:
+            row: A single row as returned by the list endpoint.
+
+        Returns:
+            A dict with named, template-friendly keys.
+        """
+        linked = row[_COL_LINKED_PROJECTS]
+        project_names: list[str] = []
+        if linked:
+            # Encoded as "id:name,id:name" by the CMS query.
+            for entry in str(linked).split(","):
+                _, _, name = entry.partition(":")
+                if name:
+                    project_names.append(name)
+
+        return {
+            "id": row[_COL_ID],
+            "field_name": row[_COL_FIELD_NAME],
+            "description": row[_COL_DESCRIPTION] or "",
+            "system_name": row[_COL_SYSTEM_NAME],
+            "field_type": row[_COL_FIELD_TYPE],
+            "entry_type": row[_COL_ENTRY_TYPE],
+            "is_system": str(row[_COL_ENTRY_TYPE]).lower() == "system",
+            "enabled": bool(row[_COL_ENABLED]),
+            "position": row[_COL_POSITION],
+            "is_required": bool(row[_COL_IS_REQUIRED]),
+            "default_value": row[_COL_DEFAULT_VALUE] or "",
+            "applies_to_all_projects": bool(row[_COL_APPLIES_TO_ALL]),
+            "linked_projects": project_names,
+        }

--- a/items/services/items_web_portal/static/css/instance_admin_customisations.css
+++ b/items/services/items_web_portal/static/css/instance_admin_customisations.css
@@ -63,10 +63,6 @@
     text-decoration: none;
 }
 
-.case-fields-table .field-locked {
-    color: #b0b8c1;
-}
-
 /*
  * Collapse the tab labels to icons only once the full-label tab bar can no
  * longer fit its container. The `icons-only` class is toggled by

--- a/items/services/items_web_portal/static/css/instance_admin_customisations.css
+++ b/items/services/items_web_portal/static/css/instance_admin_customisations.css
@@ -49,6 +49,24 @@
     margin: 0;
 }
 
+/* Case fields table */
+.case-fields-table .field-name {
+    color: #2a72b5;
+    font-weight: 600;
+}
+
+.case-fields-table .field-system-name {
+    color: #7a8794;
+}
+
+.case-fields-table .btn-link {
+    text-decoration: none;
+}
+
+.case-fields-table .field-locked {
+    color: #b0b8c1;
+}
+
 /*
  * Collapse the tab labels to icons only once the full-label tab bar can no
  * longer fit its container. The `icons-only` class is toggled by

--- a/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
@@ -1,23 +1,22 @@
 /*
- * Customisations tab bar responsive behaviour.
- *
- * Rather than relying on a fixed breakpoint, this collapses the tab labels to
- * icons only as soon as the full-label tab bar would overflow its container
- * (which would otherwise show a horizontal scroll bar). Labels are restored
- * whenever there is room for them again.
+ * Customisations admin page behaviour:
+ *   1. Responsive tab bar (collapse labels to icons when they would overflow).
+ *   2. Case Fields add/edit modal population and delete confirmation.
  */
 (function () {
+  /* ----------------------------------------------------------------
+   * Responsive tab bar
+   * ---------------------------------------------------------------- */
   const tabBar = document.getElementById('customisationsTabs');
-  if (!tabBar) {
-    return;
-  }
 
   function updateTabLabels() {
+    if (!tabBar) {
+      return;
+    }
     // Measure in the labels-shown state so the decision is based on the space
     // the labels actually need, not the collapsed width. Removing the class
     // first forces a synchronous reflow before we read the dimensions.
     tabBar.classList.remove('icons-only');
-
     if (tabBar.scrollWidth > tabBar.clientWidth) {
       tabBar.classList.add('icons-only');
     }
@@ -25,4 +24,185 @@
 
   window.addEventListener('resize', updateTabLabels);
   updateTabLabels();
+
+  /* ----------------------------------------------------------------
+   * Case field add / edit modal
+   * ---------------------------------------------------------------- */
+  const modal = document.getElementById('caseFieldModal');
+  const form = document.getElementById('caseFieldForm');
+  const title = document.getElementById('caseFieldModalLabel');
+  const appliesAll = document.getElementById('cf-applies-all');
+  const projectsWrapper = document.getElementById('cf-projects-wrapper');
+  const projectsSelect = document.getElementById('cf-projects');
+
+  const ADD_ACTION = '/admin/customisations/case_fields';
+  const systemNote = document.getElementById('cf-system-note');
+
+  function toggleProjects() {
+    if (!appliesAll || !projectsWrapper) {
+      return;
+    }
+    projectsWrapper.style.display = appliesAll.checked ? 'none' : 'block';
+  }
+
+  // System fields may only have their active state and project assignment
+  // changed, so lock (and visibly grey out) every other control. Using
+  // `disabled` rather than `readOnly` makes the locked state obvious; it is
+  // safe because the server rebuilds a system field's immutable attributes
+  // from its stored values and ignores whatever the form submits for them.
+  function applySystemLock(isSystem) {
+    if (!form) {
+      return;
+    }
+    form.field_name.disabled = isSystem;
+    form.system_name.disabled = isSystem;
+    form.description.disabled = isSystem;
+    form.default_value.disabled = isSystem;
+    form.field_type.disabled = isSystem;
+    form.is_required.disabled = isSystem;
+    if (systemNote) {
+      systemNote.style.display = isSystem ? 'block' : 'none';
+    }
+  }
+
+  // Build the Default value control to match the selected field type so the
+  // entered default is valid for that type (e.g. a Checkbox default is a
+  // true/false choice, a Date default is a date picker). The control always
+  // uses name="default_value" so the form submits it regardless of type.
+  function renderDefaultControl(type, value) {
+    const container = document.getElementById('cf-default-control');
+    if (!container) {
+      return;
+    }
+    value = value || '';
+
+    let html;
+    switch (type) {
+      case 'Checkbox':
+        html = '<select class="form-select" id="cf-default-value" name="default_value">'
+             + '<option value="false">Unchecked</option>'
+             + '<option value="true">Checked</option></select>';
+        break;
+      case 'Date':
+        html = '<input type="date" class="form-control" id="cf-default-value" name="default_value">';
+        break;
+      case 'Integer':
+        html = '<input type="number" step="1" class="form-control" id="cf-default-value" name="default_value">';
+        break;
+      case 'Url (Link)':
+        html = '<input type="url" class="form-control" id="cf-default-value" name="default_value">';
+        break;
+      case 'Text':
+        html = '<textarea class="form-control" id="cf-default-value" name="default_value" rows="2"></textarea>';
+        break;
+      default: // String, Dropdown, User
+        html = '<input type="text" class="form-control" id="cf-default-value" name="default_value">';
+    }
+
+    container.innerHTML = html;
+    const control = container.firstElementChild;
+
+    if (control.tagName === 'SELECT') {
+      control.value = (value === 'true' || value === '1') ? 'true' : 'false';
+    } else {
+      control.value = value;
+    }
+  }
+
+  if (form && form.field_type) {
+    // Rebuild the default control (starting empty) whenever the type changes.
+    form.field_type.addEventListener('change', function () {
+      renderDefaultControl(this.value, '');
+    });
+  }
+
+  function setProjectSelection(names) {
+    if (!projectsSelect) {
+      return;
+    }
+    const wanted = new Set(names.filter(Boolean));
+    Array.from(projectsSelect.options).forEach(function (opt) {
+      opt.selected = wanted.has(opt.value);
+    });
+  }
+
+  if (appliesAll) {
+    appliesAll.addEventListener('change', toggleProjects);
+  }
+
+  // Populate the shared modal for either "add" or "edit" when it opens.
+  if (modal && form) {
+    modal.addEventListener('show.bs.modal', function (event) {
+      const trigger = event.relatedTarget;
+      const isEdit = trigger && trigger.classList.contains('edit-field-btn');
+
+      if (isEdit) {
+        const id = trigger.getAttribute('data-id');
+        const isSystem = trigger.getAttribute('data-is-system') === '1';
+        title.textContent = isSystem ? 'Edit System Field' : 'Edit Case Field';
+        form.action = ADD_ACTION + '/' + id + '/modify';
+
+        form.field_name.value = trigger.getAttribute('data-field-name') || '';
+        form.system_name.value = trigger.getAttribute('data-system-name') || '';
+        form.description.value = trigger.getAttribute('data-description') || '';
+        form.field_type.value = trigger.getAttribute('data-field-type') || '';
+        renderDefaultControl(form.field_type.value,
+                             trigger.getAttribute('data-default-value') || '');
+        form.enabled.checked = trigger.getAttribute('data-enabled') === '1';
+        form.is_required.checked = trigger.getAttribute('data-is-required') === '1';
+        appliesAll.checked = trigger.getAttribute('data-applies-all') === '1';
+
+        const projects = (trigger.getAttribute('data-projects') || '').split(',');
+        setProjectSelection(projects);
+
+        applySystemLock(isSystem);
+      } else {
+        title.textContent = 'Add Case Field';
+        form.action = ADD_ACTION;
+        form.reset();
+        renderDefaultControl(form.field_type.value, '');
+        setProjectSelection([]);
+        applySystemLock(false);
+      }
+
+      toggleProjects();
+    });
+  }
+
+  /* ----------------------------------------------------------------
+   * Case field delete confirmation
+   * ---------------------------------------------------------------- */
+  const deleteModal = document.getElementById('confirmDeleteFieldModal');
+  const deleteForm = document.getElementById('cfDeleteForm');
+  const deleteName = document.getElementById('cf-delete-name');
+  const confirmCheckbox = document.getElementById('cfConfirmCheckbox');
+  const confirmButton = document.getElementById('cfConfirmDeleteButton');
+
+  if (deleteModal) {
+    deleteModal.addEventListener('show.bs.modal', function (event) {
+      const trigger = event.relatedTarget;
+      const id = trigger.getAttribute('data-id');
+      deleteName.textContent = trigger.getAttribute('data-field-name') || '';
+      deleteForm.action = '/admin/customisations/case_fields/' + id + '/delete';
+      confirmCheckbox.checked = false;
+      confirmButton.disabled = true;
+    });
+
+    deleteModal.addEventListener('hidden.bs.modal', function () {
+      confirmCheckbox.checked = false;
+      confirmButton.disabled = true;
+    });
+  }
+
+  if (confirmCheckbox) {
+    confirmCheckbox.addEventListener('change', function () {
+      confirmButton.disabled = !this.checked;
+    });
+  }
+
+  if (confirmButton) {
+    confirmButton.addEventListener('click', function () {
+      deleteForm.submit();
+    });
+  }
 })();

--- a/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_customisations.js
@@ -152,7 +152,12 @@
         form.is_required.checked = trigger.getAttribute('data-is-required') === '1';
         appliesAll.checked = trigger.getAttribute('data-applies-all') === '1';
 
-        const projects = (trigger.getAttribute('data-projects') || '').split(',');
+        let projects;
+        try {
+          projects = JSON.parse(trigger.getAttribute('data-projects') || '[]');
+        } catch (e) {
+          projects = [];
+        }
         setProjectSelection(projects);
 
         applySystemLock(isSystem);

--- a/items/services/items_web_portal/templates/instance_admin_customisations.html
+++ b/items/services/items_web_portal/templates/instance_admin_customisations.html
@@ -11,6 +11,13 @@
     <div class="flex-grow-1">
       <h4 class="mb-3">Customisations</h4>
 
+      {% if error_message %}
+      <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ error_message }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+      {% endif %}
+
       <!-- Tab navigation -->
       <ul class="nav nav-tabs customisations-tabs flex-nowrap" id="customisationsTabs" role="tablist">
         <li class="nav-item" role="presentation">
@@ -67,7 +74,86 @@
       <div class="tab-content customisations-tab-content" id="customisationsTabsContent">
         <div class="tab-pane fade show active" id="case-fields" role="tabpanel"
              aria-labelledby="case-fields-tab">
-          <p class="customisations-placeholder">Case Fields contents go here ...</p>
+          <table class="table case-fields-table align-middle">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">System / Custom</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for field in case_fields %}
+              <tr>
+                <td>
+                  <span class="field-name">{{ field.field_name }}</span>
+                  <span class="field-system-name">({{ field.system_name }})</span>
+                </td>
+                <td>{{ field.field_type }}</td>
+                <td>
+                  {% if field.is_system %}System{% else %}Custom{% endif %}
+                  {% if not field.enabled %}<span class="badge bg-secondary ms-1">Inactive</span>{% endif %}
+                </td>
+                <td class="text-end text-nowrap">
+                  {% if not field.is_system %}
+                    {% if not loop.first %}
+                    <form class="d-inline" method="POST"
+                          action="/admin/customisations/case_fields/{{ field.id }}/move">
+                      <input type="hidden" name="direction" value="up">
+                      <button type="submit" class="btn btn-link text-primary p-1"
+                              title="Move up"><i class="bi bi-arrow-up"></i></button>
+                    </form>
+                    {% endif %}
+                    {% if not loop.last %}
+                    <form class="d-inline" method="POST"
+                          action="/admin/customisations/case_fields/{{ field.id }}/move">
+                      <input type="hidden" name="direction" value="down">
+                      <button type="submit" class="btn btn-link text-primary p-1"
+                              title="Move down"><i class="bi bi-arrow-down"></i></button>
+                    </form>
+                    {% endif %}
+                  {% endif %}
+                  <button type="button" class="btn btn-link text-primary p-1 edit-field-btn"
+                          title="Edit"
+                          data-bs-toggle="modal" data-bs-target="#caseFieldModal"
+                          data-id="{{ field.id }}"
+                          data-is-system="{{ '1' if field.is_system else '0' }}"
+                          data-field-name="{{ field.field_name }}"
+                          data-description="{{ field.description }}"
+                          data-system-name="{{ field.system_name }}"
+                          data-field-type="{{ field.field_type }}"
+                          data-enabled="{{ '1' if field.enabled else '0' }}"
+                          data-is-required="{{ '1' if field.is_required else '0' }}"
+                          data-default-value="{{ field.default_value }}"
+                          data-applies-all="{{ '1' if field.applies_to_all_projects else '0' }}"
+                          data-projects="{{ field.linked_projects|join(',') }}">
+                    <i class="bi bi-pencil"></i>
+                  </button>
+                  {% if not field.is_system %}
+                    <button type="button" class="btn btn-link text-danger p-1 delete-field-btn"
+                            title="Delete"
+                            data-bs-toggle="modal" data-bs-target="#confirmDeleteFieldModal"
+                            data-id="{{ field.id }}"
+                            data-field-name="{{ field.field_name }}">
+                      <i class="bi bi-x-circle"></i>
+                    </button>
+                  {% endif %}
+                </td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="4" class="text-muted">No case fields defined yet.</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          <div class="mt-3">
+            <button type="button" class="btn btn-primary add-field-btn"
+                    data-bs-toggle="modal" data-bs-target="#caseFieldModal">
+              + Add Field
+            </button>
+          </div>
         </div>
         <div class="tab-pane fade" id="result-fields" role="tabpanel"
              aria-labelledby="result-fields-tab">
@@ -91,6 +177,108 @@
         </div>
       </div>
     </div>
+
+<!-- Add / Edit case field modal -->
+<div class="modal fade" id="caseFieldModal" tabindex="-1"
+     aria-labelledby="caseFieldModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form id="caseFieldForm" method="POST" action="/admin/customisations/case_fields">
+        <div class="modal-header">
+          <h5 class="modal-title" id="caseFieldModalLabel">Add Case Field</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-info py-2" id="cf-system-note" style="display: none;">
+            This is a system field. Only its active state and project
+            assignment can be changed.
+          </div>
+          <div class="mb-3">
+            <label for="cf-field-name" class="form-label">Name</label>
+            <input type="text" class="form-control" id="cf-field-name" name="field_name" required>
+          </div>
+          <div class="mb-3">
+            <label for="cf-system-name" class="form-label">System name</label>
+            <input type="text" class="form-control" id="cf-system-name" name="system_name"
+                   pattern="[a-z][a-z0-9_]*" required>
+            <div class="form-text">Lowercase letters, digits and underscores; must start with a letter.</div>
+          </div>
+          <div class="mb-3">
+            <label for="cf-description" class="form-label">Description</label>
+            <textarea class="form-control" id="cf-description" name="description" rows="2"></textarea>
+          </div>
+          <div class="mb-3">
+            <label for="cf-field-type" class="form-label">Type</label>
+            <select class="form-select" id="cf-field-type" name="field_type" required>
+              {% for type_name in case_field_types %}
+              <option value="{{ type_name }}">{{ type_name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="mb-3" id="cf-default-wrapper">
+            <label for="cf-default-value" class="form-label">Default value</label>
+            <div id="cf-default-control">
+              <input type="text" class="form-control" id="cf-default-value" name="default_value">
+            </div>
+          </div>
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="cf-enabled" name="enabled" checked>
+            <label class="form-check-label" for="cf-enabled">Active</label>
+          </div>
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" id="cf-is-required" name="is_required">
+            <label class="form-check-label" for="cf-is-required">Required</label>
+          </div>
+          <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="cf-applies-all"
+                   name="applies_to_all_projects" checked>
+            <label class="form-check-label" for="cf-applies-all">Applies to all projects</label>
+          </div>
+          <div class="mb-3" id="cf-projects-wrapper" style="display: none;">
+            <label for="cf-projects" class="form-label">Projects</label>
+            <select class="form-select" id="cf-projects" name="projects" multiple size="5">
+              {% for project_name in projects %}
+              <option value="{{ project_name }}">{{ project_name }}</option>
+              {% endfor %}
+            </select>
+            <div class="form-text">Select one or more projects this field applies to.</div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Delete confirmation modal -->
+<div class="modal fade" id="confirmDeleteFieldModal" tabindex="-1"
+     aria-labelledby="confirmDeleteFieldModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmDeleteFieldModalLabel">Confirmation</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete the case field
+           "<span id="cf-delete-name"></span>"? This action cannot be undone.</p>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="cfConfirmCheckbox">
+          <label class="form-check-label" for="cfConfirmCheckbox">I confirm I want to delete this item.</label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="cfConfirmDeleteButton" disabled>OK</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<form id="cfDeleteForm" method="POST" style="display: none;"></form>
 {% endblock %}
 
 {% block postBody %}{{ super() }}

--- a/items/services/items_web_portal/templates/instance_admin_customisations.html
+++ b/items/services/items_web_portal/templates/instance_admin_customisations.html
@@ -127,7 +127,7 @@
                           data-is-required="{{ '1' if field.is_required else '0' }}"
                           data-default-value="{{ field.default_value }}"
                           data-applies-all="{{ '1' if field.applies_to_all_projects else '0' }}"
-                          data-projects="{{ field.linked_projects|join(',') }}">
+                          data-projects="{{ field.linked_projects_json }}">
                     <i class="bi bi-pencil"></i>
                   </button>
                   {% if not field.is_system %}

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -24,11 +24,18 @@ from test_auth_handlers import (
 from test_route_factories import TestRouteWiring
 from test_admin_stub_handlers import (
     TestAdminOverviewPageHandler,
-    TestAdminCustomisationsPageHandler,
     TestAdminIntegrationsPageHandler,
     TestAdminManageDataPageHandler,
     TestAdminSiteSettingsPageHandler,
     TestAdminUsersAndRolesPageHandler,
+)
+from test_admin_customisations_page_handler import (
+    TestCustomisationsRead,
+    TestCaseFieldAdd,
+    TestCaseFieldModify,
+    TestCaseFieldDelete,
+    TestCaseFieldMove,
+    TestRowToField,
 )
 from test_admin_projects_handlers import (
     TestAdminProjectsPageHandlers,

--- a/unit_tests/web_portal_svc/test_admin_customisations_page_handler.py
+++ b/unit_tests/web_portal_svc/test_admin_customisations_page_handler.py
@@ -1,0 +1,474 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from http import HTTPStatus
+from weaver_framework.microservice.api_response import ApiResponse
+from _test_utils import make_app
+from items.services.items_web_portal.page_handlers.admin.\
+    admin_customisations_page_handler import AdminCustomisationsPageHandler
+
+_LOGGER = MagicMock()
+_AUTH_HEADERS = {"Cookie": "items_token=abc; items_user=bob"}
+_SESSION_VALID = ApiResponse(status_code=HTTPStatus.OK, body={"status": "VALID"})
+
+
+def _config():
+    config = MagicMock()
+    config.apis_gateway_svc = "http://gateway/"
+    return config
+
+
+def _metadata():
+    metadata = MagicMock()
+    metadata.instance_name = "INSTANCE"
+    return metadata
+
+
+def _row(field_id=1, field_name="Priority", description="desc",
+        system_name="priority", field_type="Dropdown", entry_type="user",
+        enabled=1, position=1, is_required=0, default_value="Medium",
+        applies_to_all=1, linked_projects=None):
+    """Build a positional case-field row matching the API column order."""
+    return [field_id, field_name, description, system_name, field_type,
+           entry_type, enabled, position, is_required, default_value,
+           applies_to_all, linked_projects]
+
+
+_FIELDS_LIST_OK = ApiResponse(status_code=HTTPStatus.OK, body=[_row()])
+_PROJECTS_OK = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"projects": [{"id": 1, "name": "Alpha"}, {"id": 2, "name": "Beta"}]})
+
+
+class TestCustomisationsRead(unittest.IsolatedAsyncioTestCase):
+    """Tests for AdminCustomisationsPageHandler.customisations (GET)."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminCustomisationsPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/customisations", methods=["GET"])
+        async def get_route():
+            return await handler.customisations()
+
+        self.client = app.test_client()
+
+    async def _get(self, headers=_AUTH_HEADERS):
+        async with self.client as c:
+            return await c.get("/admin/customisations", headers=headers)
+
+    async def test_not_authenticated_redirects(self):
+        response = await self._get(headers={})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_success_renders_page_with_fields(self):
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+        self.assertIn("Alpha", text)
+
+    async def test_fields_list_failure_renders_internal_error(self):
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertNotIn("Priority", text)
+        # Only the fields-list call happened - never reached the projects call.
+        self.assertEqual(self.mock_rest_client.get.call_count, 1)
+
+    async def test_projects_fetch_non_200_still_renders_page(self):
+        self.mock_rest_client.get.side_effect = [
+            _FIELDS_LIST_OK,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+
+    async def test_projects_fetch_exception_still_renders_page(self):
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, RuntimeError("boom")]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+
+
+class TestCaseFieldAdd(unittest.IsolatedAsyncioTestCase):
+    """Tests for AdminCustomisationsPageHandler.case_field_add (POST)."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        handler = AdminCustomisationsPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/customisations/case_fields", methods=["POST"])
+        async def post_route():
+            return await handler.case_field_add()
+
+        self.client = app.test_client()
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post("/admin/customisations/case_fields",
+                               form=form, headers=_AUTH_HEADERS)
+
+    async def test_applies_to_all_true_omits_projects_key(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        await self._post({
+            "field_name": "New Field", "system_name": "new_field",
+            "field_type": "String", "applies_to_all_projects": "on",
+            "enabled": "on",
+        })
+
+        payload = self.mock_rest_client.post.call_args_list[1].kwargs["json_data"]
+        self.assertNotIn("projects", payload)
+        self.assertTrue(payload["applies_to_all_projects"])
+        self.assertTrue(payload["enabled"])
+        self.assertFalse(payload["is_required"])
+
+    async def test_applies_to_all_false_includes_selected_projects(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        async with self.client as c:
+            response = await c.post(
+                "/admin/customisations/case_fields",
+                form=[
+                    ("field_name", "New Field"),
+                    ("system_name", "new_field"),
+                    ("field_type", "String"),
+                    ("projects", "Alpha"),
+                    ("projects", "Beta"),
+                ],
+                headers=_AUTH_HEADERS)
+        self.assertEqual(response.status_code, 200)
+
+        payload = self.mock_rest_client.post.call_args_list[1].kwargs["json_data"]
+        self.assertFalse(payload["applies_to_all_projects"])
+        self.assertEqual(payload["projects"], ["Alpha", "Beta"])
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post({
+            "field_name": "New Field", "system_name": "new_field",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+
+    async def test_failure_shows_error_banner_from_body(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT,
+                       body={"error": "already exists"})]
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post({
+            "field_name": "New Field", "system_name": "new_field",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("already exists", text)
+
+    async def test_failure_shows_fallback_message_without_error_key(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={})]
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post({
+            "field_name": "New Field", "system_name": "new_field",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("The request could not be completed", text)
+
+
+class TestCaseFieldModify(unittest.IsolatedAsyncioTestCase):
+    """Tests for AdminCustomisationsPageHandler.case_field_modify (POST)."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminCustomisationsPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/customisations/case_fields/<int:field_id>/modify",
+                  methods=["POST"])
+        async def post_route(field_id):
+            return await handler.case_field_modify(field_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, field_id, form):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/customisations/case_fields/{field_id}/modify",
+                form=form, headers=_AUTH_HEADERS)
+
+    async def test_non_system_field_uses_submitted_form_values(self):
+        current_row = _row(field_id=1, field_name="Old Name", entry_type="user")
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.OK, body=current_row),
+            _FIELDS_LIST_OK, _PROJECTS_OK]
+        self.mock_rest_client.put.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+
+        await self._post(1, {
+            "field_name": "New Name", "system_name": "new_name",
+            "field_type": "String", "default_value": "abc"})
+
+        payload = self.mock_rest_client.put.call_args.kwargs["json_data"]
+        self.assertEqual(payload["field_name"], "New Name")
+        self.assertEqual(payload["system_name"], "new_name")
+        self.assertEqual(payload["default_value"], "abc")
+
+    async def test_system_field_locks_immutable_attributes(self):
+        current_row = _row(field_id=2, field_name="Milestone",
+                           system_name="milestone", field_type="String",
+                           description="System field", default_value="",
+                           is_required=1, entry_type="system")
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.OK, body=current_row),
+            _FIELDS_LIST_OK, _PROJECTS_OK]
+        self.mock_rest_client.put.return_value = ApiResponse(
+            status_code=HTTPStatus.BAD_REQUEST,
+            body={"error": "System custom fields cannot be modified"})
+
+        # Attempt to smuggle different values through the form for fields
+        # that should be locked - they must not reach the payload.
+        await self._post(2, {
+            "field_name": "Hacked Name", "system_name": "hacked_name",
+            "field_type": "Integer", "default_value": "999",
+            "enabled": "on"})
+
+        payload = self.mock_rest_client.put.call_args.kwargs["json_data"]
+        self.assertEqual(payload["field_name"], "Milestone")
+        self.assertEqual(payload["system_name"], "milestone")
+        self.assertEqual(payload["field_type"], "String")
+        self.assertEqual(payload["default_value"], "")
+        self.assertTrue(payload["is_required"])
+        self.assertTrue(payload["enabled"])
+
+    async def test_current_fetch_failure_falls_back_to_form_payload(self):
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND),
+            _FIELDS_LIST_OK, _PROJECTS_OK]
+        self.mock_rest_client.put.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={"error": "not found"})
+
+        response = await self._post(999, {
+            "field_name": "New Name", "system_name": "new_name",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+
+        payload = self.mock_rest_client.put.call_args.kwargs["json_data"]
+        self.assertEqual(payload["field_name"], "New Name")
+
+    async def test_success_rerenders_page(self):
+        current_row = _row(field_id=1, entry_type="user")
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.OK, body=current_row),
+            _FIELDS_LIST_OK, _PROJECTS_OK]
+        self.mock_rest_client.put.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+
+        response = await self._post(1, {
+            "field_name": "New Name", "system_name": "new_name",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+
+    async def test_failure_shows_error_banner(self):
+        current_row = _row(field_id=1, entry_type="user")
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.OK, body=current_row),
+            _FIELDS_LIST_OK, _PROJECTS_OK]
+        self.mock_rest_client.put.return_value = ApiResponse(
+            status_code=HTTPStatus.CONFLICT, body={"error": "name taken"})
+
+        response = await self._post(1, {
+            "field_name": "New Name", "system_name": "new_name",
+            "field_type": "String"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("name taken", text)
+
+
+class TestCaseFieldDelete(unittest.IsolatedAsyncioTestCase):
+    """Tests for AdminCustomisationsPageHandler.case_field_delete (POST)."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminCustomisationsPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/customisations/case_fields/<int:field_id>/delete",
+                  methods=["POST"])
+        async def post_route(field_id):
+            return await handler.case_field_delete(field_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, field_id):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/customisations/case_fields/{field_id}/delete",
+                headers=_AUTH_HEADERS)
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post(1)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Priority", text)
+
+    async def test_failure_shows_error_banner(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.BAD_REQUEST,
+            body={"error": "System custom fields cannot be deleted"})
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post(1)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("System custom fields cannot be deleted", text)
+
+
+class TestCaseFieldMove(unittest.IsolatedAsyncioTestCase):
+    """Tests for AdminCustomisationsPageHandler.case_field_move (POST)."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminCustomisationsPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/customisations/case_fields/<int:field_id>/move",
+                  methods=["POST"])
+        async def post_route(field_id):
+            return await handler.case_field_move(field_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, field_id, direction):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/customisations/case_fields/{field_id}/move",
+                form={"direction": direction}, headers=_AUTH_HEADERS)
+
+    async def test_direction_passed_through_to_gateway(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post(1, "up")
+        self.assertEqual(response.status_code, 200)
+
+        payload = self.mock_rest_client.patch.call_args.kwargs["json_data"]
+        self.assertEqual(payload, {"direction": "up"})
+
+    async def test_failure_shows_error_banner(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.BAD_REQUEST,
+            body={"error": "already at the boundary"})
+        self.mock_rest_client.get.side_effect = [_FIELDS_LIST_OK, _PROJECTS_OK]
+
+        response = await self._post(1, "up")
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("already at the boundary", text)
+
+
+class TestRowToField(unittest.TestCase):
+    """Direct unit tests for the _row_to_field mapping helper."""
+
+    def test_maps_scalar_columns(self):
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(field_id=7, field_name="Severity", field_type="Integer",
+                is_required=1, applies_to_all=0))
+        self.assertEqual(field["id"], 7)
+        self.assertEqual(field["field_name"], "Severity")
+        self.assertEqual(field["field_type"], "Integer")
+        self.assertTrue(field["is_required"])
+        self.assertFalse(field["applies_to_all_projects"])
+
+    def test_is_system_true_for_system_entry_type(self):
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(entry_type="system"))
+        self.assertTrue(field["is_system"])
+
+    def test_is_system_false_for_user_entry_type(self):
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(entry_type="user"))
+        self.assertFalse(field["is_system"])
+
+    def test_no_linked_projects_when_none(self):
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(linked_projects=None))
+        self.assertEqual(field["linked_projects"], [])
+        self.assertEqual(field["linked_projects_json"], "[]")
+
+    def test_parses_multiple_linked_projects(self):
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(linked_projects="1:Alpha,2:Beta"))
+        self.assertEqual(field["linked_projects"], ["Alpha", "Beta"])
+        self.assertEqual(json.loads(field["linked_projects_json"]),
+                         ["Alpha", "Beta"])
+
+    def test_linked_projects_json_survives_a_comma_in_a_single_name(self):
+        # A single linked project whose name contains a comma still parses
+        # correctly once split out of the raw CMS string (only ambiguous
+        # once there are multiple linked projects - see the code comment).
+        field = AdminCustomisationsPageHandler._row_to_field(
+            _row(linked_projects="1:Acme Inc"))
+        self.assertEqual(json.loads(field["linked_projects_json"]),
+                         ["Acme Inc"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/web_portal_svc/test_admin_stub_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_stub_handlers.py
@@ -21,8 +21,6 @@ from _test_utils import make_app
 from items.services.items_web_portal.page_handlers.admin.dashboard.\
     admin_overview_page_handler import AdminOverviewPageHandler
 from items.services.items_web_portal.page_handlers.admin.\
-    admin_customisations_page_handler import AdminCustomisationsPageHandler
-from items.services.items_web_portal.page_handlers.admin.\
     admin_integrations_page_handler import AdminIntegrationsPageHandler
 from items.services.items_web_portal.page_handlers.admin.\
     admin_manage_data_page_handler import AdminManageDataPageHandler
@@ -90,8 +88,6 @@ def _make_stub_test(handler_cls, method_name, route_path):
 
 TestAdminOverviewPageHandler = _make_stub_test(
     AdminOverviewPageHandler, "overview", "/admin/")
-TestAdminCustomisationsPageHandler = _make_stub_test(
-    AdminCustomisationsPageHandler, "customisations", "/admin/customisations")
 TestAdminIntegrationsPageHandler = _make_stub_test(
     AdminIntegrationsPageHandler, "integrations", "/admin/integrations")
 TestAdminManageDataPageHandler = _make_stub_test(

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -119,6 +119,35 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
             response = await c.get("/admin/customisations")
         self.assertNotEqual(response.status_code, 405)
 
+    async def test_admin_case_field_add_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/customisations/case_fields",
+                form={"field_name": "Wiring Field",
+                     "system_name": "wiring_field", "field_type": "String"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_case_field_modify_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/customisations/case_fields/1/modify",
+                form={"field_name": "Wiring Field",
+                     "system_name": "wiring_field", "field_type": "String"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_case_field_move_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/customisations/case_fields/1/move",
+                form={"direction": "up"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_case_field_delete_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/customisations/case_fields/1/delete")
+        self.assertNotEqual(response.status_code, 405)
+
     async def test_admin_integrations_route_is_reachable(self):
         async with self.client as c:
             response = await c.get("/admin/integrations")


### PR DESCRIPTION
## What does this PR do?

# Web Portal: testcase custom fields admin page

**Branch:** `portal_tc_custom_pages` → `main`
**Stats:** 4 commits, 9 files changed, +1301/-20

## Summary

Builds out the "Case Fields" tab of the existing Customisations admin page
(previously a placeholder — `<p>Case Fields contents go here ...</p>`) into
a full add/edit/delete/reorder UI for testcase custom fields, backed by the
Gateway's `/web/testcase_custom_fields` routes (which were already
essentially complete from the prior `gateway_tc_custom_fields_routes`
branch).

## Page handler
`items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py`

- `customisations()` — renders the page with the current field list (via
  `GET /web/testcase_custom_fields/`) and the project name selector (via
  `GET /web/projects?value_fields=name`); a projects-fetch failure is
  non-fatal, the selector just renders empty.
- `case_field_add` / `case_field_modify` / `case_field_delete` /
  `case_field_move` — proxy create/update/delete/reorder to the Gateway,
  then re-render the page with an error banner if the Gateway/CMS rejects
  the request.
- System fields: `case_field_modify` fetches the field's current stored
  values first and, if it's a system field, builds the update payload from
  those stored values rather than the submitted form for every attribute
  except `enabled` and project assignment — so the form can't be used to
  smuggle changes to a system field's name/type/etc. **Note:** CMS
  currently rejects *any* update to a system field outright, so this
  particular action doesn't yet succeed end-to-end — a teammate is picking
  that up as a separate CMS PR; see `future.md`. The portal side is already
  built to the intended contract.
- `_row_to_field` maps the API's positional row format into a
  template-friendly dict, including a JSON-encoded `linked_projects_json`
  for the edit modal (see below).

## Template / JS / CSS
- `templates/instance_admin_customisations.html` — case fields table,
  add/edit modal (field type drives a type-appropriate default-value
  control), delete confirmation modal.
- `static/scripts/instance_admin_customisations.js` — modal population for
  add vs. edit, system-field lockdown (disables every control except
  Active/project assignment), delete confirmation gating.
- `static/css/instance_admin_customisations.css` — table/modal styling.

## Fixes found during review

- **Comma-encoding bug:** the edit modal's pre-selected projects were
  written into a `data-projects` HTML attribute as a comma-joined string
  and re-split on `,` in JS — a project name containing a comma would
  corrupt the selection. Switched to JSON-encode/`JSON.parse` for that
  round-trip instead. (The deeper cause — CMS's own
  `GROUP_CONCAT(id:name)` encoding being ambiguous for multi-project
  fields — needs a CMS-side fix; documented in `future.md` and as a code
  comment in `_row_to_field`.)
- **Stale test coverage:** `AdminCustomisationsPageHandler` was still
  wired into the generic stub-page test harness (`test_admin_stub_handlers.py`),
  which mocks `rest_client.post` but never `.get()`. Since the handler now
  makes real `.get()` calls, the "renders page" test was silently
  exercising the internal-error-page fallback instead of the real Case
  Fields page — passing for the wrong reason. Replaced with a dedicated
  test suite (`test_admin_customisations_page_handler.py`) covering every
  handler method, the system-field lock logic, the fetch-failure fallback
  paths, and `_row_to_field` directly.
- Removed a dead `.field-locked` CSS class left over from an earlier
  styling approach, superseded by the JS `disabled` attributes.

## New: `future.md`

Added at the repo root to track the two CMS-side items above (ambiguous
`linked_projects` encoding, system-field partial-update support) so they
don't get lost between PRs. Not yet staged — worth `git add`-ing alongside
this branch's changes.

## Test coverage

**100% line coverage maintained across the entire Web Portal suite**
(885/885 statements, 142 tests) — not just the new/changed files. Pylint:
10.00/10 (needed one `# pylint: disable=too-many-locals` on
`create_admin_page_handlers`, which grew past the threshold with the four
new case-field routes).


## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
