### PR TITLE
[CMS] Removed Edit Restriction for 'System' Custom Testcase Fields

### DIFF
--- a/future.md
+++ b/future.md
@@ -26,29 +26,12 @@ page in the web portal
 does its best with the string it's given and documents the limitation in a
 code comment there.
 
-## CMS: system custom fields can't have partial updates
+## ~~CMS: system custom fields can't have partial updates~~ (resolved)
 
-**Where:** `items_cms.repositories.testcase_custom_fields_repository.
-update_custom_field` rejects *any* update to a field with
-`entry_type == "system"` outright:
-
-```python
-if entry_type == "system":
-    return None
-```
-
-**Context:** the web portal's Case Fields admin page
-(`admin_customisations_page_handler.py`) already has UI and payload-building
-logic (`case_field_modify`, `_build_system_field_payload`) written on the
-assumption that a system field's `enabled` (active) state and project
-assignment *can* be changed, while every other attribute (name, system
-name, type, description, default value, required) stays locked. Right now
-every such request fails with `400 "System custom fields cannot be
-modified"` — the portal UI shows the error correctly, but the feature
-itself can't succeed yet.
-
-**Fix:** a teammate is picking this up as a separate CMS-side PR — allow
-`update_custom_field` to accept changes to `enabled` and project
-assignment for system fields specifically, while continuing to reject
-changes to the immutable attributes. The portal side is already built to
-match this contract and shouldn't need further changes once CMS supports it.
+Fixed on `cms_relax_system_field_edit`: `update_custom_field` now allows
+`enabled` and project assignment to change for system fields, while
+`field_name`/`description`/`system_name`/`field_type`/`is_required`/
+`default_value` are silently overridden with the field's current stored
+values regardless of what's submitted (enforced in the service layer, not
+just trusted from the caller). The web portal's Case Fields admin page was
+already built to this exact contract and needed no changes.

--- a/items/services/items_cms/repositories/testcase_custom_fields_repository.py
+++ b/items/services/items_cms/repositories/testcase_custom_fields_repository.py
@@ -59,23 +59,6 @@ class TestcaseCustomFieldsRepository:
         row = await self._db.run_query(query, (project_id,), fetch_one=True)
         return bool(row)
 
-    async def is_valid_custom_field_id(self, field_id: int) -> bool:
-        """Return True if the custom field ID exists in the database.
-
-        Args:
-            field_id: ID of the custom field to check.
-
-        Returns:
-            True if the field ID exists, False otherwise.
-
-        Raises:
-            SqliteInterfaceException: If the database query fails.
-        """
-        query = (f"SELECT 1 FROM {cms_tables.TC_CUSTOM_FIELDS} WHERE id "
-                 "= ? LIMIT 1")
-        row = await self._db.run_query(query, (field_id,), fetch_one=True)
-        return bool(row)
-
     async def custom_field_name_exists(self,
                                        field_name: str,
                                        exclude_id: Optional[int] = None) -> bool:
