### PR TITLE
[Web Portal] Fixed portal support sessions and is_administrator

### DIFF
--- a/items/services/items_web_portal/decorators.py
+++ b/items/services/items_web_portal/decorators.py
@@ -15,13 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from functools import wraps
-from quart import make_response
+from quart import g, make_response
 from items.shared.base_items_exception import BaseItemsException
 import items.services.items_web_portal.page_locations as pages
 
 
 async def _check_session(handler) -> tuple[bool, bool]:
     """Check cookies and validate the session against the gateway.
+
+    As a side effect, sets ``g.is_administrator`` on the current request
+    context so that templates can conditionally render admin-only UI (e.g.
+    the Administration link in the navbar) without each handler needing to
+    pass the flag explicitly.
 
     Args:
         handler: A ``SessionAuthMixin`` instance.
@@ -33,8 +38,11 @@ async def _check_session(handler) -> tuple[bool, bool]:
         BaseItemsException: If the gateway call fails unexpectedly.
     """
     if not await handler._has_auth_cookies():  # pylint: disable=protected-access
+        g.is_administrator = False
         return False, False
-    return await handler._validate_cookies()  # pylint: disable=protected-access
+    is_valid, is_administrator = await handler._validate_cookies()  # pylint: disable=protected-access
+    g.is_administrator = is_administrator
+    return is_valid, is_administrator
 
 
 def require_session(func):

--- a/items/services/items_web_portal/page_handlers/auth/index_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/auth/index_page_handler.py
@@ -16,15 +16,14 @@ limitations under the License.
 """
 from http import HTTPStatus
 import logging
-from quart import make_response
 from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.rest_client import RestClient
-from items.shared.base_items_exception import BaseItemsException
 from items.services.items_web_portal.configuration import Configuration
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
+from items.services.items_web_portal.decorators import require_session
 
 
 class IndexPageHandler(PortalPageHandler):
@@ -51,6 +50,7 @@ class IndexPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    @require_session
     async def index(self):
         """Handles a request for the portal dashboard.
 
