### PR TITLE
[Portal] Admin User Management Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ ITEMS is a web-based test management tool written in Python that can be used by 
 
 ## News  
 
-### 3rd July 2026
-Rework of the entire service is in progress. You cannot run ITEMS from
-the main branch.
+### 3rd August 2026
+The current Alpha release is [V0.1.0](https://github.com/SwatKat1977/items/releases/tag/V0.1.0)
+
+IMPORTANT: The current Alpha is not production ready/safe and is currently an early preview.
 
 ### Previous News
 - Important Information: The version is currently at V0.0.0 [MVP] on the main branch

--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -31,6 +31,8 @@ from items.services.items_web_portal.page_handlers.admin.dashboard import \
     create_admin_dashboard_page_handler
 from items.services.items_web_portal.page_handlers.admin.projects import \
     create_admin_projects_page_handlers
+from items.services.items_web_portal.page_handlers.admin.users import \
+    create_admin_users_page_handlers
 
 
 def create_admin_page_handlers(injections: PageHandlerInjections,
@@ -175,5 +177,10 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
 
     # Register testcases pages
     routes.register_blueprint(create_admin_projects_page_handlers(injections))
+
+    # Register user management pages under /users_roles/
+    routes.register_blueprint(
+        create_admin_users_page_handlers(injections),
+        url_prefix='/users_roles')
 
     return routes

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -27,8 +27,9 @@ from items.services.items_web_portal.portal_page_handler import (
 class AdminUsersAndRolesPageHandler(PortalPageHandler):
     """Handles requests for the administration users and roles page.
 
-    This handler renders the administration page used to manage user
-    accounts and role assignments.
+    This handler fetches the current list of users from the gateway and
+    renders the administration page used to manage user accounts and role
+    assignments.
     """
 
     def __init__(self,
@@ -51,11 +52,30 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
     async def users_and_roles(self):
         """Render the administration users and roles page.
 
+        Fetches all users from the gateway and passes them to the template.
+        On gateway failure the page is rendered with an empty user list and
+        an error message.
+
         Returns:
             The rendered administration users and roles page response.
         """
+        url = f"{self._config.apis_gateway_svc}web/users"
+        response = await self._rest_client.get(url)
+
+        if response.status_code == 200:
+            users = response.body.get("users", [])
+            error_msg_str = None
+        else:
+            self._logger.error(
+                "Failed to fetch users from gateway: status=%s",
+                response.status_code)
+            users = []
+            error_msg_str = "Could not load users — please try again."
+
         return await self._render_page(
             pages.PAGE_INSTANCE_ADMIN_USERS_AND_ROLES,
             instance_name=self._metadata_settings.instance_name,
             active_page="administration",
-            active_admin_page="admin_page_users_roles")
+            active_admin_page="admin_page_users_roles",
+            users=users,
+            error_msg_str=error_msg_str)

--- a/items/services/items_web_portal/page_handlers/admin/users/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/__init__.py
@@ -19,12 +19,14 @@ from items.services.items_web_portal.page_handler_injections import (
     PageHandlerInjections)
 from items.services.items_web_portal.page_handlers.admin.users.admin_add_user_page_handler import (
     AdminAddUserPageHandler)
+from items.services.items_web_portal.page_handlers.admin.users.admin_modify_user_page_handler import (
+    AdminModifyUserPageHandler)
 
 
 def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Blueprint:
     """Create the admin user management route handlers.
 
-    Registers routes for listing users and creating new users under the
+    Registers routes for listing, creating, and editing users under the
     /users_roles prefix.
 
     Args:
@@ -37,6 +39,12 @@ def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Bluep
     routes = Blueprint('admin_users_routes', __name__)
 
     handler_add_user = AdminAddUserPageHandler(
+        injections.logger,
+        injections.config,
+        injections.rest_client,
+        injections.metadata)
+
+    handler_modify_user = AdminModifyUserPageHandler(
         injections.logger,
         injections.config,
         injections.rest_client,
@@ -55,5 +63,19 @@ def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Bluep
     @routes.route('/add', methods=['POST'])
     async def admin_add_user_post():
         return await handler_add_user.add_user_post()
+
+    injections.logger.debug("=> %s GET /admin/users_roles/<id>/modify",
+                            "Admin modify user page (read)".ljust(40))
+
+    @routes.route('/<int:user_id>/modify', methods=['GET'])
+    async def admin_modify_user_get(user_id: int):
+        return await handler_modify_user.modify_user_get(user_id)
+
+    injections.logger.debug("=> %s POST /admin/users_roles/<id>/modify",
+                            "Admin modify user (submit)".ljust(40))
+
+    @routes.route('/<int:user_id>/modify', methods=['POST'])
+    async def admin_modify_user_post(user_id: int):
+        return await handler_modify_user.modify_user_post(user_id)
 
     return routes

--- a/items/services/items_web_portal/page_handlers/admin/users/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/__init__.py
@@ -1,0 +1,59 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from quart import Blueprint
+from items.services.items_web_portal.page_handler_injections import (
+    PageHandlerInjections)
+from items.services.items_web_portal.page_handlers.admin.users.admin_add_user_page_handler import (
+    AdminAddUserPageHandler)
+
+
+def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Blueprint:
+    """Create the admin user management route handlers.
+
+    Registers routes for listing users and creating new users under the
+    /users_roles prefix.
+
+    Args:
+        injections: Dependency injection container providing the logger,
+            configuration, REST client, and metadata.
+
+    Returns:
+        A configured Quart blueprint containing the user management routes.
+    """
+    routes = Blueprint('admin_users_routes', __name__)
+
+    handler_add_user = AdminAddUserPageHandler(
+        injections.logger,
+        injections.config,
+        injections.rest_client,
+        injections.metadata)
+
+    injections.logger.debug("=> %s GET /admin/users_roles/add",
+                            "Admin add user page (read)".ljust(40))
+
+    @routes.route('/add', methods=['GET'])
+    async def admin_add_user_get():
+        return await handler_add_user.add_user_get()
+
+    injections.logger.debug("=> %s POST /admin/users_roles/add",
+                            "Admin add user (submit)".ljust(40))
+
+    @routes.route('/add', methods=['POST'])
+    async def admin_add_user_post():
+        return await handler_add_user.add_user_post()
+
+    return routes

--- a/items/services/items_web_portal/page_handlers/admin/users/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/__init__.py
@@ -21,6 +21,8 @@ from items.services.items_web_portal.page_handlers.admin.users.admin_add_user_pa
     AdminAddUserPageHandler)
 from items.services.items_web_portal.page_handlers.admin.users.admin_modify_user_page_handler import (
     AdminModifyUserPageHandler)
+from items.services.items_web_portal.page_handlers.admin.users.admin_reset_password_page_handler import (
+    AdminResetPasswordPageHandler)
 
 
 def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Blueprint:
@@ -45,6 +47,12 @@ def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Bluep
         injections.metadata)
 
     handler_modify_user = AdminModifyUserPageHandler(
+        injections.logger,
+        injections.config,
+        injections.rest_client,
+        injections.metadata)
+
+    handler_reset_password = AdminResetPasswordPageHandler(
         injections.logger,
         injections.config,
         injections.rest_client,
@@ -77,5 +85,19 @@ def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Bluep
     @routes.route('/<int:user_id>/modify', methods=['POST'])
     async def admin_modify_user_post(user_id: int):
         return await handler_modify_user.modify_user_post(user_id)
+
+    injections.logger.debug("=> %s GET /admin/users_roles/<id>/reset_password",
+                            "Admin reset password page (read)".ljust(40))
+
+    @routes.route('/<int:user_id>/reset_password', methods=['GET'])
+    async def admin_reset_password_get(user_id: int):
+        return await handler_reset_password.reset_password_get(user_id)
+
+    injections.logger.debug("=> %s POST /admin/users_roles/<id>/reset_password",
+                            "Admin reset password (submit)".ljust(40))
+
+    @routes.route('/<int:user_id>/reset_password', methods=['POST'])
+    async def admin_reset_password_post(user_id: int):
+        return await handler_reset_password.reset_password_post(user_id)
 
     return routes

--- a/items/services/items_web_portal/page_handlers/admin/users/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/__init__.py
@@ -17,12 +17,12 @@ limitations under the License.
 from quart import Blueprint
 from items.services.items_web_portal.page_handler_injections import (
     PageHandlerInjections)
-from items.services.items_web_portal.page_handlers.admin.users.admin_add_user_page_handler import (
-    AdminAddUserPageHandler)
-from items.services.items_web_portal.page_handlers.admin.users.admin_modify_user_page_handler import (
-    AdminModifyUserPageHandler)
-from items.services.items_web_portal.page_handlers.admin.users.admin_reset_password_page_handler import (
-    AdminResetPasswordPageHandler)
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_add_user_page_handler import AdminAddUserPageHandler
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_modify_user_page_handler import AdminModifyUserPageHandler
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_reset_password_page_handler import AdminResetPasswordPageHandler
 
 
 def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Blueprint:

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
@@ -1,0 +1,137 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import http
+import logging
+from quart import make_response, request
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_administrator
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+
+class AdminAddUserPageHandler(PortalPageHandler):
+    """Handles requests for creating new users.
+
+    This handler renders the user creation form and processes submitted user
+    details by forwarding them to the gateway user management API.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialize the user creation page handler.
+
+        Args:
+            logger: Logger used to record diagnostic and operational messages.
+            config: Application configuration settings.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Instance metadata used to populate page content.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    @require_administrator
+    async def add_user_get(self):
+        """Render the user creation page.
+
+        Returns:
+            The rendered user creation page response.
+        """
+        return await self._render(form_data={})
+
+    @require_administrator
+    async def add_user_post(self):
+        """Process a user creation request.
+
+        Reads the submitted form, builds a gateway request, and handles
+        success, conflict, and error responses. On success the generated
+        password (if any) is displayed before returning the blank form.
+
+        Returns:
+            The rendered user creation page, either with a success message
+            (including any generated password) or an error message.
+        """
+        form = await request.form
+        form_data = form.to_dict()
+
+        full_name: str = form.get("full_name", "").strip()
+        display_name: str = form.get("display_name", "").strip()
+        email_address: str = form.get("email_address", "").strip()
+        password: str = form.get("password", "").strip()
+
+        if not all([full_name, display_name, email_address]):
+            return await self._render(
+                form_data=form_data,
+                error_msg_str="Full name, display name and email address are required.")
+
+        if not password or len(password) < 8:
+            return await self._render(
+                form_data=form_data,
+                error_msg_str="Password must be at least 8 characters.")
+
+        gateway_body: dict = {
+            "full_name": full_name,
+            "display_name": display_name,
+            "email_address": email_address,
+            "password": password,
+        }
+
+        url = f"{self._config.apis_gateway_svc}web/users"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=gateway_body)
+
+        if response.status_code == http.HTTPStatus.CONFLICT:
+            return await self._render(
+                form_data=form_data,
+                error_msg_str="That email address is already registered.")
+
+        if response.status_code != http.HTTPStatus.CREATED:
+            self._logger.error(
+                "Gateway POST /web/users failed: status=%s body=%s",
+                response.status_code, response.body)
+            return await self._render(
+                form_data=form_data,
+                error_msg_str="An unexpected error occurred. Please try again.")
+
+        return await make_response(
+            self._generate_redirect('/admin/users_roles'))
+
+    async def _render(self,
+                      form_data: dict,
+                      error_msg_str: str | None = None):
+        """Render the user creation page.
+
+        Args:
+            form_data: Values used to pre-populate the form fields.
+            error_msg_str: Optional error message to display.
+
+        Returns:
+            The rendered user creation page response.
+        """
+        return await self._render_page(
+            pages.PAGE_INSTANCE_ADMIN_ADD_USER,
+            instance_name=self._metadata_settings.instance_name,
+            active_page="administration",
+            active_admin_page="admin_page_users_roles",
+            form_data=form_data,
+            error_msg_str=error_msg_str)

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
@@ -1,0 +1,177 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import http
+import logging
+from quart import make_response, request
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_administrator
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+
+class AdminModifyUserPageHandler(PortalPageHandler):
+    """Handles requests for editing an existing user.
+
+    Fetches the current user data from the gateway on GET and submits a
+    patch-style update on POST.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialise the modify user page handler.
+
+        Args:
+            logger: Logger used to record diagnostic and operational messages.
+            config: Application configuration settings.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Instance metadata used to populate page content.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    @require_administrator
+    async def modify_user_get(self, user_id: int):
+        """Render the edit user page pre-populated with current user data.
+
+        Args:
+            user_id: The ID of the user to edit.
+
+        Returns:
+            The rendered edit user page, or an error page if the user is
+            not found or the gateway is unavailable.
+        """
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}"
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.status_code == http.HTTPStatus.NOT_FOUND:
+            return await self._render(
+                user_id=user_id,
+                form_data={},
+                error_msg_str="User not found.")
+
+        if response.status_code != http.HTTPStatus.OK:
+            self._logger.error(
+                "Gateway GET /web/users/%s failed: status=%s",
+                user_id, response.status_code)
+            return await self._render(
+                user_id=user_id,
+                form_data={},
+                error_msg_str="Could not load user — please try again.")
+
+        user = response.body
+        form_data = {
+            "full_name": user.get("full_name", ""),
+            "display_name": user.get("display_name", ""),
+            "email_address": user.get("email_address", ""),
+            "account_status": user.get("account_status", 1),
+        }
+        return await self._render(user_id=user_id, form_data=form_data)
+
+    @require_administrator
+    async def modify_user_post(self, user_id: int):
+        """Process an edit user submission.
+
+        Sends a PATCH request to the gateway with the supplied fields.
+        Redirects to the user list on success; re-renders the form with an
+        error message on failure.
+
+        Args:
+            user_id: The ID of the user to update.
+
+        Returns:
+            A redirect to /admin/users_roles on success, or the rendered
+            edit page with an error message on failure.
+        """
+        form = await request.form
+        form_data = form.to_dict()
+
+        full_name: str = form.get("full_name", "").strip()
+        display_name: str = form.get("display_name", "").strip()
+        account_status: int = 1 if form.get("account_status") == "1" else 0
+
+        # Re-inject account_status as int for template re-population
+        form_data["account_status"] = account_status
+
+        if not all([full_name, display_name]):
+            return await self._render(
+                user_id=user_id,
+                form_data=form_data,
+                error_msg_str="Full name and display name are required.")
+
+        gateway_body: dict = {
+            "full_name": full_name,
+            "display_name": display_name,
+            "account_status": account_status,
+        }
+
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}"
+        response: ApiResponse = await self._rest_client.patch(
+            url, json_data=gateway_body)
+
+        if response.status_code == http.HTTPStatus.FORBIDDEN:
+            return await self._render(
+                user_id=user_id,
+                form_data=form_data,
+                error_msg_str="Cannot deactivate the last active administrator.")
+
+        if response.status_code == http.HTTPStatus.NOT_FOUND:
+            return await self._render(
+                user_id=user_id,
+                form_data=form_data,
+                error_msg_str="User not found.")
+
+        if response.status_code != http.HTTPStatus.OK:
+            self._logger.error(
+                "Gateway PATCH /web/users/%s failed: status=%s body=%s",
+                user_id, response.status_code, response.body)
+            return await self._render(
+                user_id=user_id,
+                form_data=form_data,
+                error_msg_str="An unexpected error occurred. Please try again.")
+
+        return await make_response(
+            self._generate_redirect('/admin/users_roles'))
+
+    async def _render(self,
+                      user_id: int,
+                      form_data: dict,
+                      error_msg_str: str | None = None):
+        """Render the edit user page.
+
+        Args:
+            user_id: ID of the user being edited (used in the form action).
+            form_data: Values used to pre-populate the form fields.
+            error_msg_str: Optional error message to display.
+
+        Returns:
+            The rendered edit user page response.
+        """
+        return await self._render_page(
+            pages.PAGE_INSTANCE_ADMIN_MODIFY_USER,
+            instance_name=self._metadata_settings.instance_name,
+            active_page="administration",
+            active_admin_page="admin_page_users_roles",
+            user_id=user_id,
+            form_data=form_data,
+            error_msg_str=error_msg_str)

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_reset_password_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_reset_password_page_handler.py
@@ -1,0 +1,179 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import http
+import logging
+from quart import make_response, request
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.decorators import require_administrator
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+
+class AdminResetPasswordPageHandler(PortalPageHandler):
+    """Handles requests for resetting a user's password.
+
+    Fetches the user's name and email from the gateway for display, then
+    submits the new password to the gateway reset endpoint on POST.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialise the reset password page handler.
+
+        Args:
+            logger: Logger used to record diagnostic and operational messages.
+            config: Application configuration settings.
+            rest_client: REST client used to communicate with backend services.
+            metadata: Instance metadata used to populate page content.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    @require_administrator
+    async def reset_password_get(self, user_id: int):
+        """Render the reset password page.
+
+        Fetches the user's full name and email to display as context.
+
+        Args:
+            user_id: The ID of the user whose password is being reset.
+
+        Returns:
+            The rendered reset password page.
+        """
+        user_full_name, user_email = await self._fetch_user_display(user_id)
+        if user_full_name is None:
+            return await self._render(
+                user_id=user_id,
+                user_full_name="Unknown",
+                user_email="",
+                error_msg_str="User not found.")
+
+        return await self._render(
+            user_id=user_id,
+            user_full_name=user_full_name,
+            user_email=user_email)
+
+    @require_administrator
+    async def reset_password_post(self, user_id: int):
+        """Process a password reset submission.
+
+        Validates the two password fields match and meet the minimum length,
+        then forwards the new password to the gateway.
+
+        Args:
+            user_id: The ID of the user whose password is being reset.
+
+        Returns:
+            A redirect to /admin/users_roles on success, or the rendered
+            reset password page with an error message on failure.
+        """
+        form = await request.form
+        new_password: str = form.get("new_password", "").strip()
+        confirm_password: str = form.get("confirm_password", "").strip()
+
+        user_full_name, user_email = await self._fetch_user_display(user_id)
+        user_full_name = user_full_name or "Unknown"
+        user_email = user_email or ""
+
+        if not new_password or len(new_password) < 8:
+            return await self._render(
+                user_id=user_id,
+                user_full_name=user_full_name,
+                user_email=user_email,
+                error_msg_str="Password must be at least 8 characters.")
+
+        if new_password != confirm_password:
+            return await self._render(
+                user_id=user_id,
+                user_full_name=user_full_name,
+                user_email=user_email,
+                error_msg_str="Passwords do not match.")
+
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}/password"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data={"new_password": new_password})
+
+        if response.status_code == http.HTTPStatus.NOT_FOUND:
+            return await self._render(
+                user_id=user_id,
+                user_full_name=user_full_name,
+                user_email=user_email,
+                error_msg_str="User not found.")
+
+        if response.status_code != http.HTTPStatus.OK:
+            self._logger.error(
+                "Gateway POST /web/users/%s/password failed: status=%s body=%s",
+                user_id, response.status_code, response.body)
+            return await self._render(
+                user_id=user_id,
+                user_full_name=user_full_name,
+                user_email=user_email,
+                error_msg_str="An unexpected error occurred. Please try again.")
+
+        return await make_response(
+            self._generate_redirect('/admin/users_roles'))
+
+    async def _fetch_user_display(self, user_id: int) -> tuple[str | None, str | None]:
+        """Fetch the user's full name and email for display purposes.
+
+        Args:
+            user_id: The ID of the user to look up.
+
+        Returns:
+            A ``(full_name, email_address)`` tuple, or ``(None, None)`` if
+            the user is not found or the gateway is unavailable.
+        """
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}"
+        response: ApiResponse = await self._rest_client.get(url)
+        if response.status_code != http.HTTPStatus.OK:
+            return None, None
+        return (response.body.get("full_name"),
+                response.body.get("email_address"))
+
+    async def _render(self,
+                      user_id: int,
+                      user_full_name: str,
+                      user_email: str,
+                      error_msg_str: str | None = None):
+        """Render the reset password page.
+
+        Args:
+            user_id: ID of the user (used in the form action).
+            user_full_name: User's full name, shown as context.
+            user_email: User's email address, shown as context.
+            error_msg_str: Optional error message to display.
+
+        Returns:
+            The rendered reset password page response.
+        """
+        return await self._render_page(
+            pages.PAGE_INSTANCE_ADMIN_RESET_PASSWORD,
+            instance_name=self._metadata_settings.instance_name,
+            active_page="administration",
+            active_admin_page="admin_page_users_roles",
+            user_id=user_id,
+            user_full_name=user_full_name,
+            user_email=user_email,
+            error_msg_str=error_msg_str)

