### PR TITLE
[Gateway] Implement user invite

### DIFF
--- a/future.md
+++ b/future.md
@@ -26,16 +26,6 @@ page in the web portal
 does its best with the string it's given and documents the limitation in a
 code comment there.
 
-## ~~CMS: system custom fields can't have partial updates~~ (resolved)
-
-Fixed on `cms_relax_system_field_edit`: `update_custom_field` now allows
-`enabled` and project assignment to change for system fields, while
-`field_name`/`description`/`system_name`/`field_type`/`is_required`/
-`default_value` are silently overridden with the field's current stored
-values regardless of what's submitted (enforced in the service layer, not
-just trusted from the caller). The web portal's Case Fields admin page was
-already built to this exact contract and needed no changes.
-
 ## Docker: SQLite DB can end up read-only inside containers
 
 **Where:** `docker-compose.yml` bind-mounts each service's SQLite file

--- a/future.md
+++ b/future.md
@@ -35,3 +35,49 @@ Fixed on `cms_relax_system_field_edit`: `update_custom_field` now allows
 values regardless of what's submitted (enforced in the service layer, not
 just trusted from the caller). The web portal's Case Fields admin page was
 already built to this exact contract and needed no changes.
+
+## Docker: SQLite DB can end up read-only inside containers
+
+**Where:** `docker-compose.yml` bind-mounts each service's SQLite file
+directly from the host, e.g.
+
+```yaml
+volumes:
+  - "${ITEMS_DOCKER_IDENTITY_SVC_DB_FILE}:/usr/local/items/identity.db"
+```
+
+but the corresponding Dockerfiles (`docker/Dockerfile.identity_svc`,
+`docker/Dockerfile.cms_svc` — likely all of them, same template) run the
+service as a non-root `items` user:
+
+```dockerfile
+RUN addgroup -S items && adduser -S items -G items && \
+    mkdir /usr/local/items && chown items:items /usr/local/items
+...
+USER items
+```
+
+**Problem:** `chown items:items` only applies to the image's baked-in
+filesystem at build time. A bind-mounted file's ownership/permissions come
+from the *host* at runtime and can overlay right past that — if the host
+file's owner/mode doesn't happen to be writable by the container's `items`
+UID, SQLite opens it read-only and every write fails. Hit in practice
+during manual testing of `gateway_user_invite` against the identity
+container on devbox.
+
+**Fix (not attempted yet, needs a design call):** a few standard options,
+roughly in order of how much they change the setup:
+- Quick/fragile: just ensure the host DB file is `chmod`-ed writable by
+  whatever UID the container's `items` user ends up with.
+- Docker-native: switch from a host bind-mount to a named Docker volume for
+  the DB file — Docker manages ownership for named volumes consistently
+  from the container side, sidestepping host UID/GID mismatches entirely.
+- Most robust: add an entrypoint script that runs as root, `chown`/`chmod`s
+  the mounted DB path to match `items`, then drops privileges (`gosu`/
+  `su-exec`) before exec-ing the actual service — works regardless of host
+  UID, standard pattern for this exact class of problem, but adds
+  complexity (an entrypoint script per service).
+
+Affects `identity_svc` and `cms_svc` for certain (identical bind-mount +
+non-root-user pattern in both); worth checking `web_portal_svc` and
+`gateway_svc` too if either persists local state the same way.