@@ -68,15 +68,6 @@ class IndexPageHandler(PortalPageHandler):
             - The dashboard page populated with project information.
             - The internal error page if an error occurs.
         """
-        try:
-            if not await self._has_auth_cookies() or not await self._validate_cookies():
-                redirect = self._generate_redirect('login')
-                return await make_response(redirect)
-
-        except BaseItemsException as ex:
-            self._logger.error('Internal Error: %s', ex)
-            return await self._render_page(pages.TEMPLATE_INTERNAL_ERROR_PAGE)
-
         base_url: str = self._config.apis_gateway_svc
         url = f"{base_url}web/projects?value_fields=name&" + \
               "count_fields=no_of_test_runs,no_of_milestones"

--- a/items/services/items_web_portal/templates/dashboard_template.html
+++ b/items/services/items_web_portal/templates/dashboard_template.html
@@ -60,13 +60,15 @@
                 </li>
             </ul>
 
-            <!-- Right-justified item: Administration -->
+            <!-- Right-justified item: Administration (admins only) -->
+            {% if g.is_administrator %}
             <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
                 <li class="nav-item">
                     <a class="nav-link {% if active_page == 'administration' %}current{% endif %}"
                        href="/admin/">Administration</a>
                 </li>
             </ul>
+            {% endif %}
         </div>
     </nav>
 {% endblock %}

--- a/unit_tests/web_portal_svc/test_decorators.py
+++ b/unit_tests/web_portal_svc/test_decorators.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 import unittest
 from unittest.mock import AsyncMock, MagicMock
-from quart import Quart
+from quart import Quart, g
 from items.shared.base_items_exception import BaseItemsException
 from items.services.items_web_portal.decorators import (
     require_session, require_administrator)
@@ -45,13 +45,39 @@ class TestRequireSession(unittest.IsolatedAsyncioTestCase):
 
     async def test_calls_wrapped_handler_when_session_valid(self):
         handler = _FakeHandler()
-        result = await handler.protected_method()
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.protected_method()
         self.assertEqual(result, ("handler-result", (), {}))
 
     async def test_passes_through_args_and_kwargs(self):
         handler = _FakeHandler()
-        result = await handler.protected_method(1, b=2)
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.protected_method(1, b=2)
         self.assertEqual(result, ("handler-result", (1,), {"b": 2}))
+
+    async def test_sets_g_is_administrator_true_when_valid_admin(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.protected_method()
+            self.assertTrue(g.is_administrator)
+
+    async def test_sets_g_is_administrator_false_when_not_admin(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=False)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.protected_method()
+            self.assertFalse(g.is_administrator)
+
+    async def test_sets_g_is_administrator_false_when_no_cookies(self):
+        handler = _FakeHandler()
+        handler._has_auth_cookies.return_value = False
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.protected_method()
+            self.assertFalse(g.is_administrator)
 
     async def test_redirects_when_no_auth_cookies(self):
         handler = _FakeHandler()
@@ -72,7 +98,9 @@ class TestRequireSession(unittest.IsolatedAsyncioTestCase):
     async def test_internal_error_page_on_exception(self):
         handler = _FakeHandler()
         handler._validate_cookies.side_effect = BaseItemsException("boom")
-        result = await handler.protected_method()
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.protected_method()
         self.assertEqual(result, "internal-error-page")
         handler._logger.error.assert_called_once()
 
@@ -81,13 +109,24 @@ class TestRequireAdministrator(unittest.IsolatedAsyncioTestCase):
 
     async def test_calls_wrapped_handler_when_administrator(self):
         handler = _FakeHandler(is_valid=True, is_administrator=True)
-        result = await handler.admin_method()
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.admin_method()
         self.assertEqual(result, ("admin-result", (), {}))
 
     async def test_passes_through_args_and_kwargs(self):
         handler = _FakeHandler(is_valid=True, is_administrator=True)
-        result = await handler.admin_method(1, b=2)
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.admin_method(1, b=2)
         self.assertEqual(result, ("admin-result", (1,), {"b": 2}))
+
+    async def test_sets_g_is_administrator_true_for_admin(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=True)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.admin_method()
+            self.assertTrue(g.is_administrator)
 
     async def test_redirects_to_login_when_no_auth_cookies(self):
         handler = _FakeHandler(is_valid=True, is_administrator=True)
@@ -111,10 +150,19 @@ class TestRequireAdministrator(unittest.IsolatedAsyncioTestCase):
             await handler.admin_method()
         handler._generate_redirect.assert_called_once_with('')
 
+    async def test_sets_g_is_administrator_false_for_non_admin(self):
+        handler = _FakeHandler(is_valid=True, is_administrator=False)
+        app = Quart(__name__)
+        async with app.app_context():
+            await handler.admin_method()
+            self.assertFalse(g.is_administrator)
+
     async def test_internal_error_page_on_exception(self):
         handler = _FakeHandler(is_valid=True, is_administrator=True)
         handler._validate_cookies.side_effect = BaseItemsException("boom")
-        result = await handler.admin_method()
+        app = Quart(__name__)
+        async with app.app_context():
+            result = await handler.admin_method()
         self.assertEqual(result, "internal-error-page")
         handler._logger.error.assert_called_once()
 


### PR DESCRIPTION
# Changes — portal_navbar_admin_visibility

## Summary

Step 6 of the `is_administrator` rollout (§9.4 of `user_roles_design.md`).
The Administration link in the navbar is now hidden for non-administrator users.

---

## Changed — `decorators.py`

`_check_session` now sets `g.is_administrator` on the current request context
as a side effect, in addition to returning the flag as part of its tuple. This
makes the flag available to Jinja2 templates without each individual handler
needing to pass it explicitly.

`g.is_administrator` is set to `False` when cookies are absent, and to the
value returned by `_validate_cookies` otherwise (which is already `False` for
invalid sessions).

## Changed — `dashboard_template.html`

The Administration nav link is now wrapped in `{% if g.is_administrator %}`.
Non-administrators see the dashboard navbar without the Administration entry;
administrators see it as before.

## Fixed — `index_page_handler.py`

The dashboard handler had an inline session check that called
`_validate_cookies()` directly and evaluated the result as a boolean.
`_validate_cookies` returns a `tuple[bool, bool]` — a non-empty tuple is always
truthy in Python, so the check never detected an invalid session. The handler
also never called `_check_session`, so `g.is_administrator` was never set and
the Administration link was hidden even for administrators.

Replaced the inline check with `@require_session`, consistent with all other
protected handlers. This corrects both problems: invalid sessions are properly
redirected to login, and `g.is_administrator` is set before the template renders.

---

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Tests

### `test_decorators.py`

All tests in `TestRequireSession` and `TestRequireAdministrator` now run inside
a Quart `app_context` (required now that `_check_session` writes to `g`).

Three new tests added to `TestRequireSession`:

- `test_sets_g_is_administrator_true_when_valid_admin` — valid admin session
  sets `g.is_administrator = True`.
- `test_sets_g_is_administrator_false_when_not_admin` — valid non-admin session
  sets `g.is_administrator = False`.
- `test_sets_g_is_administrator_false_when_no_cookies` — absent cookies set
  `g.is_administrator = False`.

Two new tests added to `TestRequireAdministrator`:

- `test_sets_g_is_administrator_true_for_admin` — valid admin session sets
  `g.is_administrator = True`.
- `test_sets_g_is_administrator_false_for_non_admin` — valid non-admin session
  sets `g.is_administrator = False`.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
