### PR TITLE
[Identity Gateway] User invites list routes

### DIFF
--- a/future.md
+++ b/future.md
@@ -71,3 +71,31 @@ roughly in order of how much they change the setup:
 Affects `identity_svc` and `cms_svc` for certain (identical bind-mount +
 non-root-user pattern in both); worth checking `web_portal_svc` and
 `gateway_svc` too if either persists local state the same way.
+
+## Gateway: health check doesn't verify *which* service answered
+
+**Where:** `Service._identity_svc_health_check` /
+`_check_cms_svc_status` in `items_gateway/service.py` — each just GETs
+`<configured_url>/system/health` and validates the response body against
+a JSON schema (`SCHEMA_IDENTITY_SVC_HEALTH_RESPONSE` /
+`SCHEMA_CMS_SVC_HEALTH_RESPONSE`).
+
+**Problem:** those two schemas are nearly identical (`status`,
+`dependencies`, `uptime_seconds`, `version` — CMS's is a strict subset of
+Identity's). Neither includes anything identifying which service actually
+produced the response. If a misconfigured port/URL means the Gateway ends
+up talking to the wrong backend (e.g. CMS reachable on the port meant for
+Identity), the health check would validate successfully and the Gateway
+would treat the wrong service as healthy and proceed - the mismatch would
+only surface later, confusingly, when an actual request 404s or behaves
+oddly (this is close to what caused the multi-message stale-container
+confusion earlier in the invite work, just via a different mechanism).
+
+**Fix:** add a required `service` field (a string, e.g. `"identity"` /
+`"cms"` / `"gateway"` / `"web_portal"`) to the shared health-check schema
+and response, and have the Gateway check it matches the service it thinks
+it's talking to - fail the health check (rather than silently proceeding)
+if it doesn't. Touches the shared schema
+(`items/shared/interfaces/*/health.py`) and every service's own health
+handler, not just the Gateway, so this is a coordinated change across all
+services rather than a Gateway-only fix.

--- a/items/services/items_gateway/routes/web/invites/__init__.py
+++ b/items/services/items_gateway/routes/web/invites/__init__.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 from quart import Blueprint
 from items.services.items_gateway.route_injections import RouteInjections
+from items.services.items_gateway.routes.web.invites.get_invites_handler import (
+    GetInvitesHandler)
 from items.services.items_gateway.routes.web.invites.create_invite_handler import (
     CreateInviteHandler)
 from items.services.items_gateway.routes.web.invites.resend_invite_handler import (
@@ -30,6 +32,7 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
     caller (the web portal, which checks ``is_administrator`` before calling).
 
     Registered routes:
+        GET  /invites              List all pending invites.
         POST /invites              Create a new pending invite.
         POST /invites/resend       Refresh token and expiry on an existing invite.
         POST /invites/uninvite     Cancel (soft-expire) a pending invite.
@@ -40,8 +43,12 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
     Returns:
         A configured Quart Blueprint.
     """
+    # pylint: disable=too-many-locals
+
     routes = Blueprint('invites_routes', __name__)
 
+    handler_get = GetInvitesHandler(
+        injections.logger, injections.configuration, injections.rest_client)
     handler_create = CreateInviteHandler(
         injections.logger, injections.configuration, injections.rest_client)
     handler_resend = ResendInviteHandler(
@@ -50,6 +57,13 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
         injections.logger, injections.configuration, injections.rest_client)
 
     injections.logger.debug(" Invites WEB routes:")
+
+    injections.logger.debug("=> %s GET  /web/invites",
+                            "List pending invites".ljust(40))
+
+    @routes.route('/invites', methods=['GET'])
+    async def get_invites_request():
+        return await handler_get.get_invites()
 
     injections.logger.debug("=> %s POST /web/invites",
                             "Create invite".ljust(40))

--- a/items/services/items_gateway/routes/web/invites/get_invites_handler.py
+++ b/items/services/items_gateway/routes/web/invites/get_invites_handler.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class GetInvitesHandler(BaseApiRoute):
+    """Handles GET /invites — list all pending invites.
+
+    Proxies the request to the identity service and propagates the
+    response.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def get_invites(self) -> Response:
+        """Return every pending invite.
+
+        Returns:
+            200 with ``{"invites": [...]}`` on success.
+            500 if the identity service is unreachable or returns an
+            unexpected (non-JSON) response.
+        """
+        url: str = f"{self._configuration.apis_identity_svc}invites"
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.body is not None and not isinstance(response.body, dict):
+            # The identity service responded, but not with JSON - e.g. a
+            # generic web-server error page, meaning the route doesn't exist
+            # there (stale deployment, wrong version) rather than a real API
+            # response. Forwarding it as-is would mislabel raw HTML as JSON.
+            self._logger.error(
+                "Identity service returned a non-JSON response (status %s, "
+                "content-type %s) for %s",
+                response.status_code, response.content_type, url)
+            return Response(
+                json.dumps({"error": "Identity service returned an "
+                                     "unexpected response"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_identity/data_access/invite_repository.py
+++ b/items/services/items_identity/data_access/invite_repository.py
@@ -44,6 +44,13 @@ class InviteRepository:
         "FROM user_invite "
         "WHERE email_address = ? AND is_expired = 0")
 
+    GET_PENDING_INVITES_QUERY: str = (
+        "SELECT id, token, email_address, created_at, expires_at, "
+        "is_expired, expired_at "
+        "FROM user_invite "
+        "WHERE is_expired = 0 "
+        "ORDER BY created_at")
+
     INSERT_INVITE_QUERY: str = (
         "INSERT INTO user_invite (token, email_address, created_at, expires_at) "
         "VALUES(?, ?, ?, ?)")
@@ -99,6 +106,16 @@ class InviteRepository:
         """
         return await self._db.run_query(
             self.GET_INVITE_BY_EMAIL_QUERY, (email_address,), fetch_one=True)
+
+    async def get_pending_invites(self) -> list[tuple]:
+        """Fetch every pending (not yet expired or cancelled) invite.
+
+        Returns:
+            A list of 7-field row tuples, ordered by creation time, oldest
+            first. Empty if there are no pending invites.
+        """
+        rows = await self._db.run_query(self.GET_PENDING_INVITES_QUERY, ())
+        return rows or []
 
     async def create_invite(self,
                             token: str,

--- a/items/services/items_identity/routes/invites/__init__.py
+++ b/items/services/items_identity/routes/invites/__init__.py
@@ -17,6 +17,7 @@ import logging
 import quart
 from items.services.items_identity.identity_configuration import (
     IdentityConfiguration)
+from .get_invites_handler import GetInvitesHandler
 from .create_invite_handler import CreateInviteHandler
 from .resend_invite_handler import ResendInviteHandler
 from .uninvite_handler import UninviteHandler
@@ -28,6 +29,7 @@ def create_invite_routes(logger: logging.Logger,
 
     Registered routes:
 
+    * ``GET  /invites``           - List all pending invites.
     * ``POST /invites``          - Create a new pending invite.
     * ``POST /invites/resend``   - Refresh token and expiry on an existing invite.
     * ``POST /invites/uninvite`` - Cancel (soft-expire) a pending invite.
@@ -41,12 +43,15 @@ def create_invite_routes(logger: logging.Logger,
     """
     invite_routes = quart.Blueprint("invite_routes", __name__)
 
+    handler_get = GetInvitesHandler(logger, config)
     handler_create = CreateInviteHandler(logger, config)
     handler_resend = ResendInviteHandler(logger, config)
     handler_uninvite = UninviteHandler(logger, config)
 
     logger.debug("Registering Invite API routes:")
 
+    logger.debug("=> %s GET  /invites",
+                 "List pending invites".ljust(40))
     logger.debug("=> %s POST /invites",
                  "Create invite".ljust(40))
     logger.debug("=> %s POST /invites/resend",
@@ -55,6 +60,10 @@ def create_invite_routes(logger: logging.Logger,
                  "Uninvite".ljust(40))
 
     # pylint: disable=no-value-for-parameter
+
+    @invite_routes.route('/invites', methods=['GET'])
+    async def get_invites_request():
+        return await handler_get.get_invites()
 
     @invite_routes.route('/invites', methods=['POST'])
     async def create_invite_request():

--- a/items/services/items_identity/routes/invites/get_invites_handler.py
+++ b/items/services/items_identity/routes/invites/get_invites_handler.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.invite_repository import (
+    InviteRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.invite_management_service import (
+    InviteManagementService)
+
+
+class GetInvitesHandler(BaseApiRoute):
+    """Handles GET /invites — list all pending invites."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        invite_repo = InviteRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        self._service = InviteManagementService(
+            self._logger, invite_repo, user_repo)
+
+    async def get_invites(self) -> Response:
+        """Return every pending invite.
+
+        Returns:
+            200 with ``{"invites": [{"email_address", "created_at",
+            "expires_at"}, ...]}``, ordered by creation time (oldest
+            first). Always 200 - an empty pending-invite list is not an
+            error condition.
+        """
+        invites = await self._service.get_pending_invites()
+
+        return Response(
+            json.dumps({"invites": [
+                {"email_address": invite.email_address,
+                 "created_at": invite.created_at,
+                 "expires_at": invite.expires_at}
+                for invite in invites
+            ]}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/services/invite_management_service.py
+++ b/items/services/items_identity/services/invite_management_service.py
@@ -73,6 +73,21 @@ class InviteUninviteResult:
     status: InviteUninviteStatus
 
 
+@dataclass
+class PendingInvite:
+    """A single pending invite, as exposed to API callers.
+
+    Deliberately excludes the invite ``token`` - it's a secret embedded in
+    the invite email link, not needed by anything a list view does
+    (resend/uninvite act on ``email_address``), so there's no reason to
+    expose it over a general listing endpoint.
+    """
+
+    email_address: str
+    created_at: int
+    expires_at: int
+
+
 class InviteManagementService:
     """Business logic for user invite lifecycle management.
 
@@ -101,6 +116,20 @@ class InviteManagementService:
         self._logger = logger.getChild(type(self).__name__)
         self._invite_repo = invite_repo
         self._user_repo = user_repo
+
+    async def get_pending_invites(self) -> list[PendingInvite]:
+        """Return every pending (not yet expired or cancelled) invite.
+
+        Returns:
+            A list of :class:`PendingInvite`, ordered by creation time,
+            oldest first. Empty if there are no pending invites.
+        """
+        rows = await self._invite_repo.get_pending_invites()
+        return [
+            PendingInvite(email_address=row[2], created_at=row[3],
+                         expires_at=row[4])
+            for row in rows
+        ]
 
     async def create_invite(self, email_address: str) -> InviteCreateResult:
         """Create a new pending invite for an email address.

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 1
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 6"
+PRE_RELEASE = "Alpha Build 7"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -624,6 +624,23 @@
           "name": "Invites",
           "item": [
             {
+              "name": "List Invites",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/invites",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "invites"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
               "name": "Create Invite",
               "request": {
                 "method": "POST",
@@ -1461,6 +1478,24 @@
             {
               "name": "Invites",
               "item": [
+                {
+                  "name": "List Invites",
+                  "request": {
+                    "method": "GET",
+                    "header": [],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/invites",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "invites"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
                 {
                   "name": "Create Invite",
                   "request": {

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -50,6 +50,7 @@ from test_users_handlers import (
     TestResetPasswordHandlerEmail,
 )
 from test_invites_handlers import (
+    TestGetInvitesHandler,
     TestCreateInviteHandler,
     TestResendInviteHandler,
     TestUninviteHandler,

--- a/unit_tests/items_gateway/test_invites_handlers.py
+++ b/unit_tests/items_gateway/test_invites_handlers.py
@@ -1,5 +1,6 @@
 """
 Unit tests for gateway invite management route handlers:
+  GET  /invites            - GetInvitesHandler
   POST /invites            - CreateInviteHandler
   POST /invites/resend     - ResendInviteHandler
   POST /invites/uninvite   - UninviteHandler
@@ -9,6 +10,8 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 from quart import Quart
 from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.invites.get_invites_handler import (
+    GetInvitesHandler)
 from items.services.items_gateway.routes.web.invites.create_invite_handler import (
     CreateInviteHandler)
 from items.services.items_gateway.routes.web.invites.resend_invite_handler import (
@@ -32,6 +35,59 @@ def _err(body, status=500):
 
 def _conn_err():
     return ApiResponse(status_code=None, exception_msg="connection refused")
+
+
+# ---------------------------------------------------------------------------
+# GetInvitesHandler
+# ---------------------------------------------------------------------------
+
+class TestGetInvitesHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = GetInvitesHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/invites", methods=["GET"])
+        async def route():
+            return await handler.get_invites()
+
+        self.client = app.test_client()
+
+    async def _get(self):
+        async with self.client as c:
+            return await c.get("/invites")
+
+    async def test_success_returns_200_with_invites(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=200, body={"invites": [
+                {"email_address": "a@b.com", "created_at": 1,
+                 "expires_at": 2}]})
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(len(body["invites"]), 1)
+
+    async def test_request_forwarded_to_identity(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=200, body={"invites": []})
+        await self._get()
+        args, _kwargs = self.mock_rc.get.call_args
+        self.assertEqual(args[0], "http://identity/invites")
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.get.return_value = _conn_err()
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_non_json_downstream_response_returns_500(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=404, body="<!doctype html><h1>Not Found</h1>",
+            content_type="text/html")
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 500)
+        body = json.loads(await resp.get_data())
+        self.assertIn("unexpected response", body["error"])
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/items_gateway/test_route_factories.py
+++ b/unit_tests/items_gateway/test_route_factories.py
@@ -227,6 +227,11 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     # Invites routes (routes/web/invites/__init__.py)
     # ------------------------------------------------------------------
 
+    async def test_get_invites_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/web/invites")
+        self.assertNotEqual(response.status_code, 405)
+
     async def test_create_invite_route_is_reachable(self):
         async with self.client as c:
             response = await c.post(

--- a/unit_tests/items_identity/main.py
+++ b/unit_tests/items_identity/main.py
@@ -19,6 +19,7 @@ from test_apis_user_management import (
     TestChangePasswordHandler,
 )
 from test_apis_invite_management import (
+    TestGetInvitesHandler,
     TestCreateInviteHandler,
     TestResendInviteHandler,
     TestUninviteHandler,

--- a/unit_tests/items_identity/test_apis_invite_management.py
+++ b/unit_tests/items_identity/test_apis_invite_management.py
@@ -9,10 +9,12 @@ import json
 import logging
 from http import HTTPStatus
 from unittest.mock import patch, MagicMock, AsyncMock
+from routes.invites.get_invites_handler import GetInvitesHandler
 from routes.invites.create_invite_handler import CreateInviteHandler
 from routes.invites.resend_invite_handler import ResendInviteHandler
 from routes.invites.uninvite_handler import UninviteHandler
 from items.services.items_identity.services.invite_management_service import (
+    PendingInvite,
     InviteCreateResult,
     InviteCreateStatus,
     InviteResendResult,
@@ -70,6 +72,52 @@ def _make_handler_setup(handler_cls, module_name: str):
         self.handler = handler_cls(self.mock_logger, self.mock_config)
 
     return asyncSetUp
+
+
+# ---------------------------------------------------------------------------
+# GetInvitesHandler
+# ---------------------------------------------------------------------------
+
+class TestGetInvitesHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(GetInvitesHandler, "get_invites_handler")
+
+    async def _call(self):
+        app = _make_app()
+        async with app.app_context():
+            return await self.handler.get_invites()
+
+    async def test_success_returns_200(self):
+        self.mock_svc.get_pending_invites = AsyncMock(return_value=[])
+        response = await self._call()
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_empty_list_returns_empty_invites(self):
+        self.mock_svc.get_pending_invites = AsyncMock(return_value=[])
+        response = await self._call()
+        body = json.loads(await response.get_data())
+        self.assertEqual(body["invites"], [])
+
+    async def test_returns_invites_from_service(self):
+        self.mock_svc.get_pending_invites = AsyncMock(return_value=[
+            PendingInvite(email_address=_EMAIL, created_at=1700000000,
+                         expires_at=1700172800),
+        ])
+        response = await self._call()
+        body = json.loads(await response.get_data())
+        self.assertEqual(len(body["invites"]), 1)
+        self.assertEqual(body["invites"][0]["email_address"], _EMAIL)
+        self.assertEqual(body["invites"][0]["created_at"], 1700000000)
+        self.assertEqual(body["invites"][0]["expires_at"], 1700172800)
+
+    async def test_token_not_exposed_in_response(self):
+        self.mock_svc.get_pending_invites = AsyncMock(return_value=[
+            PendingInvite(email_address=_EMAIL, created_at=1700000000,
+                         expires_at=1700172800),
+        ])
+        response = await self._call()
+        body = json.loads(await response.get_data())
+        self.assertNotIn("token", body["invites"][0])
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/items_identity/test_create_routes.py
+++ b/unit_tests/items_identity/test_create_routes.py
@@ -340,6 +340,7 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_returns_blueprint_with_correct_name(self, *_mocks):
         bp = create_invite_routes(self.mock_logger, self.mock_config)
         self.assertIsInstance(bp, quart.Blueprint)
@@ -348,15 +349,17 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_initialises_all_handlers_with_correct_args(
-            self, mock_create, mock_resend, mock_uninvite):
+            self, mock_get, mock_create, mock_resend, mock_uninvite):
         create_invite_routes(self.mock_logger, self.mock_config)
-        for mock_cls in (mock_create, mock_resend, mock_uninvite):
+        for mock_cls in (mock_get, mock_create, mock_resend, mock_uninvite):
             mock_cls.assert_called_once_with(self.mock_logger, self.mock_config)
 
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_logs_route_registration(self, *_mocks):
         create_invite_routes(self.mock_logger, self.mock_config)
         self.mock_logger.debug.assert_called()
@@ -370,8 +373,9 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_post_invites_calls_create_invite(
-            self, mock_create_cls, *_rest):
+            self, _get_cls, mock_create_cls, *_rest):
         mock_handler = MagicMock()
         mock_handler.create_invite = AsyncMock(
             return_value=self._ok_response({"token": "abc"}, status=201))
@@ -389,8 +393,9 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_post_invites_resend_calls_resend_invite(
-            self, _create, mock_resend_cls, _uninvite):
+            self, _get_cls, _create, mock_resend_cls, _uninvite):
         mock_handler = MagicMock()
         mock_handler.resend_invite = AsyncMock(
             return_value=self._ok_response({"token": "abc"}))
@@ -409,8 +414,9 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     @patch("routes.invites.UninviteHandler")
     @patch("routes.invites.ResendInviteHandler")
     @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
     async def test_post_invites_uninvite_calls_uninvite(
-            self, _create, _resend, mock_uninvite_cls):
+            self, _get_cls, _create, _resend, mock_uninvite_cls):
         mock_handler = MagicMock()
         mock_handler.uninvite = AsyncMock(
             return_value=self._ok_response())
@@ -425,6 +431,26 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
                               json={"email_address": "a@b.com"})
 
         mock_handler.uninvite.assert_called_once()
+
+    @patch("routes.invites.UninviteHandler")
+    @patch("routes.invites.ResendInviteHandler")
+    @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
+    async def test_get_invites_calls_get_invites(
+            self, mock_get_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.get_invites = AsyncMock(
+            return_value=self._ok_response({"invites": []}))
+        mock_get_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_invite_routes(self.mock_logger, self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.get("/invites")
+
+        mock_handler.get_invites.assert_called_once()
 
 
 class TestCreateRoutes(unittest.IsolatedAsyncioTestCase):

--- a/unit_tests/items_identity/test_da_invite_data_access_layer.py
+++ b/unit_tests/items_identity/test_da_invite_data_access_layer.py
@@ -101,6 +101,34 @@ class TestInviteRepository(unittest.IsolatedAsyncioTestCase):
                       InviteRepository.GET_INVITE_BY_EMAIL_QUERY)
 
     # -------------------------------------------------------
+    # get_pending_invites
+    # -------------------------------------------------------
+
+    async def test_get_pending_invites_returns_empty_list_when_none(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_pending_invites()
+        self.assertEqual(result, [])
+
+    async def test_get_pending_invites_returns_rows(self):
+        self.mock_db.run_query.return_value = [_PENDING_ROW]
+        result = await self.repo.get_pending_invites()
+        self.assertEqual(result, [_PENDING_ROW])
+
+    async def test_get_pending_invites_passes_correct_query(self):
+        self.mock_db.run_query.return_value = None
+        await self.repo.get_pending_invites()
+        self.mock_db.run_query.assert_called_once_with(
+            InviteRepository.GET_PENDING_INVITES_QUERY, ())
+
+    async def test_get_pending_invites_query_filters_pending_only(self):
+        self.assertIn("is_expired = 0",
+                      InviteRepository.GET_PENDING_INVITES_QUERY)
+
+    async def test_get_pending_invites_query_orders_by_created_at(self):
+        self.assertIn("ORDER BY created_at",
+                      InviteRepository.GET_PENDING_INVITES_QUERY)
+
+    # -------------------------------------------------------
     # create_invite
     # -------------------------------------------------------
 

--- a/unit_tests/items_identity/test_services_invite_management_service.py
+++ b/unit_tests/items_identity/test_services_invite_management_service.py
@@ -20,7 +20,8 @@ from services.invite_management_service import (
     InviteManagementService,
     InviteCreateStatus,
     InviteResendStatus,
-    InviteUninviteStatus)
+    InviteUninviteStatus,
+    PendingInvite)
 
 _TOKEN = "550e8400-e29b-41d4-a716-446655440000"
 _TOKEN2 = "660e8400-e29b-41d4-a716-446655440000"
@@ -39,6 +40,7 @@ class TestInviteManagementService(unittest.IsolatedAsyncioTestCase):
         self.mock_invite_repo = MagicMock()
         self.mock_invite_repo.get_invite_by_email = AsyncMock()
         self.mock_invite_repo.get_invite_by_token = AsyncMock()
+        self.mock_invite_repo.get_pending_invites = AsyncMock()
         self.mock_invite_repo.create_invite = AsyncMock()
         self.mock_invite_repo.resend_invite = AsyncMock()
         self.mock_invite_repo.uninvite = AsyncMock()
@@ -49,6 +51,27 @@ class TestInviteManagementService(unittest.IsolatedAsyncioTestCase):
 
         self.service = InviteManagementService(
             self.logger, self.mock_invite_repo, self.mock_user_repo)
+
+    # -------------------------------------------------------
+    # get_pending_invites
+    # -------------------------------------------------------
+
+    async def test_get_pending_invites_returns_empty_list_when_none(self):
+        self.mock_invite_repo.get_pending_invites.return_value = []
+        result = await self.service.get_pending_invites()
+        self.assertEqual(result, [])
+
+    async def test_get_pending_invites_maps_rows_to_pending_invite(self):
+        self.mock_invite_repo.get_pending_invites.return_value = [_PENDING_ROW]
+        result = await self.service.get_pending_invites()
+        self.assertEqual(result, [
+            PendingInvite(email_address=_EMAIL, created_at=_NOW,
+                         expires_at=_EXPIRES)])
+
+    async def test_get_pending_invites_does_not_expose_token(self):
+        self.mock_invite_repo.get_pending_invites.return_value = [_PENDING_ROW]
+        result = await self.service.get_pending_invites()
+        self.assertFalse(hasattr(result[0], "token"))
 
     # -------------------------------------------------------
     # create_invite


### PR DESCRIPTION
# Identity + Gateway: list pending invites

**Branch:** `identity_gateway_list_invites` → `main`
**Stats:** working tree changes, not yet committed — 15 files changed, +437/-6

## Summary

Adds the one piece the invite system never had: a way to list pending
invites. `identity_user_invite_initial` shipped create/resend/uninvite but
no GET — easy to assume it was complete since all three felt like a set,
but a list endpoint was never actually built. Found while scoping the
`portal_user_invite` Web UI, which needs a "Pending Invites" table. Kept
as its own branch spanning both services (rather than splitting into
per-service branches) since it's small and tightly coupled — the Gateway
half is a pure proxy with nothing to design independently of the Identity
half.

## Identity: `GET /invites`

- `InviteRepository.get_pending_invites()` — new query, same 7-column
  shape as the existing invite queries, filtered to `is_expired = 0` and
  ordered by `created_at`.
- `InviteManagementService.get_pending_invites()` — maps rows to a new
  `PendingInvite` dataclass exposing `email_address`, `created_at`,
  `expires_at`. Deliberately **excludes the token** — it's a secret
  embedded in the invite email link, not needed by anything a list view
  does (resend/uninvite act on `email_address`), so there's no reason to
  expose it over a general listing endpoint.
- `GetInvitesHandler` — `200 {"invites": [...]}`, always 200 (an empty
  pending-invite list isn't an error condition).
- Wired into `routes/invites/__init__.py` alongside the existing three,
  matching their plain `(logger, config)` construction style (this
  domain doesn't use the `ServiceState` pattern the `users` domain does,
  so this doesn't introduce it either).

## Gateway: `GET /web/invites`

Thin proxy, same shape as the other three invite handlers — including the
non-JSON-downstream-response guard added on `gateway_user_invite`
(detects a stale/unexpected identity response and returns a clean 500
instead of forwarding raw HTML as fake JSON).

## Postman collection

Added **List Invites** (GET) to both the Identity Service and Gateway
Service `Invites` folders, positioned first in each list. Clean 35-line
diff.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Test coverage

Repository/service/handler tests on both sides follow the existing
patterns for their domain (including updating `test_create_routes.py`'s
patch-decorator argument ordering now that a fourth handler is
constructed). Route-wiring tests confirm both new endpoints are reachable.

**100% line coverage maintained on both services** — Identity: 955/955
statements, 267 tests. Gateway: 1430/1430 statements, 262 tests. Pylint
10.00/10 on both.

## Not in this branch

The actual Web Portal "Pending Invites" UI this was built to unblock is
`portal_user_invite`, picked back up now that this exists.

Manual testing also surfaced a Gateway health-check gap unrelated to this
branch's code: neither the Identity nor CMS health-check schema includes a
field identifying which service actually answered, so a misconfigured
port could have the Gateway validate the wrong backend as healthy. Written
up in `future.md`; not attempted here since it's a coordinated change
across every service's health schema/handler, not just the Gateway.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