@@ -429,6 +412,13 @@ class TestcaseCustomFieldsRepository:
                                   project_ids: list[int]) -> Optional[bool]:
         """Update an existing custom field.
 
+        Applies whatever values it is given - callers (the service layer)
+        are responsible for enforcing which attributes a given field is
+        allowed to change (e.g. system fields may only have their
+        ``enabled`` state and project assignment altered; this method has
+        no awareness of that policy and will happily overwrite any column
+        it is asked to).
+
         If ``field_type`` changes, any type-specific option rows are cleared
         before the new type is applied. Project associations are replaced in
         full: all existing links are deleted then the new set is inserted.
@@ -456,15 +446,13 @@ class TestcaseCustomFieldsRepository:
         # pylint: disable=(too-many-locals
 
         row = await self._db.run_query(
-            f"SELECT field_type_id, entry_type FROM {cms_tables.TC_CUSTOM_FIELDS} "
+            f"SELECT field_type_id FROM {cms_tables.TC_CUSTOM_FIELDS} "
             "WHERE id = ?",
             (field_id,), fetch_one=True)
         if not row:
             return False
 
-        current_type_id, entry_type = int(row[0]), row[1]
-        if entry_type == "system":
-            return None
+        current_type_id = int(row[0])
 
         field_type_info = await self._get_field_type_info(field_type)
         if field_type_info is None:

--- a/items/services/items_cms/services/testcase_custom_fields_service.py
+++ b/items/services/items_cms/services/testcase_custom_fields_service.py
@@ -289,6 +289,33 @@ class TestcaseCustomFieldsService:
                 error_msg=f"System name '{system_name}' already exists",
                 is_conflict=True), empty)
 
+        return await self._validate_project_assignment(
+            applies_to_all_projects, projects)
+
+    async def _validate_project_assignment(
+            self,
+            applies_to_all_projects: bool,
+            projects: Optional[list[str]]
+    ) -> tuple[Optional[TestcaseCustomFieldResult], list[int]]:
+        """Validate and resolve a field's project assignment.
+
+        Shared by add, update, and system-field update - the project
+        assignment is the one thing a system field is allowed to change,
+        so this is factored out from the rest of update validation (name/
+        system name uniqueness), which system fields skip entirely.
+
+        Args:
+            applies_to_all_projects: If True, project list is not checked.
+            projects:                Project names to resolve (when not global).
+
+        Returns:
+            A tuple of ``(error_result, project_ids)``. On success,
+            ``error_result`` is None and ``project_ids`` contains the resolved
+            IDs (empty list when ``applies_to_all_projects`` is True). On
+            failure, ``error_result`` is set and ``project_ids`` is empty.
+        """
+        empty: list[int] = []
+
         if applies_to_all_projects:
             return (None, empty)
 
@@ -334,19 +361,35 @@ class TestcaseCustomFieldsService:
                                    ) -> TestcaseCustomFieldResult:
         """Update an existing testcase custom field.
 
-        Validates uniqueness of ``field_name`` and ``system_name`` against
-        other fields (excluding the field being updated). Replaces project
-        associations when ``applies_to_all_projects`` is False.
+        System fields (``entry_type == "system"``) may only have their
+        ``enabled`` state and project assignment changed - every other
+        attribute (name, system name, type, description, default value,
+        required) is taken from the field's current stored values instead
+        of the request, regardless of what is submitted. This mirrors the
+        contract the web portal's admin page already builds its payloads
+        to, and is enforced here (not just trusted from the caller) since
+        the CMS API may have other callers.
+
+        For non-system fields, validates uniqueness of ``field_name`` and
+        ``system_name`` against other fields (excluding the field being
+        updated). Both kinds replace project associations when
+        ``applies_to_all_projects`` is False.
 
         Args:
             field_id:                ID of the field to update.
             field_name:              New display name (must be unique).
+                                     Ignored for system fields.
             description:             New human-readable description.
-            system_name:             New internal identifier (must be unique).
-            field_type:              New type name; must exist in types table.
+                                     Ignored for system fields.
+            system_name:             New internal identifier (must be
+                                     unique). Ignored for system fields.
+            field_type:              New type name; must exist in types
+                                     table. Ignored for system fields.
             enabled:                 Whether the field should be active.
             is_required:             Whether the field must be filled in.
-            default_value:           New default value (may be empty string).
+                                     Ignored for system fields.
+            default_value:           New default value (may be empty
+                                     string). Ignored for system fields.
             applies_to_all_projects: If True, removes per-project links.
             projects:                Project names to link when not global.
 