--- a/items/services/items_web_portal/page_handlers/auth/login_get_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/auth/login_get_page_handler.py
@@ -51,10 +51,17 @@ class LoginGetPageHandler(PortalPageHandler):
                 - The internal error page if an exception occurs.
         """
         try:
-            if await self._has_auth_cookies() and await self._validate_cookies():
-                redirect = self._generate_redirect('')
-                response = await make_response(redirect)
-                return response
+            if await self._has_auth_cookies():
+                # _validate_cookies returns (is_valid, is_administrator). The
+                # tuple must be unpacked - testing it directly is always true,
+                # because any non-empty tuple is truthy, which would redirect
+                # users with stale cookies to a page that bounces them
+                # straight back here.
+                is_valid, _ = await self._validate_cookies()
+                if is_valid:
+                    redirect = self._generate_redirect('')
+                    response = await make_response(redirect)
+                    return response
 
         except BaseItemsException as ex:
             self._logger.error('Internal Error: %s', ex)

--- a/items/services/items_web_portal/page_handlers/auth/login_post_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/auth/login_post_page_handler.py
@@ -55,10 +55,15 @@ class LoginPostPageHandler(PortalPageHandler):
         """
         # pylint: disable=too-many-return-statements
         try:
-            if await self._has_auth_cookies() and await self._validate_cookies():
-                redirect = self._generate_redirect('')
-                response: Response = await make_response(redirect)
-                return response
+            if await self._has_auth_cookies():
+                # _validate_cookies returns (is_valid, is_administrator); the
+                # tuple must be unpacked rather than tested directly, since a
+                # non-empty tuple is always truthy.
+                is_valid, _ = await self._validate_cookies()
+                if is_valid:
+                    redirect = self._generate_redirect('')
+                    response: Response = await make_response(redirect)
+                    return response
 
         except BaseItemsException as ex:
             self._logger.error('Internal Error: %s', ex)

