### PR TITLE
[Portal] Modified decorator to support administrator flag

### DIFF
--- a/items/services/items_web_portal/decorators.py
+++ b/items/services/items_web_portal/decorators.py
@@ -20,6 +20,23 @@ from items.shared.base_items_exception import BaseItemsException
 import items.services.items_web_portal.page_locations as pages
 
 
+async def _check_session(handler) -> tuple[bool, bool]:
+    """Check cookies and validate the session against the gateway.
+
+    Args:
+        handler: A ``SessionAuthMixin`` instance.
+
+    Returns:
+        ``(is_valid, is_administrator)``. Both ``False`` if cookies are absent.
+
+    Raises:
+        BaseItemsException: If the gateway call fails unexpectedly.
+    """
+    if not await handler._has_auth_cookies():  # pylint: disable=protected-access
+        return False, False
+    return await handler._validate_cookies()  # pylint: disable=protected-access
+
+
 def require_session(func):
     """Decorator that enforces an authenticated session on a page handler.
 
@@ -57,10 +74,56 @@ def require_session(func):
         # PortalPageHandler subclasses, so `self` here is always one of
         # those - the protected-member access below is intentional.
         try:
-            if not await self._has_auth_cookies() \
-                    or not await self._validate_cookies():
-                redirect = self._generate_redirect('login')
-                return await make_response(redirect)
+            valid, _ = await _check_session(self)
+            if not valid:
+                return await make_response(self._generate_redirect('login'))
+
+        except BaseItemsException as ex:
+            self._logger.error('Internal Error: %s', ex)
+            return await self._render_page(pages.TEMPLATE_INTERNAL_ERROR_PAGE)
+
+        return await func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def require_administrator(func):
+    """Decorator that enforces an authenticated administrator session.
+
+    Behaves identically to ``require_session`` for unauthenticated requests
+    (redirects to login). Additionally checks the ``is_administrator`` flag
+    returned by the gateway — non-administrators are redirected to the
+    dashboard rather than reaching the admin page body.
+
+    Args:
+        func: The page handler coroutine to protect. Its first positional
+            argument must be ``self`` (a ``SessionAuthMixin`` instance).
+
+    Returns:
+        The wrapped coroutine, which returns one of:
+
+        - A redirect to the login page for unauthenticated users.
+        - A redirect to the dashboard for authenticated non-administrators.
+        - The internal error page if session validation fails unexpectedly.
+        - The wrapped handler's result for authenticated administrators.
+
+    Example:
+        @require_administrator
+        async def admin_overview(self):
+            ...
+    """
+
+    @wraps(func)
+    async def wrapper(self, *args, **kwargs):
+        # pylint: disable=protected-access
+        try:
+            valid, is_administrator = await _check_session(self)
+
+            if not valid:
+                return await make_response(self._generate_redirect('login'))
+
+            if not is_administrator:
+                return await make_response(self._generate_redirect(''))
 
         except BaseItemsException as ex:
             self._logger.error('Internal Error: %s', ex)

--- a/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_customisations_page_handler.py
@@ -22,7 +22,7 @@ from quart import request
 from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -85,7 +85,7 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
     # Read
     # ------------------------------------------------------------------
 
-    @require_session
+    @require_administrator
     async def customisations(self):
         """Render the administration customisations page.
 
@@ -98,7 +98,7 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
     # Write: case fields
     # ------------------------------------------------------------------
 
-    @require_session
+    @require_administrator
     async def case_field_add(self):
         """Create a new case field from the submitted form.
 
@@ -115,7 +115,7 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
 
         return await self._render_after_write(response, "add")
 
-    @require_session
+    @require_administrator
     async def case_field_modify(self, field_id: int):
         """Update an existing case field from the submitted form.
 
@@ -146,7 +146,7 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
 
         return await self._render_after_write(response, "modify")
 
-    @require_session
+    @require_administrator
     async def case_field_delete(self, field_id: int):
         """Delete a case field.
 
@@ -163,7 +163,7 @@ class AdminCustomisationsPageHandler(PortalPageHandler):
 
         return await self._render_after_write(response, "delete")
 
-    @require_session
+    @require_administrator
     async def case_field_move(self, field_id: int):
         """Move a case field up or down in the ordered list.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_integrations_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_integrations_page_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -47,7 +47,7 @@ class AdminIntegrationsPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def integrations(self):
         """Render the administration integrations page.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_manage_data_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_manage_data_page_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -47,7 +47,7 @@ class AdminManageDataPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def manage_data(self):
         """Render the administration manage data page.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_site_settings_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_site_settings_page_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -47,7 +47,7 @@ class AdminSiteSettingsPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def site_settings(self):
         """Render the administration site settings page.
 

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -47,7 +47,7 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def users_and_roles(self):
         """Render the administration users and roles page.
 