@@ -357,20 +400,47 @@ class TestcaseCustomFieldsService:
         """
         # pylint: disable=too-many-arguments, too-many-positional-arguments
         # pylint: disable=too-many-return-statements
+        # pylint: disable=too-many-locals
 
         if not self._state.is_available():
             return TestcaseCustomFieldResult(success=False,
                                              error_msg="Service unavailable",
                                              is_internal=True)
 
-        if not await self._repository.is_valid_custom_field_id(field_id):
+        try:
+            current = await self._repository.get_custom_field(field_id)
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure retrieving custom field %d for update: %s",
+                field_id, ex)
+            self._state.mark_database_failed()
+            return TestcaseCustomFieldResult(success=False,
+                                             error_msg="Internal error in CMS",
+                                             is_internal=True)
+
+        if current is None:
             return TestcaseCustomFieldResult(success=False,
                                              error_msg="Custom field not found",
                                              not_found=True)
 
-        error, project_ids = await self._validate_update_request(
-            field_id, field_name, system_name, applies_to_all_projects,
-            projects)
+        (_, current_field_name, current_description, current_system_name,
+         current_field_type, current_entry_type, _current_enabled,
+         _current_position, current_is_required, current_default_value,
+         _current_applies_all, _current_linked) = current
+
+        if current_entry_type == "system":
+            field_name = current_field_name
+            description = current_description
+            system_name = current_system_name
+            field_type = current_field_type
+            is_required = bool(current_is_required)
+            default_value = current_default_value
+            error, project_ids = await self._validate_project_assignment(
+                applies_to_all_projects, projects)
+        else:
+            error, project_ids = await self._validate_update_request(
+                field_id, field_name, system_name, applies_to_all_projects,
+                projects)
         if error is not None:
             return error
 
@@ -402,7 +472,7 @@ class TestcaseCustomFieldsService:
         if updated is None:
             return TestcaseCustomFieldResult(
                 success=False,
-                error_msg="System custom fields cannot be modified")
+                error_msg=f"Unknown field type '{field_type}'")
 
         return TestcaseCustomFieldResult(success=True)
 
@@ -414,7 +484,7 @@ class TestcaseCustomFieldsService:
             applies_to_all_projects: bool,
             projects: Optional[list[str]]
     ) -> tuple[Optional[TestcaseCustomFieldResult], list[int]]:
-        """Validate a custom field update request before any writes.
+        """Validate a non-system custom field update request before any writes.
 
         Checks name and system name uniqueness against other fields, then
         resolves project names to IDs. All checks are read-only.
@@ -431,9 +501,6 @@ class TestcaseCustomFieldsService:
             ``error_result`` is None. On failure, ``error_result`` is set
             and ``project_ids`` is empty.
         """
-        # pylint: disable=too-many-arguments, too-many-positional-arguments
-        # pylint: disable=too-many-return-statements
-
         empty: list[int] = []
 
         try:
@@ -470,36 +537,8 @@ class TestcaseCustomFieldsService:
                 error_msg=f"System name '{system_name}' already exists",
                 is_conflict=True), empty)
 