--- a/items/services/items_web_portal/page_locations.py
+++ b/items/services/items_web_portal/page_locations.py
@@ -48,3 +48,5 @@ PAGE_INSTANCE_ADMIN_SITE_SETTINGS: str = "instance_admin_site_settings.html"
 
 PAGE_INSTANCE_ADMIN_ADD_PROJECT: str = "instance_admin_add_project.html"
 PAGE_INSTANCE_ADMIN_MODIFY_PROJECT: str = "instance_admin_modify_project.html"
+
+PAGE_INSTANCE_ADMIN_ADD_USER: str = "instance_admin_add_user.html"

--- a/items/services/items_web_portal/page_locations.py
+++ b/items/services/items_web_portal/page_locations.py
@@ -50,3 +50,4 @@ PAGE_INSTANCE_ADMIN_ADD_PROJECT: str = "instance_admin_add_project.html"
 PAGE_INSTANCE_ADMIN_MODIFY_PROJECT: str = "instance_admin_modify_project.html"
 
 PAGE_INSTANCE_ADMIN_ADD_USER: str = "instance_admin_add_user.html"
+PAGE_INSTANCE_ADMIN_MODIFY_USER: str = "instance_admin_modify_user.html"

--- a/items/services/items_web_portal/page_locations.py
+++ b/items/services/items_web_portal/page_locations.py
@@ -51,3 +51,4 @@ PAGE_INSTANCE_ADMIN_MODIFY_PROJECT: str = "instance_admin_modify_project.html"
 
 PAGE_INSTANCE_ADMIN_ADD_USER: str = "instance_admin_add_user.html"
 PAGE_INSTANCE_ADMIN_MODIFY_USER: str = "instance_admin_modify_user.html"
