### PR TITLE
added is_administrator flag

### DIFF
--- a/items/services/items_web_portal/portal_page_handler.py
+++ b/items/services/items_web_portal/portal_page_handler.py
@@ -33,6 +33,11 @@ SCHEMA_SESSION_VALIDATE_RESPONSE = {
         "status": {
             "type": "string",
             "enum": ["VALID", "INVALID"]
+        },
+        # Optional — present once the gateway begins reporting it (step 4 of
+        # the is_administrator rollout in user_roles_design.md §9.4).
+        "is_administrator": {
+            "type": "boolean"
         }
     },
     "required": ["status"],

--- a/unit_tests/web_portal_svc/test_portal_page_handler.py
+++ b/unit_tests/web_portal_svc/test_portal_page_handler.py
@@ -109,6 +109,27 @@ class TestValidateCookies(unittest.IsolatedAsyncioTestCase):
         result = await self._validate()
         self.assertFalse(result)
 
+    async def test_valid_status_with_is_administrator_true_returns_true(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": True})
+        result = await self._validate()
+        self.assertTrue(result)
+
+    async def test_valid_status_with_is_administrator_false_returns_true(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": False})
+        result = await self._validate()
+        self.assertTrue(result)
+
+    async def test_is_administrator_wrong_type_raises(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": "yes"})
+        with self.assertRaises(BaseItemsException):
+            await self._validate()
+
 
 class TestPortalPageHandlerRenderPage(unittest.IsolatedAsyncioTestCase):
 


### PR DESCRIPTION
# Portal: Tolerate is_administrator in session validate response

## Web Portal

- `portal_page_handler.py`: added `is_administrator` as an optional boolean
  property to `SCHEMA_SESSION_VALIDATE_RESPONSE` — the schema still rejects
  unknown fields, but will no longer raise when the gateway begins including
  the flag (step 3 of the `is_administrator` rollout in `user_roles_design.md` §9.4)
- `test_portal_page_handler.py`: added three tests covering the updated schema —
  response with `is_administrator: true` accepted, `is_administrator: false`
  accepted, wrong type rejected

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