--- a/items/services/items_web_portal/page_handlers/admin/dashboard/admin_overview_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/dashboard/admin_overview_page_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
@@ -48,7 +48,7 @@ class AdminOverviewPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def overview(self):
         """Render the administration overview page.
 

--- a/items/services/items_web_portal/page_handlers/admin/projects/admin_add_project_page_handlers.py
+++ b/items/services/items_web_portal/page_handlers/admin/projects/admin_add_project_page_handlers.py
@@ -24,7 +24,7 @@ from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 
 
 class AdminAddProjectPageHandlers(PortalPageHandler):
@@ -50,7 +50,7 @@ class AdminAddProjectPageHandlers(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def add_project_get(self):
         """Render the project creation page.
 
@@ -59,7 +59,7 @@ class AdminAddProjectPageHandlers(PortalPageHandler):
         """
         return await self._render(form_data={})
 
-    @require_session
+    @require_administrator
     async def add_project_post(self):
         """Process a project creation request.
 

--- a/items/services/items_web_portal/page_handlers/admin/projects/admin_modify_project_page_handlers.py
+++ b/items/services/items_web_portal/page_handlers/admin/projects/admin_modify_project_page_handlers.py
@@ -24,7 +24,7 @@ from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 
 
 class AdminModifyProjectPageHandlers(PortalPageHandler):