+PAGE_INSTANCE_ADMIN_RESET_PASSWORD: str = "instance_admin_reset_password.html"

--- a/items/services/items_web_portal/portal_page_handler.py
+++ b/items/services/items_web_portal/portal_page_handler.py
@@ -102,7 +102,12 @@ class SessionAuthMixin:
         before the session status is returned.
 
         Returns:
-            ``True`` if the session is valid; otherwise, ``False``.
+            A ``(is_valid, is_administrator)`` tuple. ``is_administrator`` is
+            ``False`` whenever the session is not valid.
+
+            Callers must unpack this tuple. Testing the return value directly
+            is always true, because any non-empty tuple is truthy - including
+            ``(False, False)``.
 
         Raises:
             BaseItemsException: If the gateway service returns an unexpected

--- a/items/services/items_web_portal/static/css/instance_admin_add_user.css
+++ b/items/services/items_web_portal/static/css/instance_admin_add_user.css
@@ -1,0 +1,69 @@
+.user-create-tab .nav-link {
+  border: none;
+  background-color: transparent;
+  color: #000;
+}
+
+.user-create-tab .nav-link.active {
+  border-bottom: 2px solid #007bff;
+  font-weight: bold;
+  color: #007bff;
+}
+
+.user-create-tab .nav-link:hover {
+  color: #007bff;
+}
+
+#error_msg {
+    color: #ff4d4d;
+    font-weight: bold;
+    padding: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    border-radius: 6px;
+    border: 2px solid #ff4d4d;
+    background-color: #ffe6e6;
+    text-align: center;
+}
+
+#generated_password_msg {
+    padding: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    border-radius: 6px;
+    border: 2px solid #28a745;
+    background-color: #e6f4ea;
+    color: #155724;
+}
+
+#generated_password_msg code {
+    font-size: 1.1rem;
+    color: #155724;
+    background-color: #c3e6cb;
+    padding: 2px 6px;
+    border-radius: 4px;
+}
+
+.cancelButton:hover {
+  background-color: #ede9e8 !important;
+  border-color: red !important;
+  color: red !important;
+}
+
+.cancel-icon {
+  display: inline-block;
+  color: red;
+  font-size: 18px;
+  width: 22px;
+  height: 22px;
+  text-align: center;
+  line-height: 20px;
+  margin-right: 5px;
+  transition: none;
+}
+
+.cancel-icon:hover {
+  color: red !important;
+  border-color: red !important;
+  background-color: #ffe6e6 !important;
+}

--- a/items/services/items_web_portal/static/css/instance_admin_users_roles.css
+++ b/items/services/items_web_portal/static/css/instance_admin_users_roles.css
@@ -1,0 +1,4 @@
+a.user-link:hover {
+    color: #007bff !important;
+    cursor: pointer !important;
+}