--- a/items/services/items_gateway/routes/web/__init__.py
+++ b/items/services/items_gateway/routes/web/__init__.py
@@ -16,6 +16,8 @@ limitations under the License.
 """
 import quart
 from items.services.items_gateway.route_injections import RouteInjections
+from items.services.items_gateway.routes.web.invites import (
+    create_invite_routes)
 from items.services.items_gateway.routes.web.projects import (
     create_projects_routes)
 from items.services.items_gateway.routes.web.sessions import (
@@ -45,6 +47,9 @@ def create_web_routes(injections: RouteInjections) -> quart.Blueprint:
     routes_bp = quart.Blueprint("api_routes", __name__)
 
     injections.logger.debug("|--- Registering WEB routes ---|")
+
+    # Register invite routes.
+    routes_bp.register_blueprint(create_invite_routes(injections))
 
     # Register projects routes.
     routes_bp.register_blueprint(create_projects_routes(

--- a/items/services/items_gateway/routes/web/invites/__init__.py
+++ b/items/services/items_gateway/routes/web/invites/__init__.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from quart import Blueprint
+from items.services.items_gateway.route_injections import RouteInjections
+from items.services.items_gateway.routes.web.invites.create_invite_handler import (
+    CreateInviteHandler)
+from items.services.items_gateway.routes.web.invites.resend_invite_handler import (
+    ResendInviteHandler)
+from items.services.items_gateway.routes.web.invites.uninvite_handler import (
+    UninviteHandler)
+
+
+def create_invite_routes(injections: RouteInjections) -> Blueprint:
+    """Create the Blueprint containing invite management web routes.
+
+    All routes are admin-only and must be enforced at this layer or by the
+    caller (the web portal, which checks ``is_administrator`` before calling).
+
+    Registered routes:
+        POST /invites              Create a new pending invite.
+        POST /invites/resend       Refresh token and expiry on an existing invite.
+        POST /invites/uninvite     Cancel (soft-expire) a pending invite.
+
+    Args:
+        injections: Shared application dependencies.
+
+    Returns:
+        A configured Quart Blueprint.
+    """
+    routes = Blueprint('invites_routes', __name__)
+
+    handler_create = CreateInviteHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_resend = ResendInviteHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_uninvite = UninviteHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+
+    injections.logger.debug(" Invites WEB routes:")
+
+    injections.logger.debug("=> %s POST /web/invites",
+                            "Create invite".ljust(40))
+
+    @routes.route('/invites', methods=['POST'])
+    async def create_invite_request():
+        return await handler_create.create_invite()
+
+    injections.logger.debug("=> %s POST /web/invites/resend",
+                            "Resend invite".ljust(40))
+
+    @routes.route('/invites/resend', methods=['POST'])
+    async def resend_invite_request():
+        return await handler_resend.resend_invite()
+
+    injections.logger.debug("=> %s POST /web/invites/uninvite",
+                            "Uninvite".ljust(40))
+
+    @routes.route('/invites/uninvite', methods=['POST'])
+    async def uninvite_request():
+        return await handler_uninvite.uninvite()
+
+    return routes

--- a/items/services/items_gateway/routes/web/invites/create_invite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/create_invite_handler.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class CreateInviteHandler(BaseApiRoute):
+    """Handles POST /invites — create a new user invite.
+
+    Proxies the request body to the identity service and propagates the
+    response. Schema validation is performed by the identity service;
+    invalid payloads will receive a 400 response propagated from there.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def create_invite(self) -> Response:
+        """Create a new pending invite for an email address.
+
+        Returns:
+            201 with ``{"token": <uuid>}`` on success.
+            400 if the request body is missing or not valid JSON.
+            409 if the email is already registered or already has a
+            pending invite.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = f"{self._configuration.apis_identity_svc}invites"
+        response: ApiResponse = await self._rest_client.post(url,
+                                                              json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.body is not None and not isinstance(response.body, dict):
+            # The identity service responded, but not with JSON - e.g. a
+            # generic web-server error page, meaning the route doesn't exist
+            # there (stale deployment, wrong version) rather than a real API
+            # response. Forwarding it as-is would mislabel raw HTML as JSON.
+            self._logger.error(
+                "Identity service returned a non-JSON response (status %s, "
+                "content-type %s) for %s",
+                response.status_code, response.content_type, url)
+            return Response(
+                json.dumps({"error": "Identity service returned an "
+                                     "unexpected response"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/invites/resend_invite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/resend_invite_handler.py
@@ -1,0 +1,88 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class ResendInviteHandler(BaseApiRoute):
+    """Handles POST /invites/resend — refresh token and expiry on a
+    pending invite.
+
+    Proxies the request body to the identity service and propagates the
+    response. Schema validation is performed by the identity service;
+    invalid payloads will receive a 400 response propagated from there.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def resend_invite(self) -> Response:
+        """Refresh the invite token and expiry for a pending invite.
+
+        Returns:
+            200 with ``{"token": <new_uuid>}`` on success.
+            400 if the request body is missing or not valid JSON.
+            404 if no pending invite exists for the email address.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = f"{self._configuration.apis_identity_svc}invites/resend"
+        response: ApiResponse = await self._rest_client.post(url,
+                                                              json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.body is not None and not isinstance(response.body, dict):
+            # The identity service responded, but not with JSON - e.g. a
+            # generic web-server error page, meaning the route doesn't exist
+            # there (stale deployment, wrong version) rather than a real API
+            # response. Forwarding it as-is would mislabel raw HTML as JSON.
+            self._logger.error(
+                "Identity service returned a non-JSON response (status %s, "
+                "content-type %s) for %s",
+                response.status_code, response.content_type, url)
+            return Response(
+                json.dumps({"error": "Identity service returned an "
+                                     "unexpected response"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/invites/uninvite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/uninvite_handler.py
@@ -1,0 +1,87 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class UninviteHandler(BaseApiRoute):
+    """Handles POST /invites/uninvite — cancel a pending invite.
+
+    Proxies the request body to the identity service and propagates the
+    response. Schema validation is performed by the identity service;
+    invalid payloads will receive a 400 response propagated from there.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def uninvite(self) -> Response:
+        """Cancel a pending invite by soft-expiring it.
+
+        Returns:
+            200 on success.
+            400 if the request body is missing or not valid JSON.
+            404 if no pending invite exists for the email address.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = f"{self._configuration.apis_identity_svc}invites/uninvite"
+        response: ApiResponse = await self._rest_client.post(url,
+                                                              json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.body is not None and not isinstance(response.body, dict):
+            # The identity service responded, but not with JSON - e.g. a
+            # generic web-server error page, meaning the route doesn't exist
+            # there (stale deployment, wrong version) rather than a real API
+            # response. Forwarding it as-is would mislabel raw HTML as JSON.
+            self._logger.error(
+                "Identity service returned a non-JSON response (status %s, "
+                "content-type %s) for %s",
+                response.status_code, response.content_type, url)
+            return Response(
+                json.dumps({"error": "Identity service returned an "
+                                     "unexpected response"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 1
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 5"
+PRE_RELEASE = "Alpha Build 6"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -1459,6 +1459,94 @@
               ]
             },
             {
+              "name": "Invites",
+              "item": [
+                {
+                  "name": "Create Invite",
+                  "request": {
+                    "method": "POST",
+                    "header": [],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/invites",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "invites"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Resend Invite",
+                  "request": {
+                    "method": "POST",
+                    "header": [],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/invites/resend",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "invites",
+                        "resend"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Uninvite",
+                  "request": {
+                    "method": "POST",
+                    "header": [],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/invites/uninvite",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "invites",
+                        "uninvite"
+                      ]
+                    }
+                  },
+                  "response": []
+                }
+              ]
+            },
+            {
               "name": "Users",
               "item": [
                 {

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -49,6 +49,11 @@ from test_users_handlers import (
     TestResetPasswordHandler,
     TestResetPasswordHandlerEmail,
 )
+from test_invites_handlers import (
+    TestCreateInviteHandler,
+    TestResendInviteHandler,
+    TestUninviteHandler,
+)
 from test_email_service import (
     TestEmailServiceAbstract,
     TestSmtpEmailServiceInit,

--- a/unit_tests/items_gateway/test_invites_handlers.py
+++ b/unit_tests/items_gateway/test_invites_handlers.py
@@ -95,6 +95,17 @@ class TestCreateInviteHandler(unittest.IsolatedAsyncioTestCase):
         resp = await self._post(_EMAIL_BODY)
         self.assertEqual(resp.status_code, 500)
 
+    async def test_non_json_downstream_response_returns_500(self):
+        # e.g. a stale identity deployment serving its own generic HTML
+        # error page for a route it doesn't have.
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=404, body="<!doctype html><h1>Not Found</h1>",
+            content_type="text/html")
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+        body = json.loads(await resp.get_data())
+        self.assertIn("unexpected response", body["error"])
+
     async def test_response_is_json(self):
         self.mock_rc.post.return_value = ApiResponse(
             status_code=201, body={"token": "abc123"})
@@ -157,6 +168,15 @@ class TestResendInviteHandler(unittest.IsolatedAsyncioTestCase):
         resp = await self._post(_EMAIL_BODY)
         self.assertEqual(resp.status_code, 500)
 
+    async def test_non_json_downstream_response_returns_500(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=404, body="<!doctype html><h1>Not Found</h1>",
+            content_type="text/html")
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+        body = json.loads(await resp.get_data())
+        self.assertIn("unexpected response", body["error"])
+
 
 # ---------------------------------------------------------------------------
 # UninviteHandler
@@ -208,6 +228,15 @@ class TestUninviteHandler(unittest.IsolatedAsyncioTestCase):
         self.mock_rc.post.return_value = _conn_err()
         resp = await self._post(_EMAIL_BODY)
         self.assertEqual(resp.status_code, 500)
+
+    async def test_non_json_downstream_response_returns_500(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=404, body="<!doctype html><h1>Not Found</h1>",
+            content_type="text/html")
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+        body = json.loads(await resp.get_data())
+        self.assertIn("unexpected response", body["error"])
 
 
 if __name__ == "__main__":

--- a/unit_tests/items_gateway/test_invites_handlers.py
+++ b/unit_tests/items_gateway/test_invites_handlers.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for gateway invite management route handlers:
+  POST /invites            - CreateInviteHandler
+  POST /invites/resend     - ResendInviteHandler
+  POST /invites/uninvite   - UninviteHandler
+"""
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.invites.create_invite_handler import (
+    CreateInviteHandler)
+from items.services.items_gateway.routes.web.invites.resend_invite_handler import (
+    ResendInviteHandler)
+from items.services.items_gateway.routes.web.invites.uninvite_handler import (
+    UninviteHandler)
+
+_LOGGER = MagicMock()
+_EMAIL_BODY = {"email_address": "newuser@example.com"}
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_identity_svc = "http://identity/"
+    return cfg
+
+
+def _err(body, status=500):
+    return ApiResponse(status_code=status, body=body)
+
+
+def _conn_err():
+    return ApiResponse(status_code=None, exception_msg="connection refused")
+
+
+# ---------------------------------------------------------------------------
+# CreateInviteHandler
+# ---------------------------------------------------------------------------
+
+class TestCreateInviteHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = CreateInviteHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/invites", methods=["POST"])
+        async def route():
+            return await handler.create_invite()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/invites", json=body)
+
+    async def test_success_returns_201_with_token(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"token": "abc123"})
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 201)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["token"], "abc123")
+
+    async def test_body_forwarded_to_identity(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"token": "abc123"})
+        await self._post(_EMAIL_BODY)
+        args, kwargs = self.mock_rc.post.call_args
+        self.assertEqual(args[0], "http://identity/invites")
+        self.assertEqual(kwargs["json_data"], _EMAIL_BODY)
+
+    async def test_already_registered_409_is_propagated(self):
+        self.mock_rc.post.return_value = _err(
+            {"error": "Email address is already registered"}, 409)
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 409)
+
+    async def test_already_invited_409_is_propagated(self):
+        self.mock_rc.post.return_value = _err(
+            {"error": "A pending invite already exists for this email"}, 409)
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 409)
+
+    async def test_missing_body_returns_400(self):
+        async with self.client as c:
+            resp = await c.post("/invites", data="not json",
+                                headers={"Content-Type": "text/plain"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.post.return_value = _conn_err()
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"token": "abc123"})
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# ResendInviteHandler
+# ---------------------------------------------------------------------------
+
+class TestResendInviteHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = ResendInviteHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/invites/resend", methods=["POST"])
+        async def route():
+            return await handler.resend_invite()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/invites/resend", json=body)
+
+    async def test_success_returns_200_with_new_token(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=200, body={"token": "new-token"})
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["token"], "new-token")
+
+    async def test_body_forwarded_to_identity(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=200, body={"token": "new-token"})
+        await self._post(_EMAIL_BODY)
+        args, kwargs = self.mock_rc.post.call_args
+        self.assertEqual(args[0], "http://identity/invites/resend")
+        self.assertEqual(kwargs["json_data"], _EMAIL_BODY)
+
+    async def test_no_pending_invite_404_is_propagated(self):
+        self.mock_rc.post.return_value = _err(
+            {"error": "No pending invite found for this email address"}, 404)
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_missing_body_returns_400(self):
+        async with self.client as c:
+            resp = await c.post("/invites/resend", data="not json",
+                                headers={"Content-Type": "text/plain"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.post.return_value = _conn_err()
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+
+
+# ---------------------------------------------------------------------------
+# UninviteHandler
+# ---------------------------------------------------------------------------
+
+class TestUninviteHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = UninviteHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/invites/uninvite", methods=["POST"])
+        async def route():
+            return await handler.uninvite()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/invites/uninvite", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_rc.post.return_value = ApiResponse(status_code=200, body={})
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_body_forwarded_to_identity(self):
+        self.mock_rc.post.return_value = ApiResponse(status_code=200, body={})
+        await self._post(_EMAIL_BODY)
+        args, kwargs = self.mock_rc.post.call_args
+        self.assertEqual(args[0], "http://identity/invites/uninvite")
+        self.assertEqual(kwargs["json_data"], _EMAIL_BODY)
+
+    async def test_no_pending_invite_404_is_propagated(self):
+        self.mock_rc.post.return_value = _err(
+            {"error": "No pending invite found for this email address"}, 404)
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_missing_body_returns_400(self):
+        async with self.client as c:
+            resp = await c.post("/invites/uninvite", data="not json",
+                                headers={"Content-Type": "text/plain"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.post.return_value = _conn_err()
+        resp = await self._post(_EMAIL_BODY)
+        self.assertEqual(resp.status_code, 500)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_gateway/test_route_factories.py
+++ b/unit_tests/items_gateway/test_route_factories.py
@@ -224,6 +224,28 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
+    # Invites routes (routes/web/invites/__init__.py)
+    # ------------------------------------------------------------------
+
+    async def test_create_invite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/web/invites", json={"email_address": "a@b.com"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_resend_invite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/web/invites/resend", json={"email_address": "a@b.com"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_uninvite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/web/invites/uninvite", json={"email_address": "a@b.com"})
+        self.assertNotEqual(response.status_code, 405)
+
+    # ------------------------------------------------------------------
     # Webhook routes (routes/web/webhook/__init__.py)
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
# Gateway: user invite routes

**Branch:** `gateway_user_invite` → `main`
**Stats:** 3 commits + `future.md` still uncommitted — 10 files changed, +747
(`future.md` isn't staged yet — worth a `git add` before/alongside the PR,
same as the other loose docs files on this repo's PRs)

## Summary

Exposes the identity service's invite system (`identity_user_invite_initial`,
already merged) through the Gateway, following the "later PR" the identity
branch explicitly deferred. Three thin proxy endpoints, mirroring the
existing `routes/web/users/create_user_handler.py` style rather than the
more elaborate per-status-branch style used elsewhere: forward the request
body as-is, pass through whatever status/body the identity service returns,
500 on a connection failure or a non-JSON downstream response. No new
logic to get wrong — the identity service already returns the right status
codes and error bodies for anything it actually recognises.

## New: invite routes
`items/services/items_gateway/routes/web/invites/`

| Method | Path | Notes |
|---|---|---|
| POST | `/web/invites` | body: `{"email_address": ...}`; 201 + `{"token"}` on success, 409 if already registered/invited (propagated from identity), 500 if identity unreachable |
| POST | `/web/invites/resend` | 200 + `{"token"}` on success, 404 if no pending invite |
| POST | `/web/invites/uninvite` | 200 on success, 404 if no pending invite |

`CreateInviteHandler` / `ResendInviteHandler` / `UninviteHandler` each parse
the JSON body themselves (400 on invalid/missing JSON, matching
`create_user_handler.py`) rather than using the `@validate_json` schema
decorator — schema validation already happens identity-side, so this avoids
duplicating the schema in two places.

Wired into `routes/web/__init__.py` alongside the existing projects/
sessions/testcases/users/webhook blueprints.

## Bugfix found during manual testing: non-JSON downstream responses

Manual testing against a stale identity deployment (a Docker container built
before the invite routes existed) surfaced a real gap: `weaver_framework`'s
`RestClient` only sets `exception_msg` on a transport-level failure — if the
downstream server responds at all, even with a generic HTML error page
(`content_type="text/html"`), `response.body` is just the raw HTML string
and `exception_msg` stays `None`. The original handlers only checked
`exception_msg`, so they happily `json.dumps()`'d that raw HTML string and
forwarded it as a "successful" JSON response with the downstream's status
code — producing a deeply confusing response that looked like it came from
our own JSON API but was actually a wrapped error page.

All three handlers now also check whether `response.body` is a dict (or
`None`) and treat anything else — i.e. a non-JSON body — as an unexpected
response from identity, logging the real status/content-type and returning
a clean `500 {"error": "Identity service returned an unexpected response"}`
instead. Same weakness likely exists in other Gateway proxy handlers built
on this pattern (e.g. `create_user_handler.py`); not touched here since
it's out of scope for this branch, but worth a follow-up sweep.

## Postman collection
`postman/ITEMS.postman_collection.json`

Added a **Gateway Service → Web → Invites** folder mirroring the existing
Identity Service one (Create Invite / Resend Invite / Uninvite, same
`{"email_address": "newuser@localhost"}` body), positioned right before
Users. Spliced in as raw text rather than a full JSON re-serialize, to
avoid reformatting unrelated pre-existing entries elsewhere in the file
(some of which use compact rather than pretty-printed JSON) — clean
88-line diff.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

Handler tests mock the REST client and cover every branch (success, each
propagated error status, missing/invalid JSON body, connection failure,
non-JSON downstream response); a route-wiring test confirms all three
endpoints are reachable through the real blueprint tree.

**100% line coverage maintained across the entire Gateway suite**
(1401/1401 statements, 257 tests) — not just the new files. Pylint: 10.00/10.

## Not in this branch

Web Portal integration (a UI for inviting users, on the Users &
Roles admin page) is separate follow-up work, not started here.

Manual testing also surfaced a Docker issue unrelated to this branch's
code: the identity/CMS containers' SQLite files can end up read-only,
because `docker-compose.yml` bind-mounts them straight from the host while
the Dockerfiles run as a non-root `items` user — the container's `chown`
never touches a runtime bind mount. Root cause and candidate fixes (named
volume vs. entrypoint privilege-drop) written up in `future.md`; not
attempted here.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
