### PR TITLE
[Gateway] Adding support for is_administrator

### DIFF
--- a/items/services/items_gateway/routes/web/sessions/new_session_password_handler.py
+++ b/items/services/items_gateway/routes/web/sessions/new_session_password_handler.py
@@ -128,9 +128,27 @@ class NewSessionPasswordHandler(BaseApiRoute):
             self._logger.info("User '%s' logged in",
                               email_address)
 
+        # Fetch the user profile so we can store is_administrator against
+        # the session and return it on every subsequent validate call.
+        is_administrator: bool = False
+        profile_url: str = (f"{self._configuration.apis_identity_svc}"
+                            f"users/profile")
+        profile_response: ApiResponse = await self._rest_client.post(
+            profile_url, json_data={"email_address": email_address})
+
+        if profile_response.status_code == HTTPStatus.OK and profile_response.body:
+            is_administrator = bool(
+                profile_response.body.get("is_administrator", False))
+        else:
+            self._logger.warning(
+                "Could not retrieve profile for '%s' (status %s); "
+                "is_administrator will default to False",
+                email_address, profile_response.status_code)
+
         await self._sessions.add_session(email_address,
                                          token,
-                                         AccountLogonType.BASIC)
+                                         AccountLogonType.BASIC,
+                                         is_administrator)
 
         return Response(
             json.dumps({"status": 1, "token": token}),

--- a/items/services/items_gateway/routes/web/sessions/validate_session_handler.py
+++ b/items/services/items_gateway/routes/web/sessions/validate_session_handler.py
@@ -73,10 +73,15 @@ class ValidateSessionHandler(BaseApiRoute):
         email_address: str = request_msg.body["email_address"]
         token: str = request_msg.body["token"]
 
-        valid = await self._sessions.is_valid_session(email_address, token)
+        entry = await self._sessions.get_session_entry(email_address, token)
 
-        response_json = {"status": "VALID" if valid else "INVALID"}
-        response_status = HTTPStatus.OK
+        if entry:
+            response_json = {
+                "status": "VALID",
+                "is_administrator": entry.is_administrator
+            }
+        else:
+            response_json = {"status": "INVALID"}
 
-        return Response(json.dumps(response_json), response_status,
+        return Response(json.dumps(response_json), HTTPStatus.OK,
                         content_type="application/json")

--- a/items/services/items_gateway/sessions.py
+++ b/items/services/items_gateway/sessions.py
@@ -29,11 +29,13 @@ class SessionEntry:
         authentication_type (AccountLogonType): The type of authentication used.
         session_expiry (int): The session expiration timestamp (Unix time).
         token (str): The unique token identifying the session.
+        is_administrator (bool): Whether the user has administrator privileges.
     """
     email_address: str = ""
     authentication_type: AccountLogonType = AccountLogonType.BASIC
     session_expiry: int = 0
     token: str = ""
+    is_administrator: bool = False
 
 
 class Sessions:
@@ -52,7 +54,8 @@ class Sessions:
     async def add_session(self,
                           email_address: str,
                           token: str,
-                          auth_type: AccountLogonType) -> None:
+                          auth_type: AccountLogonType,
+                          is_administrator: bool = False) -> None:
         """
         Add an authentication session. Any existing session for the same email
         address is invalidated and replaced.
@@ -61,12 +64,15 @@ class Sessions:
             email_address (str): Email address of the user.
             token (str): Unique token for the session.
             auth_type (AccountLogonType): Type of authentication used.
+            is_administrator (bool): Whether the user has administrator
+                privileges. Defaults to False.
         """
         async with self._lock:
             entry: SessionEntry = SessionEntry()
             entry.email_address = email_address
             entry.token = token
             entry.authentication_type = auth_type
+            entry.is_administrator = is_administrator
 
             # If you logon a second time it will invalid any previous session.
             self._sessions.pop(email_address, None)
@@ -81,6 +87,26 @@ class Sessions:
         """
         async with self._lock:
             self._sessions.pop(email_address, None)
+
+    async def get_session_entry(self,
+                                email_address: str,
+                                token: str) -> SessionEntry | None:
+        """
+        Return the session entry if the token is valid, otherwise None.
+
+        Args:
+            email_address (str): Email address of the user.
+            token (str): Token value to validate.
+
+        Returns:
+            SessionEntry if a session exists and the token matches,
+            None otherwise.
+        """
+        async with self._lock:
+            entry = self._sessions.get(email_address)
+            if entry and entry.token == token:
+                return entry
+        return None
 
     async def is_valid_session(self, email_address: str, token: str) -> bool:
         """

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 1
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build [A2]"
+PRE_RELEASE = "Alpha Build [A3]"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/items/shared/interfaces/cms/health.py
+++ b/items/shared/interfaces/cms/health.py
@@ -61,7 +61,7 @@ SCHEMA_CMS_SVC_HEALTH_RESPONSE: dict = {
         },
         "version": {
             "type": "string",
-            "pattern": "^V\\d+\\.\\d+\\.\\d+(?:-[A-Za-z0-9 #._-]+)?$"
+            "minLength": 1
         }
     },
     "required": ["status", "dependencies", "uptime_seconds", "version"],

--- a/items/shared/interfaces/identity/health.py
+++ b/items/shared/interfaces/identity/health.py
@@ -61,7 +61,7 @@ SCHEMA_IDENTITY_SVC_HEALTH_RESPONSE: dict = {
         },
         "version": {
             "type": "string",
-            "pattern": "^V\\d+\\.\\d+\\.\\d+(?:-[A-Za-z0-9 #._-]+)?$"
+            "minLength": 1
         }
     },
     "required": ["status", "dependencies", "uptime_seconds", "version"],

--- a/unit_tests/items_gateway/test_sessions.py
+++ b/unit_tests/items_gateway/test_sessions.py
@@ -76,6 +76,34 @@ class TestSessions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(entry.authentication_type, AccountLogonType.BASIC)
         self.assertEqual(entry.session_expiry, 0)
         self.assertEqual(entry.token, "")
+        self.assertFalse(entry.is_administrator)
+
+    async def test_add_session_stores_is_administrator(self):
+        await self.sessions.add_session(
+            self.email, self.token, self.auth_type, is_administrator=True)
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertIsNotNone(entry)
+        self.assertTrue(entry.is_administrator)
+
+    async def test_add_session_is_administrator_defaults_false(self):
+        await self.sessions.add_session(self.email, self.token, self.auth_type)
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertFalse(entry.is_administrator)
+
+    async def test_get_session_entry_valid_token_returns_entry(self):
+        await self.sessions.add_session(self.email, self.token, self.auth_type)
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertIsNotNone(entry)
+        self.assertEqual(entry.token, self.token)
+
+    async def test_get_session_entry_wrong_token_returns_none(self):
+        await self.sessions.add_session(self.email, self.token, self.auth_type)
+        entry = await self.sessions.get_session_entry(self.email, "wrong_token")
+        self.assertIsNone(entry)
+
+    async def test_get_session_entry_no_session_returns_none(self):
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertIsNone(entry)
 
 
 if __name__ == "__main__":

--- a/unit_tests/items_gateway/test_sessions_handlers.py
+++ b/unit_tests/items_gateway/test_sessions_handlers.py
@@ -25,6 +25,7 @@ from items.services.items_gateway.routes.web.sessions.refresh_session_handler \
     import RefreshSessionHandler
 from items.services.items_gateway.routes.web.sessions.validate_session_handler \
     import ValidateSessionHandler
+from items.services.items_gateway.sessions import SessionEntry
 
 _LOGGER = MagicMock()
 _VALID_TOKEN = "a" * 32
@@ -82,7 +83,10 @@ class TestNewSessionPasswordHandler(unittest.IsolatedAsyncioTestCase):
 
     async def test_success_new_login(self):
         self.mock_sessions.has_session.return_value = False
-        self.mock_rest_client.post.return_value = ApiResponse(status_code=200)
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200, body={"is_administrator": False})
+        ]
         response = await self._post(
             {"email_address": "a@b.com", "password": "password1"})
         self.assertEqual(response.status_code, 200)
@@ -92,11 +96,39 @@ class TestNewSessionPasswordHandler(unittest.IsolatedAsyncioTestCase):
 
     async def test_success_relogin(self):
         self.mock_sessions.has_session.return_value = True
-        self.mock_rest_client.post.return_value = ApiResponse(status_code=200)
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200, body={"is_administrator": False})
+        ]
         response = await self._post(
             {"email_address": "a@b.com", "password": "password1"})
         self.assertEqual(response.status_code, 200)
         self.mock_sessions.add_session.assert_called_once()
+
+    async def test_success_stores_is_administrator_true(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200, body={"is_administrator": True})
+        ]
+        await self._post({"email_address": "a@b.com", "password": "password1"})
+        args, kwargs = self.mock_sessions.add_session.call_args
+        # is_administrator may be passed positionally (index 3) or as a kwarg
+        is_admin = kwargs.get("is_administrator", args[3] if len(args) > 3 else False)
+        self.assertTrue(is_admin)
+
+    async def test_profile_fetch_failure_defaults_is_administrator_false(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=503)
+        ]
+        response = await self._post(
+            {"email_address": "a@b.com", "password": "password1"})
+        self.assertEqual(response.status_code, 200)
+        args, kwargs = self.mock_sessions.add_session.call_args
+        is_admin = kwargs.get("is_administrator", args[3] if len(args) > 3 else False)
+        self.assertFalse(is_admin)
 
 
 # ------------------------------------------------------------------
@@ -192,21 +224,36 @@ class TestValidateSessionHandler(unittest.IsolatedAsyncioTestCase):
         response = await self._post({"email_address": "a@b.com"})
         self.assertEqual(response.status_code, 400)
 
-    async def test_valid_session_returns_valid(self):
-        self.mock_sessions.is_valid_session.return_value = True
+    async def test_valid_session_returns_valid_with_is_administrator_false(self):
+        entry = SessionEntry(email_address="a@b.com", token=_VALID_TOKEN,
+                             is_administrator=False)
+        self.mock_sessions.get_session_entry.return_value = entry
         response = await self._post(
             {"email_address": "a@b.com", "token": _VALID_TOKEN})
         self.assertEqual(response.status_code, 200)
         data = await response.get_json()
         self.assertEqual(data["status"], "VALID")
+        self.assertFalse(data["is_administrator"])
+
+    async def test_valid_session_returns_is_administrator_true(self):
+        entry = SessionEntry(email_address="a@b.com", token=_VALID_TOKEN,
+                             is_administrator=True)
+        self.mock_sessions.get_session_entry.return_value = entry
+        response = await self._post(
+            {"email_address": "a@b.com", "token": _VALID_TOKEN})
+        self.assertEqual(response.status_code, 200)
+        data = await response.get_json()
+        self.assertEqual(data["status"], "VALID")
+        self.assertTrue(data["is_administrator"])
 
     async def test_invalid_session_returns_invalid(self):
-        self.mock_sessions.is_valid_session.return_value = False
+        self.mock_sessions.get_session_entry.return_value = None
         response = await self._post(
             {"email_address": "a@b.com", "token": _VALID_TOKEN})
         self.assertEqual(response.status_code, 200)
         data = await response.get_json()
         self.assertEqual(data["status"], "INVALID")
+        self.assertNotIn("is_administrator", data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Gateway: Capture and return is_administrator on session validate

## Gateway — Sessions

- `SessionEntry`: added `is_administrator` boolean field (default `False`)
- `Sessions.add_session()`: accepts `is_administrator` parameter and stores it
  against the session entry
- `Sessions.get_session_entry()`: new method — returns the full `SessionEntry`
  if the token is valid, `None` otherwise
- `validate_session_handler.py`: now returns `is_administrator` alongside
  `status` when a session is valid; invalid sessions return only
  `{"status": "INVALID"}` (step 4 of the `is_administrator` rollout in
  `user_roles_design.md` §9.4)
- `new_session_password_handler.py`: after successful authentication, calls
  identity `POST /users/profile` to retrieve `is_administrator` and stores it
  in the session; if the profile fetch fails the login still succeeds with
  `is_administrator` defaulting to `False`

## Shared interfaces — Health response schemas

- Removed the `pattern` constraint from the `version` field in
  `interfaces/identity/health.py` and `interfaces/cms/health.py`; replaced
  with `minLength: 1` — version format is defined in `shared/__init__.py` and
  should not be duplicated in API schemas

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Tests

- `test_sessions.py`: added `is_administrator` to `SessionEntry` defaults
  check; new tests for `add_session` storing the flag and `get_session_entry`
  (valid token, wrong token, no session)
- `test_sessions_handlers.py`: updated login tests to use `side_effect` for
  two REST calls (auth + profile); added tests for `is_administrator: True`
  being stored and profile fetch failure defaulting to `False`; updated
  validate tests to use `get_session_entry` and assert `is_administrator` in
  the response


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