@@ -50,7 +50,7 @@ class AdminModifyProjectPageHandlers(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def modify_project_get(self, project_id):
         """Render the project modification page.
 
@@ -89,7 +89,7 @@ class AdminModifyProjectPageHandlers(PortalPageHandler):
             active_admin_page="admin_page_site_settings",
             form_data=form_data)
 
-    @require_session
+    @require_administrator
     async def modify_project_post(self, project_id):
         """Process a project modification request.
 

--- a/items/services/items_web_portal/page_handlers/admin/projects/admin_projects_page_handlers.py
+++ b/items/services/items_web_portal/page_handlers/admin/projects/admin_projects_page_handlers.py
@@ -24,7 +24,7 @@ from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import require_administrator
 
 
 class AdminProjectsPageHandlers(PortalPageHandler):
@@ -50,7 +50,7 @@ class AdminProjectsPageHandlers(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
-    @require_session
+    @require_administrator
     async def projects_post(self):
         """Delete a project.
 
@@ -77,7 +77,7 @@ class AdminProjectsPageHandlers(PortalPageHandler):
 
         return await self.projects_read()
 
-    @require_session
+    @require_administrator
     async def projects_read(self):
         """Render the administration projects page.
 

--- a/items/services/items_web_portal/portal_page_handler.py
+++ b/items/services/items_web_portal/portal_page_handler.py
@@ -94,7 +94,7 @@ class SessionAuthMixin:
         retrieved_username = request.cookies.get(self.COOKIE_USER)
         return retrieved_token is not None and retrieved_username is not None
 
-    async def _validate_cookies(self) -> bool:
+    async def _validate_cookies(self) -> tuple[bool, bool]:
         """Validates the current authentication session.
 
         The stored authentication cookies are submitted to the gateway service
@@ -138,7 +138,12 @@ class SessionAuthMixin:
                 "Schema for gateway svc session validate response "
                 "invalid!") from ex
 
-        return response.body["status"] == "VALID"
+        is_valid = response.body["status"] == "VALID"
+        is_administrator = (
+            bool(response.body.get("is_administrator", False))
+            if is_valid else False
+        )
+        return is_valid, is_administrator
 
 
 class PortalPageHandler(SessionAuthMixin, BaseApiRoute):

--- a/unit_tests/web_portal_svc/test_admin_customisations_page_handler.py
+++ b/unit_tests/web_portal_svc/test_admin_customisations_page_handler.py
@@ -24,7 +24,9 @@ from items.services.items_web_portal.page_handlers.admin.\
 
 _LOGGER = MagicMock()
 _AUTH_HEADERS = {"Cookie": "items_token=abc; items_user=bob"}
-_SESSION_VALID = ApiResponse(status_code=HTTPStatus.OK, body={"status": "VALID"})
+_SESSION_VALID = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"status": "VALID", "is_administrator": True})
 
 
 def _config():

--- a/unit_tests/web_portal_svc/test_admin_projects_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_projects_handlers.py
@@ -29,7 +29,9 @@ _LOGGER = MagicMock()
 
 _VALID_ADD_FORM = {"project_name": "Project X", "announcement": ""}
 _AUTH_HEADERS = {"Cookie": "items_token=abc; items_user=bob"}
-_SESSION_VALID = ApiResponse(status_code=HTTPStatus.OK, body={"status": "VALID"})
+_SESSION_VALID = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"status": "VALID", "is_administrator": True})
 
 
 def _config():
@@ -48,7 +50,7 @@ def _metadata():
 # AdminProjectsPageHandlers
 # ------------------------------------------------------------------
 # projects_read/projects_post use .get()/.delete() for their own logic, so
-# session validation (.post()) never collides with them - a single blanket
+# admin validation (.post()) never collides with them - a single blanket
 # post.return_value covers every test in this class.
 
 class TestAdminProjectsPageHandlers(unittest.IsolatedAsyncioTestCase):
@@ -110,10 +112,10 @@ class TestAdminProjectsPageHandlers(unittest.IsolatedAsyncioTestCase):
 # ------------------------------------------------------------------
 # AdminAddProjectPageHandlers
 # ------------------------------------------------------------------
-# add_project_get/add_project_post both go through @require_session (which
-# itself calls .post() to validate the session) AND add_project_post makes
-# its own .post() call to submit to CMS - so the session-validation call and
-# the CMS call share the same mocked method. side_effect lists the session
+# add_project_get/add_project_post both go through @require_administrator
+# (which calls .post() to validate the session) AND add_project_post makes
+# its own .post() call to submit to CMS - so the admin-validation call and
+# the CMS call share the same mocked method. side_effect lists the admin
 # validation response first, then whatever the test wants the CMS call to
 # return.
 
@@ -219,8 +221,8 @@ class TestAdminAddProjectPageHandlers(unittest.IsolatedAsyncioTestCase):
 # AdminModifyProjectPageHandlers
 # ------------------------------------------------------------------
 # Both modify_project_get and modify_project_post are wrapped in
-# @require_session, which validates the session via .post() - separate from
-# .get()/.patch() used by the handlers' own logic, so no side_effect
+# @require_administrator, which validates the session via .post() - separate
+# from .get()/.patch() used by the handlers' own logic, so no side_effect
 # ordering is needed, just a blanket post.return_value plus auth cookies.
 
 class TestAdminModifyProjectPageHandlers(unittest.IsolatedAsyncioTestCase):

--- a/unit_tests/web_portal_svc/test_admin_stub_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_stub_handlers.py
@@ -57,7 +57,8 @@ def _make_stub_test(handler_cls, method_name, route_path):
         async def asyncSetUp(self):
             self.rest_client = AsyncMock()
             self.rest_client.post.return_value = ApiResponse(
-                status_code=HTTPStatus.OK, body={"status": "VALID"})
+                status_code=HTTPStatus.OK,
+                body={"status": "VALID", "is_administrator": True})
             handler = handler_cls(_LOGGER, _config(), self.rest_client,
                                   _metadata())
 
@@ -82,6 +83,23 @@ def _make_stub_test(handler_cls, method_name, route_path):
             self.assertEqual(response.status_code, 200)
             text = await response.get_data(as_text=True)
             self.assertIn("Refresh", text)
+
+        async def test_redirects_when_not_administrator(self):
+            self.rest_client.post.return_value = ApiResponse(
+                status_code=HTTPStatus.OK,
+                body={"status": "VALID", "is_administrator": False})
+            async with self.client as c:
+                response = await c.get(route_path, headers=_AUTH_HEADERS)
+            self.assertEqual(response.status_code, 200)
+            text = await response.get_data(as_text=True)
+            self.assertIn("Refresh", text)
+
+        async def test_internal_error_when_gateway_unavailable(self):
+            self.rest_client.post.return_value = ApiResponse(
+                status_code=HTTPStatus.SERVICE_UNAVAILABLE)
+            async with self.client as c:
+                response = await c.get(route_path, headers=_AUTH_HEADERS)
+            self.assertEqual(response.status_code, 200)
 
     return _Test
 

--- a/unit_tests/web_portal_svc/test_decorators.py
+++ b/unit_tests/web_portal_svc/test_decorators.py
@@ -17,15 +17,17 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 from quart import Quart
 from items.shared.base_items_exception import BaseItemsException
-from items.services.items_web_portal.decorators import require_session
+from items.services.items_web_portal.decorators import (
+    require_session, require_administrator)
 
 
 class _FakeHandler:
     """Minimal stand-in for a SessionAuthMixin/PortalPageHandler subclass."""
 
-    def __init__(self):
+    def __init__(self, is_valid=True, is_administrator=False):
         self._has_auth_cookies = AsyncMock(return_value=True)
-        self._validate_cookies = AsyncMock(return_value=True)
+        self._validate_cookies = AsyncMock(
+            return_value=(is_valid, is_administrator))
         self._generate_redirect = MagicMock(return_value="<redirect/>")
         self._logger = MagicMock()
         self._render_page = AsyncMock(return_value="internal-error-page")
@@ -33,6 +35,10 @@ class _FakeHandler:
     @require_session
     async def protected_method(self, *args, **kwargs):
         return ("handler-result", args, kwargs)
+
+    @require_administrator
+    async def admin_method(self, *args, **kwargs):
+        return ("admin-result", args, kwargs)
 
 
 class TestRequireSession(unittest.IsolatedAsyncioTestCase):
@@ -57,8 +63,7 @@ class TestRequireSession(unittest.IsolatedAsyncioTestCase):
         handler._generate_redirect.assert_called_once_with('login')
 
     async def test_redirects_when_cookies_invalid(self):
-        handler = _FakeHandler()
-        handler._validate_cookies.return_value = False
+        handler = _FakeHandler(is_valid=False)
         app = Quart(__name__)
         async with app.app_context():
             await handler.protected_method()
@@ -68,6 +73,48 @@ class TestRequireSession(unittest.IsolatedAsyncioTestCase):
         handler = _FakeHandler()
         handler._validate_cookies.side_effect = BaseItemsException("boom")
         result = await handler.protected_method()
+        self.assertEqual(result, "internal-error-page")
+        handler._logger.error.assert_called_once()
+
+
+class TestRequireAdministrator(unittest.IsolatedAsyncioTestCase):
+
+    async def test_calls_wrapped_handler_when_administrator(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        result = await handler.admin_method()
+        self.assertEqual(result, ("admin-result", (), {}))
+
+    async def test_passes_through_args_and_kwargs(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        result = await handler.admin_method(1, b=2)
+        self.assertEqual(result, ("admin-result", (1,), {"b": 2}))
+
+    async def test_redirects_to_login_when_no_auth_cookies(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        handler._has_auth_cookies.return_value = False
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.admin_method()
+        handler._generate_redirect.assert_called_once_with('login')
+
+    async def test_redirects_to_login_when_session_invalid(self):
+        handler = _FakeHandler(is_valid=False, is_administrator=False)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.admin_method()
+        handler._generate_redirect.assert_called_once_with('login')
+
+    async def test_redirects_to_dashboard_when_not_administrator(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=False)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.admin_method()
+        handler._generate_redirect.assert_called_once_with('')
+
+    async def test_internal_error_page_on_exception(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        handler._validate_cookies.side_effect = BaseItemsException("boom")
+        result = await handler.admin_method()
         self.assertEqual(result, "internal-error-page")
         handler._logger.error.assert_called_once()
 

--- a/unit_tests/web_portal_svc/test_portal_page_handler.py
+++ b/unit_tests/web_portal_svc/test_portal_page_handler.py
@@ -97,31 +97,35 @@ class TestValidateCookies(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(BaseItemsException):
             await self._validate()
 
-    async def test_valid_status_returns_true(self):
+    async def test_valid_status_returns_true_and_is_administrator_false(self):
         self.mock_rest_client.post.return_value = ApiResponse(
             status_code=HTTPStatus.OK, body={"status": "VALID"})
-        result = await self._validate()
-        self.assertTrue(result)
+        is_valid, is_administrator = await self._validate()
+        self.assertTrue(is_valid)
+        self.assertFalse(is_administrator)
 
-    async def test_invalid_status_returns_false(self):
+    async def test_invalid_status_returns_false_and_is_administrator_false(self):
         self.mock_rest_client.post.return_value = ApiResponse(
             status_code=HTTPStatus.OK, body={"status": "INVALID"})
-        result = await self._validate()
-        self.assertFalse(result)
+        is_valid, is_administrator = await self._validate()
+        self.assertFalse(is_valid)
+        self.assertFalse(is_administrator)
 
-    async def test_valid_status_with_is_administrator_true_returns_true(self):
+    async def test_valid_status_with_is_administrator_true(self):
         self.mock_rest_client.post.return_value = ApiResponse(
             status_code=HTTPStatus.OK,
             body={"status": "VALID", "is_administrator": True})
-        result = await self._validate()
-        self.assertTrue(result)
+        is_valid, is_administrator = await self._validate()
+        self.assertTrue(is_valid)
+        self.assertTrue(is_administrator)
 
-    async def test_valid_status_with_is_administrator_false_returns_true(self):
+    async def test_valid_status_with_is_administrator_false(self):
         self.mock_rest_client.post.return_value = ApiResponse(
             status_code=HTTPStatus.OK,
             body={"status": "VALID", "is_administrator": False})
-        result = await self._validate()
-        self.assertTrue(result)
+        is_valid, is_administrator = await self._validate()
+        self.assertTrue(is_valid)
+        self.assertFalse(is_administrator)
 
     async def test_is_administrator_wrong_type_raises(self):
         self.mock_rest_client.post.return_value = ApiResponse(


### PR DESCRIPTION
# Changes — portal_admin_require_administrator

## Summary

Step 5 of the `is_administrator` rollout (§9.4 of `user_roles_design.md`).
The web portal now enforces administrator access on all `/admin/` routes.

---

## New — `decorators.py`

Added `require_administrator` decorator and `_check_session` private helper.

`_check_session(handler)` consolidates the cookie presence check and gateway
validation call used by both decorators, returning `(is_valid, is_administrator)`
as a tuple. Both `require_session` and `require_administrator` delegate to it,
eliminating the duplication that would otherwise exist between the two guards.

`require_administrator` behaves like `require_session` for unauthenticated
requests (redirects to login), and additionally checks the `is_administrator`
flag — non-administrators are redirected to the dashboard rather than reaching
the protected handler body.

`require_session` was updated to unpack the tuple returned by `_check_session`,
discarding the `is_administrator` value it does not need.

## Changed — admin page handlers (9 files)

All admin page handlers swapped `@require_session` for `@require_administrator`:

- `page_handlers/admin/dashboard/admin_overview_page_handler.py`
- `page_handlers/admin/admin_customisations_page_handler.py`
- `page_handlers/admin/admin_integrations_page_handler.py`
- `page_handlers/admin/admin_manage_data_page_handler.py`
- `page_handlers/admin/admin_site_settings_page_handler.py`
- `page_handlers/admin/admin_users_and_roles_page_handler.py`
- `page_handlers/admin/projects/admin_projects_page_handlers.py`
- `page_handlers/admin/projects/admin_add_project_page_handlers.py`
- `page_handlers/admin/projects/admin_modify_project_page_handlers.py`

---

## Tests

### `test_decorators.py`

- `_FakeHandler` updated: accepts `is_valid` and `is_administrator` params;
  `_validate_cookies` mock returns a `(bool, bool)` tuple.
- `TestRequireSession` updated to unpack the tuple result.
- `TestRequireAdministrator` added — 6 tests:
  - Valid administrator reaches the handler.
  - Args and kwargs are passed through.
  - No auth cookies → redirect to login.
  - Invalid session → redirect to login.
  - Valid but non-administrator → redirect to dashboard.
  - Gateway exception → internal error page.

### `test_portal_page_handler.py`

- `_validate_cookies` tests updated to unpack the `(is_valid, is_administrator)`
  tuple and assert both values.

### `test_admin_stub_handlers.py`

- Session-valid response updated to include `"is_administrator": True`.
- `_make_stub_test` comment updated to reference `@require_administrator`.
- Two new tests added to every stub handler class:
  - `test_redirects_when_not_administrator` — valid session, non-admin flag →
    redirect response.
  - `test_internal_error_when_gateway_unavailable` — gateway 503 → internal
    error page.

### `test_admin_projects_handlers.py`

- `_SESSION_VALID` updated to include `"is_administrator": True`.
- Comments updated to reference `@require_administrator`.

### `test_admin_customisations_page_handler.py`

- `_SESSION_VALID` updated to include `"is_administrator": True`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