-        if applies_to_all_projects:
-            return (None, empty)
-
-        if not projects:
-            return (TestcaseCustomFieldResult(
-                success=False,
-                error_msg="projects is required when applies_to_all_projects "
-                          "is false"), empty)
-
-        if len(projects) != len(set(projects)):
-            return (TestcaseCustomFieldResult(
-                success=False,
-                error_msg="Duplicate project names in the request"), empty)
-
-        try:
-            resolved = await self._repository.resolve_project_names(projects)
-        except SqliteInterfaceException as ex:
-            self._logger.exception(
-                "Database failure resolving project names: %s", ex)
-            self._state.mark_database_failed()
-            return (TestcaseCustomFieldResult(success=False,
-                                              error_msg="Internal error in CMS",
-                                              is_internal=True), empty)
-
-        if resolved is None:
-            return (TestcaseCustomFieldResult(
-                success=False,
-                error_msg="One or more project names are invalid"), empty)
-
-        return (None, resolved)
+        return await self._validate_project_assignment(
+            applies_to_all_projects, projects)
 
     async def delete_custom_field(self, field_id: int) -> TestcaseCustomFieldResult:
         """Permanently remove a custom field and all its dependent data.

--- a/unit_tests/items_cms/test_testcase_custom_field_handlers.py
+++ b/unit_tests/items_cms/test_testcase_custom_field_handlers.py
@@ -370,7 +370,7 @@ class TestUpdateCustomFieldHandler(unittest.IsolatedAsyncioTestCase):
 
     async def test_update_field_bad_request_returns_400(self):
         self.mock_service.update_custom_field.return_value = _bad_request(
-            "System custom fields cannot be modified")
+            "Unknown field type 'NotAType'")
         response = await self._put(1, _VALID_FIELD_BODY)
         self.assertEqual(response.status_code, 400)
 

--- a/unit_tests/items_cms/test_testcase_custom_fields_repository.py
+++ b/unit_tests/items_cms/test_testcase_custom_fields_repository.py
@@ -448,13 +448,19 @@ class TestTestcaseCustomFieldsRepository(unittest.IsolatedAsyncioTestCase):
             True, False, "", True, [])
         self.assertFalse(result)
 
-    async def test_update_returns_none_for_system_field(self):
+    async def test_update_succeeds_for_system_field(self):
+        # The repository has no opinion on which fields a system field is
+        # allowed to change - that policy lives in the service layer. Given
+        # values, it updates them regardless of entry_type.
         field_id = self._insert_field(
             "SysField", "sys_field", entry_type="system")
         result = await self.repo.update_custom_field(
             field_id, "SysField", "desc", "sys_field", "String",
-            True, False, "", True, [])
-        self.assertIsNone(result)
+            False, False, "", True, [])
+        self.assertTrue(result)
+        rows = self._db_query(
+            "SELECT enabled FROM tc_custom_fields WHERE id = ?", (field_id,))
+        self.assertEqual(rows[0][0], 0)
 
     async def test_update_returns_none_for_invalid_type(self):
         field_id = self._insert_field("Priority", "priority")

--- a/unit_tests/items_cms/test_testcase_custom_fields_service.py
+++ b/unit_tests/items_cms/test_testcase_custom_fields_service.py
@@ -25,6 +25,17 @@ from items.services.items_cms.repositories.testcase_custom_fields_repository\
 from items.shared.service_state import ServiceState
 
 
+def _field_row(field_id=1, field_name="Old Name", description="old desc",
+               system_name="old_name", field_type="String",
+               entry_type="user", enabled=True, position=1,
+               is_required=False, default_value="", applies_to_all=True,
+               linked_projects=None):
+    """Build a get_custom_field-shaped row tuple for mocking."""
+    return (field_id, field_name, description, system_name, field_type,
+           entry_type, enabled, position, is_required, default_value,
+           applies_to_all, linked_projects)
+
+
 class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
     """Unit tests for TestcaseCustomFieldsService."""
 
@@ -33,6 +44,9 @@ class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
         self.mock_state = MagicMock(spec=ServiceState)
         self.mock_state.is_available.return_value = True
         self.mock_repo = AsyncMock(spec=TestcaseCustomFieldsRepository)
+        # Most update_custom_field tests exercise the non-system path; the
+        # small number of system-field tests override this explicitly.
+        self.mock_repo.get_custom_field.return_value = _field_row()
         self.service = TestcaseCustomFieldsService(
             self.mock_logger, self.mock_state, self.mock_repo)
 
@@ -396,6 +410,20 @@ class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.success)
         self.assertTrue(result.is_internal)
 
+    async def test_update_field_lookup_db_exception(self):
+        self.mock_repo.get_custom_field.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self._update_field()
+        self.assertFalse(result.success)
+        self.assertTrue(result.is_internal)
+        self.mock_state.mark_database_failed.assert_called_once()
+
+    async def test_update_field_not_found(self):
+        self.mock_repo.get_custom_field.return_value = None
+        result = await self._update_field()
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
+
     async def test_update_field_name_conflict(self):
         self.mock_repo.custom_field_name_exists.return_value = True
         result = await self._update_field()
@@ -441,7 +469,8 @@ class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.success)
         self.assertIn("invalid", result.error_msg)
 
-    async def test_update_field_not_found(self):
+    async def test_update_field_race_deleted_before_write(self):
+        # get_custom_field found it, but it was deleted before the write.
         self.mock_repo.custom_field_name_exists.return_value = False
         self.mock_repo.system_name_exists.return_value = False
         self.mock_repo.update_custom_field.return_value = False
@@ -449,15 +478,15 @@ class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.success)
         self.assertTrue(result.not_found)
 
-    async def test_update_field_system_field_rejected(self):
+    async def test_update_field_unknown_type(self):
         self.mock_repo.custom_field_name_exists.return_value = False
         self.mock_repo.system_name_exists.return_value = False
         self.mock_repo.update_custom_field.return_value = None
-        result = await self._update_field()
+        result = await self._update_field(field_type="NotAType")
         self.assertFalse(result.success)
         self.assertFalse(result.not_found)
         self.assertFalse(result.is_internal)
-        self.assertIn("System", result.error_msg)
+        self.assertIn("NotAType", result.error_msg)
 
     async def test_update_field_db_exception(self):
         self.mock_repo.custom_field_name_exists.return_value = False
@@ -526,6 +555,71 @@ class TestTestcaseCustomFieldsService(unittest.IsolatedAsyncioTestCase):
         self.mock_repo.update_custom_field.assert_called_once()
         call_kwargs = self.mock_repo.update_custom_field.call_args.kwargs
         self.assertEqual(call_kwargs["project_ids"], [3, 4])
+
+    # ------------------------------------------------------------------
+    # update_custom_field - system fields
+    # ------------------------------------------------------------------
+    # System fields may only have `enabled` and project assignment changed;
+    # everything else submitted in the request must be ignored in favour
+    # of the field's current stored values.
+
+    async def test_update_system_field_locks_immutable_attributes(self):
+        self.mock_repo.get_custom_field.return_value = _field_row(
+            field_name="Milestone", description="A milestone",
+            system_name="milestone", field_type="String",
+            entry_type="system", is_required=True, default_value="",
+            applies_to_all=True)
+        self.mock_repo.update_custom_field.return_value = True
+
+        await self._update_field(
+            field_name="Hacked Name", description="hacked",
+            system_name="hacked_name", field_type="Integer",
+            is_required=False, default_value="999", enabled=False)
+
+        call_kwargs = self.mock_repo.update_custom_field.call_args.kwargs
+        self.assertEqual(call_kwargs["field_name"], "Milestone")
+        self.assertEqual(call_kwargs["description"], "A milestone")
+        self.assertEqual(call_kwargs["system_name"], "milestone")
+        self.assertEqual(call_kwargs["field_type"], "String")
+        self.assertTrue(call_kwargs["is_required"])
+        self.assertEqual(call_kwargs["default_value"], "")
+        # enabled is one of the two attributes a system field CAN change.
+        self.assertFalse(call_kwargs["enabled"])
+
+    async def test_update_system_field_skips_uniqueness_checks(self):
+        self.mock_repo.get_custom_field.return_value = _field_row(
+            entry_type="system")
+        self.mock_repo.update_custom_field.return_value = True
+
+        await self._update_field()
+
+        self.mock_repo.custom_field_name_exists.assert_not_called()
+        self.mock_repo.system_name_exists.assert_not_called()
+
+    async def test_update_system_field_still_validates_project_assignment(self):
+        self.mock_repo.get_custom_field.return_value = _field_row(
+            entry_type="system")
+
+        result = await self._update_field(
+            applies_to_all_projects=False, projects=None)
+
+        self.assertFalse(result.success)
+        self.assertIn("projects is required", result.error_msg)
+        self.mock_repo.update_custom_field.assert_not_called()
+
+    async def test_update_system_field_success_changes_projects(self):
+        self.mock_repo.get_custom_field.return_value = _field_row(
+            entry_type="system", applies_to_all=True)
+        self.mock_repo.resolve_project_names.return_value = [9]
+        self.mock_repo.update_custom_field.return_value = True
+
+        result = await self._update_field(
+            applies_to_all_projects=False, projects=["Zulu"])
+
+        self.assertTrue(result.success)
+        call_kwargs = self.mock_repo.update_custom_field.call_args.kwargs
+        self.assertEqual(call_kwargs["project_ids"], [9])
+        self.assertFalse(call_kwargs["applies_to_all_projects"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

# CMS: relax system custom field edit rules

**Branch:** `cms_relax_system_field_edit` → `main`
**Stats:** 5 files changed, +201/-74

## Summary

Closes the gap flagged in `future.md`: system testcase custom fields
previously rejected *any* update outright (`400 "System custom fields
cannot be modified"`), even though the Web Portal's Case Fields admin page
(`portal_tc_custom_pages`) was already built and tested against a looser
contract — that a system field's `enabled` state and project assignment
*should* be changeable, with every other attribute (name, system name,
type, description, default value, required) locked to its current value.
This branch makes CMS actually enforce that contract instead of blocking
the whole request.

## Repository
`items/services/items_cms/repositories/testcase_custom_fields_repository.py`

- `update_custom_field` no longer special-cases `entry_type == "system"` —
  it just applies whatever values it's given, for any field. The repository
  has no opinion on which attributes a given field is allowed to change;
  that policy now lives entirely in the service layer (matches the existing
  read/write split elsewhere in this codebase).
- Removed `is_valid_custom_field_id` — it had exactly one caller
  (`update_custom_field`'s old not-found check), which is now replaced by
  a full `get_custom_field` fetch; left with zero callers, so deleted
  rather than kept around unused.

## Service
`items/services/items_cms/services/testcase_custom_fields_service.py`

- `update_custom_field` now fetches the field's current stored values
  first (`get_custom_field`, not just an existence check). If it's a
  system field, `field_name`/`description`/`system_name`/`field_type`/
  `is_required`/`default_value` are overridden with the stored values
  *regardless of what was submitted* — enforced server-side, not just
  trusted from the caller, since CMS may have other API consumers besides
  the portal. Name/system-name uniqueness checks are skipped entirely for
  system fields (nothing eligible to conflict, since those values aren't
  changing). Project assignment is still validated and resolved for both
  kinds of field via a new shared `_validate_project_assignment` helper,
  extracted from the near-identical tail previously duplicated across
  `_validate_add_request` and `_validate_update_request`.
- The old `updated is None → "System custom fields cannot be modified"`
  branch is gone; `None` from the repository now means what it means
  everywhere else in this file — an unknown `field_type` name — with a
  matching `"Unknown field type '<type>'"` error message.

## Test coverage

- Repository: replaced the "system fields are rejected" test with one
  proving the repository will update a system-entry-type field's row just
  like any other, confirming the policy really did move to the service.
- Service: full rewrite of the `update_custom_field` test section —
  every non-system-field test now configures `get_custom_field` (since the
  method is called unconditionally up front), plus new tests for: system
  fields locking immutable attributes while passing through `enabled`,
  skipping the uniqueness checks, still validating/resolving project
  assignment, and succeeding end-to-end.
- Handler: updated one test's example error message (it was reusing the
  now-removed "System custom fields cannot be modified" string purely as
  a generic 400-body fixture) to something that reflects an actual current
  error.

**100% line coverage maintained across the entire CMS suite** (1904/1904
statements, 465 tests) — not just the changed files. Pylint: 10.00/10.

## Not in this branch

The other `future.md` item — CMS's `linked_projects` encoding being
ambiguous for project names containing a comma — is unrelated to this fix
and untouched here.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