--- a/items/services/items_web_portal/templates/instance_admin_add_user.html
+++ b/items/services/items_web_portal/templates/instance_admin_add_user.html
@@ -1,0 +1,147 @@
+{% extends "instance_admin_template.html" %}
+{% block title %}ITEMS | Add User{% endblock %}
+{% block head %}{{ super() }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_add_user.css') }}">
+{% endblock %}
+
+{% block body_params %}id="body-pd"{% endblock %}
+
+{% block instance_admin_body %}
+  <h4 class="mb-3">Add User</h4>
+  <hr />
+
+  <form id="addUserForm" action="/admin/users_roles/add" method="post">
+
+    <!-- Tab Navigation -->
+    <ul class="nav user-create-tab mb-3" id="addUserTabs">
+      <li class="nav-item">
+        <a class="nav-link active" data-bs-toggle="tab" href="#tab-user">User</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-bs-toggle="tab" href="#tab-access">Access</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-bs-toggle="tab" href="#tab-projects">Projects</a>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+
+      <!-- USER TAB -->
+      <div class="tab-pane active" id="tab-user">
+
+        <div class="mb-3">
+          <label for="full_name" class="form-label">Full Name *</label>
+          <input type="text" class="form-control" id="full_name" name="full_name"
+                 required pattern="\S.*"
+                 placeholder="e.g. Jane Smith"
+                 value="{{ form_data.get('full_name', '') }}">
+        </div>
+
+        <div class="mb-3">
+          <label for="display_name" class="form-label">Display Name *</label>
+          <input type="text" class="form-control" id="display_name" name="display_name"
+                 required pattern="\S.*"
+                 placeholder="e.g. Jane"
+                 value="{{ form_data.get('display_name', '') }}">
+        </div>
+
+        <div class="mb-3">
+          <label for="email_address" class="form-label">Email Address *</label>
+          <input type="email" class="form-control" id="email_address" name="email_address"
+                 required
+                 placeholder="e.g. jane@example.com"
+                 value="{{ form_data.get('email_address', '') }}">
+        </div>
+
+        <hr class="my-4">
+
+        <div class="mb-3">
+          <label for="language" class="form-label text-muted">Language</label>
+          <select class="form-select" id="language" name="language" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Language preferences will be configurable in a future release.</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="locale" class="form-label text-muted">Locale</label>
+          <select class="form-select" id="locale" name="locale" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Locale preferences will be configurable in a future release.</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="timezone" class="form-label text-muted">Time Zone</label>
+          <select class="form-select" id="timezone" name="timezone" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Time zone preferences will be configurable in a future release.</div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="mb-3">
+          <label class="form-label">Password</label>
+          <div class="mb-2">
+            <div class="form-check">
+              <input class="form-check-input" type="radio" name="password_mode"
+                     id="password_mode_generate" value="generate" disabled>
+              <label class="form-check-label text-muted" for="password_mode_generate">
+                <strong>Auto-generate password</strong>
+                <div class="form-text">Available once email invitations are supported.</div>
+              </label>
+            </div>
+            <div class="form-check mt-2">
+              <input class="form-check-input" type="radio" name="password_mode"
+                     id="password_mode_manual" value="manual" checked>
+              <label class="form-check-label" for="password_mode_manual">
+                <strong>Manually specify password</strong>
+              </label>
+            </div>
+          </div>
+          <div id="password_field" class="mt-2">
+            <input type="password" class="form-control" id="password" name="password"
+                   placeholder="Enter password" required minlength="8"
+                   value="{{ form_data.get('password', '') }}">
+            <div class="form-text">Minimum 8 characters.</div>
+          </div>
+        </div>
+
+      </div>
+
+      <!-- ACCESS TAB -->
+      <div class="tab-pane" id="tab-access">
+        <p class="text-muted mt-3">
+          Role and access configuration will be available in a future release.
+          New users are created as standard (non-administrator) users by default.
+        </p>
+      </div>
+
+      <!-- PROJECTS TAB -->
+      <div class="tab-pane" id="tab-projects">
+        <p class="text-muted mt-3">
+          Per-user project access configuration will be available in a future release.
+        </p>
+      </div>
+
+    </div>
+
+    {% if error_msg_str %}
+    <div id="error_msg">{{ error_msg_str }}</div>
+    {% endif %}
+
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary">Add User</button>
+      <button type="button" class="btn btn-outline-danger cancelButton"
+              onclick="window.location.href='/admin/users_roles'">
+        <i class="bi bi-x-lg cancel-icon"></i> Cancel
+      </button>
+    </div>
+
+  </form>
+{% endblock %}
+
+{% block postBody %}{{ super() }}{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_modify_user.html
+++ b/items/services/items_web_portal/templates/instance_admin_modify_user.html
@@ -1,0 +1,124 @@
+{% extends "instance_admin_template.html" %}
+{% block title %}ITEMS | Edit User{% endblock %}
+{% block head %}{{ super() }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_add_user.css') }}">
+{% endblock %}
+
+{% block body_params %}id="body-pd"{% endblock %}
+
+{% block instance_admin_body %}
+  <h4 class="mb-3">Edit User</h4>
+  <hr />
+
+  <form id="modifyUserForm" action="/admin/users_roles/{{ user_id }}/modify" method="post">
+
+    <!-- Tab Navigation -->
+    <ul class="nav user-create-tab mb-3" id="modifyUserTabs">
+      <li class="nav-item">
+        <a class="nav-link active" data-bs-toggle="tab" href="#tab-user">User</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-bs-toggle="tab" href="#tab-access">Access</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" data-bs-toggle="tab" href="#tab-projects">Projects</a>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+
+      <!-- USER TAB -->
+      <div class="tab-pane active" id="tab-user">
+
+        <div class="mb-3">
+          <label for="full_name" class="form-label">Full Name *</label>
+          <input type="text" class="form-control" id="full_name" name="full_name"
+                 required pattern="\S.*"
+                 value="{{ form_data.get('full_name', '') }}">
+        </div>
+
+        <div class="mb-3">
+          <label for="display_name" class="form-label">Display Name *</label>
+          <input type="text" class="form-control" id="display_name" name="display_name"
+                 required pattern="\S.*"
+                 value="{{ form_data.get('display_name', '') }}">
+        </div>
+
+        <div class="mb-3">
+          <label for="email_address" class="form-label text-muted">Email Address</label>
+          <input type="email" class="form-control" id="email_address" name="email_address"
+                 readonly
+                 value="{{ form_data.get('email_address', '') }}">
+          <div class="form-text text-muted">Email address cannot be changed.</div>
+        </div>
+
+        <div class="mb-3">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="account_status"
+                   name="account_status" value="1"
+                   {% if form_data.get('account_status') == 1 %}checked{% endif %}>
+            <label class="form-check-label" for="account_status">Active</label>
+          </div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="mb-3">
+          <label for="language" class="form-label text-muted">Language</label>
+          <select class="form-select" id="language" name="language" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Language preferences will be configurable in a future release.</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="locale" class="form-label text-muted">Locale</label>
+          <select class="form-select" id="locale" name="locale" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Locale preferences will be configurable in a future release.</div>
+        </div>
+
+        <div class="mb-3">
+          <label for="timezone" class="form-label text-muted">Time Zone</label>
+          <select class="form-select" id="timezone" name="timezone" disabled>
+            <option>Use application default</option>
+          </select>
+          <div class="form-text text-muted">Time zone preferences will be configurable in a future release.</div>
+        </div>
+
+      </div>
+
+      <!-- ACCESS TAB -->
+      <div class="tab-pane" id="tab-access">
+        <p class="text-muted mt-3">
+          Role and access configuration will be available in a future release.
+        </p>
+      </div>
+
+      <!-- PROJECTS TAB -->
+      <div class="tab-pane" id="tab-projects">
+        <p class="text-muted mt-3">
+          Per-user project access configuration will be available in a future release.
+        </p>
+      </div>
+
+    </div>
+
+    {% if error_msg_str %}
+    <div id="error_msg">{{ error_msg_str }}</div>
+    {% endif %}
+
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary">Save User</button>
+      <button type="button" class="btn btn-outline-danger cancelButton"
+              onclick="window.location.href='/admin/users_roles'">
+        <i class="bi bi-x-lg cancel-icon"></i> Cancel
+      </button>
+    </div>
+
+  </form>
+{% endblock %}
+
+{% block postBody %}{{ super() }}{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_reset_password.html
+++ b/items/services/items_web_portal/templates/instance_admin_reset_password.html
@@ -1,0 +1,46 @@
+{% extends "instance_admin_template.html" %}
+{% block title %}ITEMS | Reset Password{% endblock %}
+{% block head %}{{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_add_user.css') }}">
+{% endblock %}
+
+{% block body_params %}id="body-pd"{% endblock %}
+
+{% block instance_admin_body %}
+  <h4 class="mb-3">Reset Password</h4>
+  <p class="text-muted">Resetting password for <strong>{{ user_full_name }}</strong> ({{ user_email }})</p>
+  <hr />
+
+  <form id="resetPasswordForm" action="/admin/users_roles/{{ user_id }}/reset_password" method="post">
+
+    <div class="mb-3">
+      <label for="new_password" class="form-label">New Password *</label>
+      <input type="password" class="form-control" id="new_password" name="new_password"
+             required minlength="8"
+             placeholder="Enter new password">
+      <div class="form-text">Minimum 8 characters.</div>
+    </div>
+
+    <div class="mb-3">
+      <label for="confirm_password" class="form-label">Confirm Password *</label>
+      <input type="password" class="form-control" id="confirm_password" name="confirm_password"
+             required minlength="8"
+             placeholder="Re-enter new password">
+    </div>
+
+    {% if error_msg_str %}
+    <div id="error_msg">{{ error_msg_str }}</div>
+    {% endif %}
+
+    <div class="mt-4">
+      <button type="submit" class="btn btn-primary">Reset Password</button>
+      <button type="button" class="btn btn-outline-danger cancelButton"
+              onclick="window.location.href='/admin/users_roles'">
+        <i class="bi bi-x-lg cancel-icon"></i> Cancel
+      </button>
+    </div>
+
+  </form>
+{% endblock %}
+
+{% block postBody %}{{ super() }}{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -1,10 +1,59 @@
 {% extends "instance_admin_template.html" %}
-{% block title %}ITEMS | Admin Overview{% endblock %}
+{% block title %}ITEMS | Users & Roles{% endblock %}
 {% block head %}{{ super() }}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_users_roles.css') }}">
 {% endblock %}
 
 {% block body_params %}id="body-pd"{% endblock %}
 
 {% block instance_admin_body %}
-    <h3>Users & Roles contents go here ...</h3>
+    <div class="flex-grow-1">
+      <h4 class="mb-3">Users & Roles</h4>
+      <hr />
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Full Name</th>
+            <th scope="col">Display Name</th>
+            <th scope="col">Email Address</th>
+            <th scope="col">Status</th>
+            <th scope="col">Administrator</th>
+            <th scope="col" class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for user in users %}
+        <tr>
+          <td>{{ user.full_name }}</td>
+          <td>{{ user.display_name }}</td>
+          <td>{{ user.email_address }}</td>
+          <td>
+            {% if user.account_status == 1 %}
+              <span class="badge bg-success">Active</span>
+            {% else %}
+              <span class="badge bg-secondary">Inactive</span>
+            {% endif %}
+          </td>
+          <td>
+            {% if user.is_administrator %}
+              <span class="badge bg-primary">Admin</span>
+            {% else %}
+              &mdash;
+            {% endif %}
+          </td>
+          <td class="text-end">
+            <button class="btn btn-link text-primary"
+                    onclick="window.location.href='/admin/users_roles/{{ user.id }}/modify'">
+              <i class="bi bi-pencil"></i>
+            </button>
+          </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <div class="mt-3">
+        <button class="btn btn-primary" onclick="window.location.href='/admin/users_roles/add'">+ Add User</button>
+      </div>
+    </div>
 {% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -3,6 +3,7 @@
 {% block head %}{{ super() }}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" />
   <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_users_roles.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/instance_admin_add_user.css') }}">
 {% endblock %}
 
 {% block body_params %}id="body-pd"{% endblock %}
@@ -62,4 +63,8 @@
         <button class="btn btn-primary" onclick="window.location.href='/admin/users_roles/add'">+ Add User</button>
       </div>
     </div>
+
+    {% if error_msg_str %}
+    <div id="error_msg">{{ error_msg_str }}</div>
+    {% endif %}
 {% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -44,8 +44,14 @@
           </td>
           <td class="text-end">
             <button class="btn btn-link text-primary"
+                    title="Edit user"
                     onclick="window.location.href='/admin/users_roles/{{ user.id }}/modify'">
               <i class="bi bi-pencil"></i>
+            </button>
+            <button class="btn btn-link text-secondary"
+                    title="Reset password"
+                    onclick="window.location.href='/admin/users_roles/{{ user.id }}/reset_password'">
+              <i class="bi bi-key"></i>
             </button>
           </td>
         </tr>

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 1
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 4"
+PRE_RELEASE = "Alpha Build 5"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -42,6 +42,11 @@ from test_admin_projects_handlers import (
     TestAdminAddProjectPageHandlers,
     TestAdminModifyProjectPageHandlers,
 )
+from test_admin_users_handlers import (
+    TestAdminAddUserPageHandler,
+    TestAdminModifyUserPageHandler,
+    TestAdminResetPasswordPageHandler,
+)
 from test_projects_testcases_handlers import (
     TestGetProjectOverviewPageHandler,
     TestGetProjectTestcasesPageHandler,

--- a/unit_tests/web_portal_svc/test_admin_stub_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_stub_handlers.py
@@ -112,8 +112,56 @@ TestAdminManageDataPageHandler = _make_stub_test(
     AdminManageDataPageHandler, "manage_data", "/admin/manage_data")
 TestAdminSiteSettingsPageHandler = _make_stub_test(
     AdminSiteSettingsPageHandler, "site_settings", "/admin/site_settings")
-TestAdminUsersAndRolesPageHandler = _make_stub_test(
-    AdminUsersAndRolesPageHandler, "users_and_roles", "/admin/users_roles")
+class TestAdminUsersAndRolesPageHandler(unittest.IsolatedAsyncioTestCase):
+    """Users & Roles list page — now fetches users from gateway."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": True})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles", methods=["GET"])
+        async def route():
+            return await handler.users_and_roles()
+
+        self.client = app.test_client()
+
+    async def _get(self, headers=_AUTH_HEADERS):
+        async with self.client as c:
+            return await c.get("/admin/users_roles", headers=headers)
+
+    async def test_renders_page_with_users(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"users": [{"id": 1, "full_name": "Alice"}]})
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+
+    async def test_gateway_failure_renders_error_message(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Could not load users", text)
+
+    async def test_redirects_when_not_authenticated(self):
+        response = await self._get(headers={})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_redirects_when_not_administrator(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": False})
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
 
 
 if __name__ == "__main__":

--- a/unit_tests/web_portal_svc/test_admin_users_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_users_handlers.py
@@ -1,0 +1,422 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from http import HTTPStatus
+from weaver_framework.microservice.api_response import ApiResponse
+from _test_utils import make_app
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_add_user_page_handler import AdminAddUserPageHandler
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_modify_user_page_handler import AdminModifyUserPageHandler
+from items.services.items_web_portal.page_handlers.admin.users.\
+    admin_reset_password_page_handler import AdminResetPasswordPageHandler
+
+_LOGGER = MagicMock()
+_AUTH_HEADERS = {"Cookie": "items_token=abc; items_user=bob"}
+
+_SESSION_VALID = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"status": "VALID", "is_administrator": True})
+
+_USER = {
+    "id": 1,
+    "full_name": "Alice Smith",
+    "display_name": "Alice",
+    "email_address": "alice@localhost",
+    "account_status": 1,
+    "is_administrator": False,
+}
+
+_VALID_ADD_FORM = {
+    "full_name": "Alice Smith",
+    "display_name": "Alice",
+    "email_address": "alice@localhost",
+    "password": "securepass",
+    "password_mode": "manual",
+}
+
+_VALID_MODIFY_FORM = {
+    "full_name": "Alice Smith",
+    "display_name": "Alice",
+    "account_status": "1",
+}
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_gateway_svc = "http://gateway/"
+    return cfg
+
+
+def _metadata():
+    m = MagicMock()
+    m.instance_name = "INSTANCE"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# AdminAddUserPageHandler
+# ---------------------------------------------------------------------------
+
+class TestAdminAddUserPageHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        handler = AdminAddUserPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/add", methods=["GET"])
+        async def get_route():
+            return await handler.add_user_get()
+
+        @app.route("/admin/users_roles/add", methods=["POST"])
+        async def post_route():
+            return await handler.add_user_post()
+
+        self.client = app.test_client()
+
+    async def _get(self):
+        async with self.client as c:
+            return await c.get("/admin/users_roles/add", headers=_AUTH_HEADERS)
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post("/admin/users_roles/add", form=form,
+                                headers=_AUTH_HEADERS)
+
+    async def test_get_renders_blank_form(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertNotIn("Refresh", text)
+
+    async def test_post_missing_full_name_renders_error(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        form = dict(_VALID_ADD_FORM)
+        del form["full_name"]
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("required", text)
+        self.mock_rest_client.post.assert_called_once()
+
+    async def test_post_missing_display_name_renders_error(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        form = dict(_VALID_ADD_FORM)
+        del form["display_name"]
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        self.mock_rest_client.post.assert_called_once()
+
+    async def test_post_missing_email_renders_error(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        form = dict(_VALID_ADD_FORM)
+        del form["email_address"]
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        self.mock_rest_client.post.assert_called_once()
+
+    async def test_post_short_password_renders_error(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        form = dict(_VALID_ADD_FORM)
+        form["password"] = "short"
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("8 characters", text)
+        self.mock_rest_client.post.assert_called_once()
+
+    async def test_post_conflict_renders_email_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT, body={}),
+        ]
+        response = await self._post(_VALID_ADD_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("already registered", text)
+
+    async def test_post_gateway_error_renders_unexpected_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={}),
+        ]
+        response = await self._post(_VALID_ADD_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("unexpected error", text)
+
+    async def test_post_success_redirects(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 2}),
+        ]
+        response = await self._post(_VALID_ADD_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_redirects_when_not_authenticated(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/add")
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+
+# ---------------------------------------------------------------------------
+# AdminModifyUserPageHandler
+# ---------------------------------------------------------------------------
+
+class TestAdminModifyUserPageHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminModifyUserPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/<int:user_id>/modify", methods=["GET"])
+        async def get_route(user_id: int):
+            return await handler.modify_user_get(user_id)
+
+        @app.route("/admin/users_roles/<int:user_id>/modify", methods=["POST"])
+        async def post_route(user_id: int):
+            return await handler.modify_user_post(user_id)
+
+        self.client = app.test_client()
+
+    async def _get(self, user_id=1):
+        async with self.client as c:
+            return await c.get(f"/admin/users_roles/{user_id}/modify",
+                               headers=_AUTH_HEADERS)
+
+    async def _post(self, form, user_id=1):
+        async with self.client as c:
+            return await c.post(f"/admin/users_roles/{user_id}/modify",
+                                form=form, headers=_AUTH_HEADERS)
+
+    async def test_get_success_pre_populates_form(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Alice Smith", text)
+
+    async def test_get_not_found_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={})
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("not found", text)
+
+    async def test_get_gateway_error_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Could not load", text)
+
+    async def test_post_missing_full_name_renders_error(self):
+        form = dict(_VALID_MODIFY_FORM)
+        del form["full_name"]
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("required", text)
+        self.mock_rest_client.patch.assert_not_called()
+
+    async def test_post_missing_display_name_renders_error(self):
+        form = dict(_VALID_MODIFY_FORM)
+        del form["display_name"]
+        response = await self._post(form)
+        self.assertEqual(response.status_code, 200)
+        self.mock_rest_client.patch.assert_not_called()
+
+    async def test_post_forbidden_renders_last_admin_error(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.FORBIDDEN, body={})
+        response = await self._post(_VALID_MODIFY_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("last active administrator", text)
+
+    async def test_post_not_found_renders_error(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={})
+        response = await self._post(_VALID_MODIFY_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("not found", text)
+
+    async def test_post_gateway_error_renders_unexpected_error(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={})
+        response = await self._post(_VALID_MODIFY_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("unexpected error", text)
+
+    async def test_post_success_redirects(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={})
+        response = await self._post(_VALID_MODIFY_FORM)
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_redirects_when_not_authenticated(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/1/modify")
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+
+# ---------------------------------------------------------------------------
+# AdminResetPasswordPageHandler
+# ---------------------------------------------------------------------------
+
+class TestAdminResetPasswordPageHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminResetPasswordPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/<int:user_id>/reset_password",
+                   methods=["GET"])
+        async def get_route(user_id: int):
+            return await handler.reset_password_get(user_id)
+
+        @app.route("/admin/users_roles/<int:user_id>/reset_password",
+                   methods=["POST"])
+        async def post_route(user_id: int):
+            return await handler.reset_password_post(user_id)
+
+        self.client = app.test_client()
+
+    async def _get(self, user_id=1):
+        async with self.client as c:
+            return await c.get(
+                f"/admin/users_roles/{user_id}/reset_password",
+                headers=_AUTH_HEADERS)
+
+    async def _post(self, form, user_id=1):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/users_roles/{user_id}/reset_password",
+                form=form, headers=_AUTH_HEADERS)
+
+    async def test_get_success_shows_user_context(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Alice Smith", text)
+        self.assertIn("alice@localhost", text)
+
+    async def test_get_user_not_found_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={})
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("not found", text)
+
+    async def test_post_passwords_do_not_match_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        response = await self._post({
+            "new_password": "password1",
+            "confirm_password": "password2"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("do not match", text)
+        self.mock_rest_client.post.assert_called_once()  # only session validate
+
+    async def test_post_password_too_short_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        response = await self._post({
+            "new_password": "short",
+            "confirm_password": "short"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("8 characters", text)
+
+    async def test_post_not_found_renders_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND, body={}),
+        ]
+        response = await self._post({
+            "new_password": "newpassword1",
+            "confirm_password": "newpassword1"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("not found", text)
+
+    async def test_post_gateway_error_renders_unexpected_error(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={}),
+        ]
+        response = await self._post({
+            "new_password": "newpassword1",
+            "confirm_password": "newpassword1"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("unexpected error", text)
+
+    async def test_post_success_redirects(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.OK, body={}),
+        ]
+        response = await self._post({
+            "new_password": "newpassword1",
+            "confirm_password": "newpassword1"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_redirects_when_not_authenticated(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/1/reset_password")
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/web_portal_svc/test_auth_handlers.py
+++ b/unit_tests/web_portal_svc/test_auth_handlers.py
@@ -132,6 +132,14 @@ class TestLoginGetPageHandler(unittest.IsolatedAsyncioTestCase):
                 "/login", headers={"Cookie": "items_token=a; items_user=b"})
         self.assertEqual(response.status_code, 200)
 
+        # A redirect is also served as a 200 (it is a meta-refresh document),
+        # so the status code alone cannot distinguish the login page from a
+        # bounce to '/'. Assert the absence of the refresh explicitly:
+        # stale cookies must land on the login page, not be redirected to a
+        # page that sends them straight back here.
+        text = await response.get_data(as_text=True)
+        self.assertNotIn("Refresh", text)
+
     async def test_validation_exception_renders_internal_error_page(self):
         self.mock_rest_client.post.side_effect = BaseItemsException("boom")
         async with self.client as c:
@@ -170,6 +178,25 @@ class TestLoginPostPageHandler(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         text = await response.get_data(as_text=True)
         self.assertIn("Refresh", text)
+
+    async def test_stale_cookies_do_not_redirect_and_login_proceeds(self):
+        """Submitting the form with stale cookies must not bounce to '/'.
+
+        _validate_cookies returns a (is_valid, is_administrator) tuple. If it
+        is tested directly rather than unpacked it is always truthy - even
+        (False, False) - which redirects the user to '/', where the session
+        guard sends them back to /login, looping indefinitely.
+        """
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"status": "INVALID"})
+
+        response = await self._post(cookies="items_token=a; items_user=b")
+
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertNotIn("Refresh", text)
+        # Fell through to processing the (empty) form rather than redirecting.
+        self.assertIn("Invalid username/password", text)
 
     async def test_validate_exception_renders_internal_error_page(self):
         self.mock_rest_client.post.side_effect = BaseItemsException("boom")

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -48,6 +48,7 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
                 "announcement": "",
                 "show_announcement_on_overview": False,
                 "projects": [],
+                "users": [],
                 "folders": [],
                 "test_cases": [],
             })
@@ -192,6 +193,48 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
         async with self.client as c:
             response = await c.post("/admin/1/modify_project",
                                     form=_VALID_PROJECT_BODY)
+        self.assertNotEqual(response.status_code, 405)
+
+    # ------------------------------------------------------------------
+    # Admin users
+    # ------------------------------------------------------------------
+
+    async def test_admin_add_user_get_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/add")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_add_user_post_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/add",
+                                    form={"full_name": "Alice",
+                                          "display_name": "Alice",
+                                          "email_address": "a@b.com",
+                                          "password": "password1"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_modify_user_get_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/1/modify")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_modify_user_post_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/1/modify",
+                                    form={"full_name": "Alice",
+                                          "display_name": "Alice"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_reset_password_get_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/admin/users_roles/1/reset_password")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_reset_password_post_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/1/reset_password",
+                                    form={"new_password": "password1",
+                                          "confirm_password": "password1"})
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
# Changes — portal_user_management

## Summary

Implements the user management pages in the web portal, allowing administrators
to list, add, edit, and reset passwords for users. Calls the gateway user
management API added in the `identity_user_management` branch. Also fixes an
infinite redirect loop in the login handlers.

---

## Bug fix — infinite redirect loop on login

`LoginGetPageHandler` and `LoginPostPageHandler` both called
`await self._validate_cookies()` and tested the return value directly. Since
`_validate_cookies` returns a `(is_valid, is_administrator)` tuple, a non-empty
tuple is always truthy in Python — including `(False, False)`. This meant users
with stale or invalid cookies were redirected to `/`, where `@require_session`
found them unauthenticated and redirected them back to `/login`, looping
indefinitely.

Fixed by unpacking the tuple and testing `is_valid` explicitly. The
`_validate_cookies` docstring was updated to warn future callers of this
behaviour. Regression tests added to `test_auth_handlers.py` asserting that
invalid cookies land on the login page rather than triggering a redirect.

---

## New — user list page (`/admin/users_roles`)

Updated the existing stub to render a table of all users fetched from the
gateway, showing full name, display name, email address, active/inactive status
badge, and administrator badge. Each row has edit (✏️) and reset password (🔑)
action buttons. An "Add User" button links to the add user page.

---

## New — add user page (`/admin/users_roles/add`)

Three-tab form (User / Access / Projects):

- **User tab** — full name, display name, email address, password (manual
  only; minimum 8 characters). Language, locale, and time zone are shown as
  disabled placeholders pending site settings support. Auto-generate password
  is shown as a disabled option pending email invite support.
- **Access tab** — placeholder for future role configuration.
- **Projects tab** — placeholder for future per-user project access.

On success, redirects to the user list. On conflict (duplicate email) or
validation failure, re-renders the form with an error message.

---

## New — edit user page (`/admin/users_roles/<id>/modify`)

Same three-tab structure as add user, pre-populated from the gateway. Email
address is read-only (changing email is deferred — requires email verification
and session invalidation logic). Includes an active/inactive toggle.

Handles the last-administrator guard (403 from gateway) with a clear error
message. Redirects to the user list on success.

---

## New — reset password page (`/admin/users_roles/<id>/reset_password`)

Simple dedicated page showing the target user's name and email as context.
Two password fields (new password + confirm), both with an 8-character minimum
enforced client- and server-side. Redirects to the user list on success.

Password reset is a separate action from edit (accessible via the 🔑 icon in
the user list) rather than being embedded in the edit form.

---

## New files

- `templates/instance_admin_users_roles.html` — user list (replaces stub)
- `templates/instance_admin_add_user.html`
- `templates/instance_admin_modify_user.html`
- `templates/instance_admin_reset_password.html`
- `static/css/instance_admin_users_roles.css`
- `static/css/instance_admin_add_user.css` (shared by modify and reset pages)
- `page_handlers/admin/users/__init__.py` — route factory
- `page_handlers/admin/users/admin_add_user_page_handler.py`
- `page_handlers/admin/users/admin_modify_user_page_handler.py`
- `page_handlers/admin/users/admin_reset_password_page_handler.py`

## Updated files

- `page_handlers/admin/admin_users_and_roles_page_handler.py` — fetches users
  from gateway and passes to template
- `page_handlers/admin/__init__.py` — registers users sub-blueprint
- `page_locations.py` — four new page constants added

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
