### PR TITLE
[Portal] User Invite

### DIFF
--- a/future.md
+++ b/future.md
@@ -3,6 +3,61 @@
 Running list of known, deliberately-deferred items — not urgent, but worth
 tracking so they don't get lost.
 
+## Gateway: admin-only routes are not actually enforced
+
+**This one is a security issue rather than a tidy-up**, and is listed first
+for that reason.
+
+**Where:** every route under `items_gateway/routes/web/`. There is no
+authorisation check anywhere in the Gateway — no session validation, no
+`is_administrator` check, no decorator. The invites blueprint states the
+position outright:
+
+```python
+"""All routes are admin-only and must be enforced at this layer or by the
+caller (the web portal, which checks ``is_administrator`` before calling)."""
+```
+
+It is currently the second of those: the Gateway trusts that the caller was
+the web portal and that the portal checked.
+
+**Problem:** in production the Gateway is the *only* externally visible
+service — CMS and Identity bind to `127.0.0.1`. So the Gateway is the public
+attack surface, and nothing about a request proves it came from the portal.
+`POST /web/users` is therefore a publicly reachable, unauthenticated
+account-creation endpoint: anyone who can reach the Gateway can create
+themselves an account, including an administrator one, with a single `curl`
+and without ever loading the portal. The same applies to every other
+admin-only route (project deletion, custom field changes, invites, user
+modification).
+
+The portal's `require_administrator` decorator is real and works, but it
+guards the *portal's* pages. Hiding a button is a user-experience decision,
+not a security boundary — exactly the point already made in §9.1 of
+`design_docs/user_roles_design.md`, which names the Gateway as the
+enforcement point. That part was never implemented.
+
+**Fix:** enforce at the Gateway. It already holds the session table
+(`sessions.py`), and `SessionEntry` already carries `is_administrator`, so
+the pieces exist — what is missing is a check on the request path. Broadly:
+
+- Require session credentials on `/web/*` requests and validate them against
+  the session store.
+- Gate admin-only routes on the session's `is_administrator` flag.
+- Decide how the portal passes the caller's session to the Gateway; it
+  currently forwards none, so this is the main design question.
+
+**Two routes must be explicitly exempted**, and this is easy to get wrong
+with a blanket rule:
+
+- `GET  /web/invites/token/<token>`
+- `POST /web/accept_invite`
+
+Both are deliberately unauthenticated, because somebody redeeming an
+invitation has no account yet — the invite token authorises them instead.
+This is documented in the invites blueprint docstring so it is not
+"corrected" by mistake.
+
 ## CMS: `linked_projects` encoding is ambiguous
 
 **Where:** `items_cms.repositories.testcase_custom_fields_repository`'s

--- a/future.md
+++ b/future.md
@@ -154,3 +154,34 @@ if it doesn't. Touches the shared schema
 (`items/shared/interfaces/*/health.py`) and every service's own health
 handler, not just the Gateway, so this is a coordinated change across all
 services rather than a Gateway-only fix.
+
+## Identity: invite consumption has a narrow TOCTOU race (low priority)
+
+**Where:** `InviteManagementService.uninvite()` (also used as the "consume"
+step inside `accept_invite`'s flow) does a `SELECT` (existence check via
+`get_invite_by_email`) followed by a separate `UPDATE` (soft-expire) as two
+sequential DB round trips, rather than one atomic statement.
+
+**Problem:** two concurrent callers submitting the same token/email within
+the few-millisecond gap between the SELECT and the UPDATE could both pass
+the existence check before either UPDATE lands, both believing they
+successfully consumed the invite. In practice this requires the exact same
+token submitted twice near-simultaneously (a double-click, a client retry,
+or deliberate racing) - a narrow window, and even if hit, the failure is
+already safe: `create_user`'s email-uniqueness constraint means the second
+`accept_invite` attempt fails at account creation regardless, so there is no
+duplicate account and no takeover - just a confusing "please ask for a new
+invite" error for the losing request.
+
+**Fix (not attempted - low priority, P4/P5):** no framework change needed -
+`SqliteInterface.run_query(..., commit=True)` already returns
+`cursor.rowcount`. Change `InviteRepository.uninvite()` to return that
+rowcount instead of discarding it, and change
+`InviteManagementService.uninvite()` to drop the separate
+`get_invite_by_email()` pre-check, performing the atomic
+`UPDATE ... WHERE is_expired = 0` directly and branching SUCCESS vs.
+NO_PENDING_INVITE on whether the rowcount was 1 or 0. The Gateway's
+`_consume_invite` (in `accept_invite_handler.py`) needs no changes - it
+already just checks for a 200 status. Roughly a 30-45 minute change
+including light test updates to `test_da_invite_data_access_layer.py` and
+`test_services_invite_management_service.py`.

--- a/items/services/items_cms/service.py
+++ b/items/services/items_cms/service.py
@@ -31,6 +31,7 @@ from items.services.items_cms.routes import create_routes
 class Service(BaseMicroservice):
     """ ITEMS CMS Microservice """
 
+    SERVICE_NAME: str = "CMS"
     CONFIG_FILE_ENV: str = "ITEMS_CMS_CONFIG_FILE"
     CONFIG_REQUIRED_ENV: str = "ITEMS_CMS_CONFIG_FILE_REQUIRED"
 

--- a/items/services/items_gateway/routes/web/invites/__init__.py
+++ b/items/services/items_gateway/routes/web/invites/__init__.py
@@ -49,10 +49,15 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
 
     handler_get = GetInvitesHandler(
         injections.logger, injections.configuration, injections.rest_client)
+    # Both of these send mail: creating an invite emails the invitation, and
+    # resending it regenerates the token and emails the new link. Omitting the
+    # email service leaves them silently issuing invites nobody receives.
     handler_create = CreateInviteHandler(
-        injections.logger, injections.configuration, injections.rest_client)
+        injections.logger, injections.configuration, injections.rest_client,
+        injections.email_service)
     handler_resend = ResendInviteHandler(
-        injections.logger, injections.configuration, injections.rest_client)
+        injections.logger, injections.configuration, injections.rest_client,
+        injections.email_service)
     handler_uninvite = UninviteHandler(
         injections.logger, injections.configuration, injections.rest_client)
 

--- a/items/services/items_gateway/routes/web/invites/__init__.py
+++ b/items/services/items_gateway/routes/web/invites/__init__.py
@@ -23,19 +23,31 @@ from items.services.items_gateway.routes.web.invites.resend_invite_handler impor
     ResendInviteHandler)
 from items.services.items_gateway.routes.web.invites.uninvite_handler import (
     UninviteHandler)
+from items.services.items_gateway.routes.web.invites.accept_invite_handler import (
+    AcceptInviteHandler)
+from items.services.items_gateway.routes.web.invites.get_invite_by_token_handler import (
+    GetInviteByTokenHandler)
 
 
 def create_invite_routes(injections: RouteInjections) -> Blueprint:
     """Create the Blueprint containing invite management web routes.
 
-    All routes are admin-only and must be enforced at this layer or by the
-    caller (the web portal, which checks ``is_administrator`` before calling).
+    The management routes are admin-only and must be enforced at this layer or
+    by the caller (the web portal, which checks ``is_administrator`` before
+    calling).
+
+    ``POST /accept_invite`` is the exception: it is **deliberately
+    unauthenticated**, because the person redeeming an invitation does not yet
+    have an account. The invite token authorises that request instead. When
+    authorisation is enforced at this layer, this route must be explicitly
+    exempted rather than being caught by a blanket rule.
 
     Registered routes:
         GET  /invites              List all pending invites.
         POST /invites              Create a new pending invite.
         POST /invites/resend       Refresh token and expiry on an existing invite.
         POST /invites/uninvite     Cancel (soft-expire) a pending invite.
+        POST /accept_invite        Redeem an invitation (unauthenticated).
 
     Args:
         injections: Shared application dependencies.
@@ -49,6 +61,12 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
 
     handler_get = GetInvitesHandler(
         injections.logger, injections.configuration, injections.rest_client)
+    handler_accept = AcceptInviteHandler(
+        injections.logger, injections.configuration, injections.rest_client,
+        injections.email_service)
+    handler_by_token = GetInviteByTokenHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+
     # Both of these send mail: creating an invite emails the invitation, and
     # resending it regenerates the token and emails the new link. Omitting the
     # email service leaves them silently issuing invites nobody receives.
@@ -83,6 +101,20 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
     @routes.route('/invites/resend', methods=['POST'])
     async def resend_invite_request():
         return await handler_resend.resend_invite()
+
+    injections.logger.debug("=> %s GET  /web/invites/token/<token>",
+                            "Resolve invite token (unauthenticated)".ljust(40))
+
+    @routes.route('/invites/token/<string:token>', methods=['GET'])
+    async def get_invite_by_token_request(token: str):
+        return await handler_by_token.get_invite_by_token(token)
+
+    injections.logger.debug("=> %s POST /web/accept_invite",
+                            "Accept invite (unauthenticated)".ljust(40))
+
+    @routes.route('/accept_invite', methods=['POST'])
+    async def accept_invite_request():
+        return await handler_accept.accept_invite()
 
     injections.logger.debug("=> %s POST /web/invites/uninvite",
                             "Uninvite".ljust(40))

--- a/items/services/items_gateway/routes/web/invites/accept_invite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/accept_invite_handler.py
@@ -1,0 +1,173 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+from items.services.items_gateway.services.email_service import EmailService
+from items.services.items_gateway.services.invite_email import (
+    send_welcome_email)
+
+_REQUIRED_FIELDS = ("token", "full_name", "display_name", "password")
+
+
+class AcceptInviteHandler(BaseApiRoute):
+    """Handles POST /accept_invite — redeem an invitation.
+
+    This is the one route an unauthenticated caller is *meant* to be able to
+    reach: the person accepting an invite does not yet have an account. The
+    invite token is what authorises the request, so it is validated here
+    rather than being trusted from the page that submitted the form.
+
+    The email address is taken from the invite record, never from the request
+    body. Otherwise an invitation issued to one address could be redeemed to
+    create an account for another.
+
+    The invite is consumed *before* the account is created. If consuming
+    succeeded and creation then failed, the invite is spent and an
+    administrator must reissue it - which is a nuisance. The other ordering
+    would leave a live invite that could be redeemed repeatedly, which is a
+    security hole. The nuisance is the better failure.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient,
+                 email_service: EmailService | None = None) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+        self._email_service = email_service
+
+    async def accept_invite(self) -> Response:
+        """Redeem an invitation and create the invited user's account.
+
+        Returns:
+            201 with the created user on success.
+            400 if the body is missing fields or is not valid JSON.
+            404 if the token is unknown, already used, cancelled or expired.
+            500 if the identity service is unreachable, or if the account
+            could not be created after the invite was consumed.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return self._error("Invalid JSON body", HTTPStatus.BAD_REQUEST)
+
+        missing = [f for f in _REQUIRED_FIELDS if not body.get(f)]
+        if missing:
+            return self._error(
+                f"Missing required field(s): {', '.join(missing)}",
+                HTTPStatus.BAD_REQUEST)
+
+        # 1. Resolve the token. The address comes from here, not the caller.
+        email_address = await self._resolve_token(body["token"])
+        if email_address is None:
+            return self._error("Invite not found or no longer valid",
+                               HTTPStatus.NOT_FOUND)
+
+        # 2. Consume the invite before creating anything (see class docstring).
+        consumed = await self._consume_invite(email_address)
+        if not consumed:
+            return self._error("Could not redeem this invite",
+                               HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        # 3. Create the account.
+        create_response = await self._create_user(body, email_address)
+
+        if create_response.status_code != HTTPStatus.CREATED:
+            self._logger.error(
+                "Invite for %s was consumed but account creation failed "
+                "(status %s). The invite must be reissued.",
+                email_address, create_response.status_code)
+            return self._error(
+                "Your invitation could not be completed. Please ask an "
+                "administrator to send a new invitation.",
+                HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        # 4. Confirm to the new user. Never fails the request.
+        await send_welcome_email(
+            logger=self._logger,
+            email_service=self._email_service,
+            portal_url=self._configuration.apis_web_portal_svc,
+            email_address=email_address,
+            display_name=body["display_name"])
+
+        self._logger.info("Invite accepted; account created for %s",
+                          email_address)
+
+        return Response(json.dumps(create_response.body),
+                        status=HTTPStatus.CREATED,
+                        content_type="application/json")
+
+    # ------------------------------------------------------------------
+    # Steps
+    # ------------------------------------------------------------------
+
+    async def _resolve_token(self, token: str) -> str | None:
+        """Return the address an invite was issued to, or None if unusable."""
+        url = (f"{self._configuration.apis_identity_svc}"
+               f"invites/token/{token}")
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return None
+
+        if response.status_code != HTTPStatus.OK:
+            return None
+
+        return (response.body or {}).get("email_address")
+
+    async def _consume_invite(self, email_address: str) -> bool:
+        """Mark the invite as used so the link cannot be redeemed again."""
+        url = f"{self._configuration.apis_identity_svc}invites/uninvite"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data={"email_address": email_address})
+
+        if response.exception_msg is not None or \
+                response.status_code != HTTPStatus.OK:
+            self._logger.error(
+                "Could not consume invite for %s (status %s); refusing to "
+                "create the account, as the invite would remain redeemable",
+                email_address, response.status_code)
+            return False
+
+        return True
+
+    async def _create_user(self, body: dict,
+                           email_address: str) -> ApiResponse:
+        """Create the account, using the address from the invite."""
+        url = f"{self._configuration.apis_identity_svc}users"
+        return await self._rest_client.post(url, json_data={
+            # Deliberately from the invite, not from the submitted form.
+            "email_address": email_address,
+            "full_name": body["full_name"],
+            "display_name": body["display_name"],
+            "password": body["password"],
+        })
+
+    @staticmethod
+    def _error(message: str, status: HTTPStatus) -> Response:
+        """Build a JSON error response."""
+        return Response(json.dumps({"error": message}),
+                        status=status,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/invites/create_invite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/create_invite_handler.py
@@ -21,6 +21,9 @@ from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.base_api_route import BaseApiRoute
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+from items.services.items_gateway.services.email_service import EmailService
+from items.services.items_gateway.services.invite_email import (
+    send_invite_email)
 
 
 class CreateInviteHandler(BaseApiRoute):
@@ -29,15 +32,22 @@ class CreateInviteHandler(BaseApiRoute):
     Proxies the request body to the identity service and propagates the
     response. Schema validation is performed by the identity service;
     invalid payloads will receive a 400 response propagated from there.
+
+    After the invite is created the handler emails the invitation to the
+    recipient. Identity has no mail capability, so the gateway is responsible
+    for delivery. A failure to send is logged but does not fail the request —
+    the invite exists and can be resent.
     """
 
     def __init__(self,
                  logger: logging.Logger,
                  configuration: GatewayConfiguration,
-                 rest_client: RestClient) -> None:
+                 rest_client: RestClient,
+                 email_service: EmailService | None = None) -> None:
         self._logger = logger.getChild(type(self).__name__)
         self._configuration = configuration
         self._rest_client = rest_client
+        self._email_service = email_service
 
     async def create_invite(self) -> Response:
         """Create a new pending invite for an email address.
@@ -82,6 +92,14 @@ class CreateInviteHandler(BaseApiRoute):
                                      "unexpected response"}),
                 status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 content_type="application/json")
+
+        await send_invite_email(
+            logger=self._logger,
+            email_service=self._email_service,
+            portal_url=self._configuration.apis_web_portal_svc,
+            response=response,
+            email_address=body.get("email_address", ""),
+            expected_status=HTTPStatus.CREATED)
 
         return Response(json.dumps(response.body),
                         status=response.status_code,

--- a/items/services/items_gateway/routes/web/invites/get_invite_by_token_handler.py
+++ b/items/services/items_gateway/routes/web/invites/get_invite_by_token_handler.py
@@ -1,0 +1,81 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class GetInviteByTokenHandler(BaseApiRoute):
+    """Handles GET /invites/token/<token> — resolve an invitation link.
+
+    **Deliberately unauthenticated**, like ``POST /accept_invite``: someone
+    opening an invitation link has no account yet. It exists so the setup page
+    can show the invited address read-only, rather than asking the recipient
+    to type it - which would let an invitation be redeemed for a different
+    address.
+
+    Only the email address is returned. Unknown, expired and cancelled tokens
+    are all reported as 404 and cannot be told apart, so this cannot be used
+    to probe for valid tokens.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def get_invite_by_token(self, token: str) -> Response:
+        """Resolve an invite token to the address it was issued to.
+
+        Args:
+            token: The token from the invitation link.
+
+        Returns:
+            200 with ``{"email_address": <address>}`` for a usable invite.
+            404 if the token is unknown, used, cancelled or expired.
+            500 if the identity service is unreachable.
+        """
+        url: str = (f"{self._configuration.apis_identity_svc}"
+                    f"invites/token/{token}")
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.status_code != HTTPStatus.OK:
+            return Response(
+                json.dumps({"error": "Invite not found or no longer valid"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"email_address":
+                        (response.body or {}).get("email_address")}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_gateway/routes/web/invites/resend_invite_handler.py
+++ b/items/services/items_gateway/routes/web/invites/resend_invite_handler.py
@@ -21,6 +21,9 @@ from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.base_api_route import BaseApiRoute
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+from items.services.items_gateway.services.email_service import EmailService
+from items.services.items_gateway.services.invite_email import (
+    send_invite_email)
 
 
 class ResendInviteHandler(BaseApiRoute):
@@ -30,15 +33,21 @@ class ResendInviteHandler(BaseApiRoute):
     Proxies the request body to the identity service and propagates the
     response. Schema validation is performed by the identity service;
     invalid payloads will receive a 400 response propagated from there.
+
+    Because the token is regenerated, the invitation is emailed again with the
+    new link — otherwise "resend" would refresh the token without the
+    recipient ever receiving it.
     """
 
     def __init__(self,
                  logger: logging.Logger,
                  configuration: GatewayConfiguration,
-                 rest_client: RestClient) -> None:
+                 rest_client: RestClient,
+                 email_service: EmailService | None = None) -> None:
         self._logger = logger.getChild(type(self).__name__)
         self._configuration = configuration
         self._rest_client = rest_client
+        self._email_service = email_service
 
     async def resend_invite(self) -> Response:
         """Refresh the invite token and expiry for a pending invite.
@@ -82,6 +91,14 @@ class ResendInviteHandler(BaseApiRoute):
                                      "unexpected response"}),
                 status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 content_type="application/json")
+
+        await send_invite_email(
+            logger=self._logger,
+            email_service=self._email_service,
+            portal_url=self._configuration.apis_web_portal_svc,
+            response=response,
+            email_address=body.get("email_address", ""),
+            expected_status=HTTPStatus.OK)
 
         return Response(json.dumps(response.body),
                         status=response.status_code,

--- a/items/services/items_gateway/services/invite_email.py
+++ b/items/services/items_gateway/services/invite_email.py
@@ -1,0 +1,113 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from http import HTTPStatus
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.services.email_service import (
+    EmailService, EmailServiceError)
+
+INVITE_SUBJECT: str = "You have been invited to ITEMS"
+
+# Portal path the invitation link points at. The recipient exchanges the token
+# there for an account.
+INVITE_ACCEPT_PATH: str = "/accept_invite"
+
+
+def build_invite_url(portal_url: str, token: str) -> str:
+    """Build the link an invited user follows to accept their invitation.
+
+    Args:
+        portal_url: Base URL of the web portal.
+        token:      The invite token issued by the identity service.
+
+    Returns:
+        The absolute URL to include in the invitation email.
+    """
+    return f"{portal_url.rstrip('/')}{INVITE_ACCEPT_PATH}?token={token}"
+
+
+def build_invite_body(portal_url: str, token: str) -> str:
+    """Build the body of an invitation email.
+
+    Args:
+        portal_url: Base URL of the web portal.
+        token:      The invite token issued by the identity service.
+
+    Returns:
+        The plain-text email body.
+    """
+    return (
+        "Hello,\n\n"
+        "You have been invited to join ITEMS.\n\n"
+        "To accept the invitation and set up your account, follow this link:\n"
+        f"{build_invite_url(portal_url, token)}\n\n"
+        "This invitation will expire. If it does, ask an administrator to "
+        "send you a new one.\n\n"
+        "If you were not expecting this invitation you can ignore this "
+        "message.\n"
+    )
+
+
+async def send_invite_email(logger: logging.Logger,
+                            email_service: EmailService | None,
+                            portal_url: str,
+                            response: ApiResponse,
+                            email_address: str,
+                            expected_status: HTTPStatus) -> None:
+    """Email an invitation, if the invite was issued successfully.
+
+    Shared by the create and resend handlers so the two cannot drift apart.
+    Delivery failures are logged rather than raised: the invite already exists
+    in the identity service, and the caller's request succeeded. Raising here
+    would report failure for an operation that did in fact happen.
+
+    Args:
+        logger:          Logger used to record delivery problems.
+        email_service:   Service used to send the message. When None, no mail
+            is configured and the send is skipped.
+        portal_url:      Base URL of the web portal, used to build the link.
+        response:        The identity service's response to the invite request.
+        email_address:   Recipient of the invitation.
+        expected_status: The status indicating the invite was issued (created
+            for a new invite, OK for a resend).
+    """
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+
+    if email_service is None:
+        logger.warning(
+            "No email service configured; invitation for %s was not sent",
+            email_address)
+        return
+
+    if response.status_code != expected_status:
+        return
+
+    token = (response.body or {}).get("token")
+    if not token:
+        logger.error(
+            "Identity service issued an invite for %s without a token; "
+            "cannot send the invitation email", email_address)
+        return
+
+    try:
+        await email_service.send(
+            to=email_address,
+            subject=INVITE_SUBJECT,
+            body=build_invite_body(portal_url, token))
+
+    except EmailServiceError as exc:
+        logger.error("Failed to send invitation email to %s: %s",
+                     email_address, exc)

--- a/items/services/items_gateway/services/invite_email.py
+++ b/items/services/items_gateway/services/invite_email.py
@@ -61,6 +61,60 @@ def build_invite_body(portal_url: str, token: str) -> str:
     )
 
 
+WELCOME_SUBJECT: str = "Welcome to ITEMS"
+
+
+def build_welcome_body(portal_url: str, display_name: str) -> str:
+    """Build the body of the welcome email sent after an invite is accepted.
+
+    Args:
+        portal_url:   Base URL of the web portal.
+        display_name: Name the new user chose to be known by.
+
+    Returns:
+        The plain-text email body.
+    """
+    login_url = portal_url.rstrip("/") + "/login"
+    return (
+        f"Hello {display_name},\n\n"
+        "Your ITEMS account is now set up and ready to use.\n\n"
+        f"You can sign in here:\n{login_url}\n\n"
+        "If you have any trouble signing in, contact your administrator.\n"
+    )
+
+
+async def send_welcome_email(logger: logging.Logger,
+                             email_service: EmailService | None,
+                             portal_url: str,
+                             email_address: str,
+                             display_name: str) -> None:
+    """Email a newly created user to confirm their account is ready.
+
+    Delivery failures are logged rather than raised: the account already
+    exists and the person can sign in regardless of whether this arrives.
+
+    Args:
+        logger:        Logger used to record delivery problems.
+        email_service: Service used to send the message; None when no mail is
+            configured.
+        portal_url:    Base URL of the web portal.
+        email_address: Recipient address.
+        display_name:  Name to greet the recipient by.
+    """
+    if email_service is None:
+        return
+
+    try:
+        await email_service.send(
+            to=email_address,
+            subject=WELCOME_SUBJECT,
+            body=build_welcome_body(portal_url, display_name))
+
+    except EmailServiceError as exc:
+        logger.error("Failed to send welcome email to %s: %s",
+                     email_address, exc)
+
+
 async def send_invite_email(logger: logging.Logger,
                             email_service: EmailService | None,
                             portal_url: str,

--- a/items/services/items_identity/routes/invites/__init__.py
+++ b/items/services/items_identity/routes/invites/__init__.py
@@ -18,6 +18,7 @@ import quart
 from items.services.items_identity.identity_configuration import (
     IdentityConfiguration)
 from .get_invites_handler import GetInvitesHandler
+from .get_invite_by_token_handler import GetInviteByTokenHandler
 from .create_invite_handler import CreateInviteHandler
 from .resend_invite_handler import ResendInviteHandler
 from .uninvite_handler import UninviteHandler
@@ -30,6 +31,8 @@ def create_invite_routes(logger: logging.Logger,
     Registered routes:
 
     * ``GET  /invites``           - List all pending invites.
+    * ``GET  /invites/token/<token>`` - Resolve an invitation link to the
+      address it was issued to.
     * ``POST /invites``          - Create a new pending invite.
     * ``POST /invites/resend``   - Refresh token and expiry on an existing invite.
     * ``POST /invites/uninvite`` - Cancel (soft-expire) a pending invite.
@@ -44,6 +47,7 @@ def create_invite_routes(logger: logging.Logger,
     invite_routes = quart.Blueprint("invite_routes", __name__)
 
     handler_get = GetInvitesHandler(logger, config)
+    handler_get_by_token = GetInviteByTokenHandler(logger, config)
     handler_create = CreateInviteHandler(logger, config)
     handler_resend = ResendInviteHandler(logger, config)
     handler_uninvite = UninviteHandler(logger, config)
@@ -52,6 +56,8 @@ def create_invite_routes(logger: logging.Logger,
 
     logger.debug("=> %s GET  /invites",
                  "List pending invites".ljust(40))
+    logger.debug("=> %s GET  /invites/token/<token>",
+                 "Resolve invite token".ljust(40))
     logger.debug("=> %s POST /invites",
                  "Create invite".ljust(40))
     logger.debug("=> %s POST /invites/resend",
@@ -64,6 +70,10 @@ def create_invite_routes(logger: logging.Logger,
     @invite_routes.route('/invites', methods=['GET'])
     async def get_invites_request():
         return await handler_get.get_invites()
+
+    @invite_routes.route('/invites/token/<string:token>', methods=['GET'])
+    async def get_invite_by_token_request(token: str):
+        return await handler_get_by_token.get_invite_by_token(token)
 
     @invite_routes.route('/invites', methods=['POST'])
     async def create_invite_request():

--- a/items/services/items_identity/routes/invites/get_invite_by_token_handler.py
+++ b/items/services/items_identity/routes/invites/get_invite_by_token_handler.py
@@ -1,0 +1,75 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.invite_repository import (
+    InviteRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.invite_management_service import (
+    InviteManagementService)
+
+
+class GetInviteByTokenHandler(BaseApiRoute):
+    """Handles GET /invites/token/<token> — resolve an invitation link.
+
+    Called when an invited person opens their invitation link, so that the
+    address the account is created for comes from the invite record rather
+    than from anything the recipient supplies.
+
+    Unknown, cancelled and expired tokens all return 404. They are not
+    distinguished, so this endpoint cannot be used to discover whether a
+    particular token exists.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        invite_repo = InviteRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        self._service = InviteManagementService(
+            self._logger, invite_repo, user_repo)
+
+    async def get_invite_by_token(self, token: str) -> Response:
+        """Resolve an invite token to the address it was issued to.
+
+        Args:
+            token: The token from the invitation link.
+
+        Returns:
+            200 with ``{"email_address": <address>}`` when the token matches a
+            pending, unexpired invite.
+            404 otherwise - whether the token is unknown, already used,
+            cancelled or expired.
+        """
+        result = await self._service.get_invite_by_token(token)
+
+        if not result.valid:
+            return Response(
+                json.dumps({"error": "Invite not found or no longer valid"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"email_address": result.email_address}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/service.py
+++ b/items/services/items_identity/service.py
@@ -41,6 +41,7 @@ _INVITE_EXPIRY_INTERVAL_SECONDS: int = 5 * 60  # 5 minutes
 class Service(BaseMicroservice):
     """ ITEMS Identity Microservice """
 
+    SERVICE_NAME: str = "Identity"
     CONFIG_FILE_ENV: str = "ITEMS_IDENTITY_CONFIG_FILE"
     CONFIG_REQUIRED_ENV: str = "ITEMS_IDENTITY_CONFIG_FILE_REQUIRED"
 

--- a/items/services/items_identity/services/invite_management_service.py
+++ b/items/services/items_identity/services/invite_management_service.py
@@ -74,6 +74,23 @@ class InviteUninviteResult:
 
 
 @dataclass
+class InviteLookupResult:
+    """Outcome of looking up an invite by its token.
+
+    Attributes:
+        valid:         True only when the token matches a pending, unexpired
+            invite. Unknown, cancelled and expired tokens are all reported
+            identically, so a caller cannot probe for token existence.
+        email_address: The address the invite was issued to, present only
+            when ``valid`` is True. This is the address the account must be
+            created for - it is never taken from the recipient's input.
+    """
+
+    valid: bool
+    email_address: Optional[str] = None
+
+
+@dataclass
 class PendingInvite:
     """A single pending invite, as exposed to API callers.
 
@@ -116,6 +133,40 @@ class InviteManagementService:
         self._logger = logger.getChild(type(self).__name__)
         self._invite_repo = invite_repo
         self._user_repo = user_repo
+
+    async def get_invite_by_token(self, token: str) -> InviteLookupResult:
+        """Look up an invite by the token from its email link.
+
+        Used when an invited person opens their invitation link, so the
+        address the account will be created for comes from the invite itself
+        rather than from anything the recipient supplies.
+
+        An invite is only usable while it is pending and unexpired. Expired,
+        cancelled and unknown tokens are all reported as simply not valid, so
+        that a caller cannot use this endpoint to discover whether a given
+        token ever existed.
+
+        Args:
+            token: The token from the invitation link.
+
+        Returns:
+            An :class:`InviteLookupResult`. ``email_address`` is populated
+            only when ``valid`` is True.
+        """
+        row = await self._invite_repo.get_invite_by_token(token)
+
+        if row is None:
+            return InviteLookupResult(valid=False)
+
+        _, _, email_address, _, expires_at, is_expired, _ = row
+
+        if is_expired:
+            return InviteLookupResult(valid=False)
+
+        if expires_at <= int(time.time()):
+            return InviteLookupResult(valid=False)
+
+        return InviteLookupResult(valid=True, email_address=email_address)
 
     async def get_pending_invites(self) -> list[PendingInvite]:
         """Return every pending (not yet expired or cancelled) invite.

--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -102,6 +102,32 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
     async def admin_admin_users_and_roles_request():
         return await handler_users_and_roles.users_and_roles()
 
+    # Admin page | Invite user: POST '/admin/users_roles/invite'
+    injections.logger.debug("=> %s POST /admin/users_roles/invite",
+                            "Admin invite user".ljust(40))
+
+    @routes.route('/users_roles/invite', methods=['POST'])
+    async def admin_users_and_roles_invite_request():
+        return await handler_users_and_roles.invite_user()
+
+    # Admin page | Resend invite: POST '/admin/users_roles/invite/resend'
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/invite/resend",
+        "Admin resend invite".ljust(40))
+
+    @routes.route('/users_roles/invite/resend', methods=['POST'])
+    async def admin_users_and_roles_resend_invite_request():
+        return await handler_users_and_roles.resend_invite()
+
+    # Admin page | Cancel invite: POST '/admin/users_roles/invite/uninvite'
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/invite/uninvite",
+        "Admin cancel invite".ljust(40))
+
+    @routes.route('/users_roles/invite/uninvite', methods=['POST'])
+    async def admin_users_and_roles_uninvite_request():
+        return await handler_users_and_roles.uninvite()
+
     # Admin page | Manage Data (read): '/admin/users_roles'
     injections.logger.debug("=> %s GET /admin/manage_data",
                             "Admin manage data page (read)".ljust(40))

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -89,15 +89,16 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "invite")
+        return await self._render_after_write(response, "invite",
+                                              email_address)
 
     @require_administrator
     async def resend_invite(self):
         """Refresh the token and expiry for a pending invite.
 
         Returns:
-            The re-rendered users and roles page, showing an error banner
-            if the gateway/identity rejects the request.
+            The re-rendered users and roles page, confirming the resend or
+            showing an error banner if the gateway/identity rejects it.
         """
         form = await request.form
         email_address = form.get("email_address", "").strip()
@@ -106,7 +107,8 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "resend")
+        return await self._render_after_write(response, "resend",
+                                              email_address)
 
     @require_administrator
     async def uninvite(self):
@@ -123,33 +125,70 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "uninvite")
+        return await self._render_after_write(response, "uninvite",
+                                              email_address)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
 
+    # Confirmation shown after each invite action succeeds. Without these the
+    # page re-renders looking identical to having done nothing, so there is no
+    # way to tell a successful action from one that silently failed.
+    #
+    # The resend message mentions the previous link because resending
+    # regenerates the token: any invitation already sent stops working, which
+    # the administrator cannot otherwise know.
+    _SUCCESS_MESSAGES: dict = {
+        "invite": "Invitation sent to {email}.",
+        "resend": ("Invitation resent to {email}. Any previous invitation "
+                   "link is no longer valid."),
+        "uninvite": "Invitation for {email} has been cancelled.",
+    }
+
+    # How long each confirmation stays on screen. Resend gets longer because
+    # it reports that the previous link has stopped working - a fact the
+    # administrator may need to act on, rather than a simple acknowledgement.
+    # Errors are never auto-dismissed; see the template.
+    _DEFAULT_DISMISS_MS: int = 10_000
+    _SUCCESS_DISMISS_MS: dict = {
+        "resend": 20_000,
+    }
+
     async def _render_after_write(self, response: ApiResponse,
-                                  action: str):
-        """Re-render the page after a write, surfacing any gateway error.
+                                  action: str,
+                                  email_address: str = ""):
+        """Re-render the page after a write, confirming it or showing an error.
 
         Args:
             response: The gateway response for the write operation.
-            action: Short action name used in logging ("invite", "resend",
-                "uninvite").
+            action: Short action name used in logging and to select the
+                confirmation message ("invite", "resend", "uninvite").
+            email_address: Address the action applied to, named in the
+                confirmation so it is clear which row was affected.
 
         Returns:
             The re-rendered users and roles page.
         """
         error_msg_str: Optional[str] = None
+        success_msg_str: Optional[str] = None
+        success_dismiss_ms: int = self._DEFAULT_DISMISS_MS
 
         if response.status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
             error_msg_str = self._extract_error(response)
             self._logger.warning(
                 "Invite %s failed (status %s): %s",
                 action, response.status_code, error_msg_str)
+        else:
+            template = self._SUCCESS_MESSAGES.get(action)
+            if template:
+                success_msg_str = template.format(email=email_address)
+                success_dismiss_ms = self._SUCCESS_DISMISS_MS.get(
+                    action, self._DEFAULT_DISMISS_MS)
 
-        return await self._render(error_msg_str=error_msg_str)
+        return await self._render(error_msg_str=error_msg_str,
+                                  success_msg_str=success_msg_str,
+                                  success_dismiss_ms=success_dismiss_ms)
 
     @staticmethod
     def _extract_error(response: ApiResponse) -> str:
@@ -158,11 +197,17 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
             return str(response.body["error"])
         return "The request could not be completed. Please try again."
 
-    async def _render(self, error_msg_str: Optional[str] = None):
+    async def _render(self, error_msg_str: Optional[str] = None,
+                      success_msg_str: Optional[str] = None,
+                      success_dismiss_ms: int = _DEFAULT_DISMISS_MS):
         """Fetch users and pending invites, then render the page.
 
         Args:
             error_msg_str: Optional error banner to display on the page.
+            success_msg_str: Optional confirmation banner to display on the
+                page.
+            success_dismiss_ms: How long the confirmation stays on screen
+                before dismissing itself.
 
         Returns:
             The rendered users and roles page response.
@@ -189,7 +234,9 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
             active_admin_page="admin_page_users_roles",
             users=users,
             invites=invites,
-            error_msg_str=error_msg_str)
+            error_msg_str=error_msg_str,
+            success_msg_str=success_msg_str,
+            success_dismiss_ms=success_dismiss_ms)
 
     async def _fetch_pending_invites(self) -> list[dict]:
         """Fetch the list of pending invites from the gateway.

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -14,7 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from datetime import datetime, timezone
+from http import HTTPStatus
 import logging
+from typing import Optional
+from quart import request
+from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_web_portal.configuration import Configuration
 from items.services.items_web_portal.decorators import require_administrator
@@ -27,9 +32,9 @@ from items.services.items_web_portal.portal_page_handler import (
 class AdminUsersAndRolesPageHandler(PortalPageHandler):
     """Handles requests for the administration users and roles page.
 
-    This handler fetches the current list of users from the gateway and
-    renders the administration page used to manage user accounts and role
-    assignments.
+    This handler fetches the current list of users and pending invites from
+    the gateway and renders the administration page used to manage user
+    accounts, role assignments, and outstanding invites.
     """
 
     def __init__(self,
@@ -48,29 +53,134 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
 
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
     @require_administrator
     async def users_and_roles(self):
         """Render the administration users and roles page.
 
-        Fetches all users from the gateway and passes them to the template.
-        On gateway failure the page is rendered with an empty user list and
-        an error message.
-
         Returns:
             The rendered administration users and roles page response.
         """
-        url = f"{self._config.apis_gateway_svc}web/users"
-        response = await self._rest_client.get(url)
+        return await self._render()
 
-        if response.status_code == 200:
-            users = response.body.get("users", [])
-            error_msg_str = None
+    # ------------------------------------------------------------------
+    # Write: invites
+    # ------------------------------------------------------------------
+
+    @require_administrator
+    async def invite_user(self):
+        """Create a new pending invite from the submitted form.
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        email_address = form.get("email_address", "").strip()
+
+        if not email_address:
+            return await self._render(
+                error_msg_str="Email address is required.")
+
+        url = f"{self._config.apis_gateway_svc}web/invites"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data={"email_address": email_address})
+
+        return await self._render_after_write(response, "invite")
+
+    @require_administrator
+    async def resend_invite(self):
+        """Refresh the token and expiry for a pending invite.
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        email_address = form.get("email_address", "").strip()
+
+        url = f"{self._config.apis_gateway_svc}web/invites/resend"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data={"email_address": email_address})
+
+        return await self._render_after_write(response, "resend")
+
+    @require_administrator
+    async def uninvite(self):
+        """Cancel a pending invite.
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        email_address = form.get("email_address", "").strip()
+
+        url = f"{self._config.apis_gateway_svc}web/invites/uninvite"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data={"email_address": email_address})
+
+        return await self._render_after_write(response, "uninvite")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    async def _render_after_write(self, response: ApiResponse,
+                                  action: str):
+        """Re-render the page after a write, surfacing any gateway error.
+
+        Args:
+            response: The gateway response for the write operation.
+            action: Short action name used in logging ("invite", "resend",
+                "uninvite").
+
+        Returns:
+            The re-rendered users and roles page.
+        """
+        error_msg_str: Optional[str] = None
+
+        if response.status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
+            error_msg_str = self._extract_error(response)
+            self._logger.warning(
+                "Invite %s failed (status %s): %s",
+                action, response.status_code, error_msg_str)
+
+        return await self._render(error_msg_str=error_msg_str)
+
+    @staticmethod
+    def _extract_error(response: ApiResponse) -> str:
+        """Extract a human-readable error message from a gateway response."""
+        if isinstance(response.body, dict) and response.body.get("error"):
+            return str(response.body["error"])
+        return "The request could not be completed. Please try again."
+
+    async def _render(self, error_msg_str: Optional[str] = None):
+        """Fetch users and pending invites, then render the page.
+
+        Args:
+            error_msg_str: Optional error banner to display on the page.
+
+        Returns:
+            The rendered users and roles page response.
+        """
+        base_url = self._config.apis_gateway_svc
+
+        users_response = await self._rest_client.get(f"{base_url}web/users")
+        if users_response.status_code == HTTPStatus.OK:
+            users = users_response.body.get("users", [])
         else:
             self._logger.error(
                 "Failed to fetch users from gateway: status=%s",
-                response.status_code)
+                users_response.status_code)
             users = []
-            error_msg_str = "Could not load users — please try again."
+            error_msg_str = error_msg_str or (
+                "Could not load users — please try again.")
+
+        invites = await self._fetch_pending_invites()
 
         return await self._render_page(
             pages.PAGE_INSTANCE_ADMIN_USERS_AND_ROLES,
@@ -78,4 +188,55 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
             active_page="administration",
             active_admin_page="admin_page_users_roles",
             users=users,
+            invites=invites,
             error_msg_str=error_msg_str)
+
+    async def _fetch_pending_invites(self) -> list[dict]:
+        """Fetch the list of pending invites from the gateway.
+
+        A failure here is non-fatal: the table is simply rendered empty so
+        the rest of the page still works.
+
+        Returns:
+            A list of ``{"email_address", "created_at", "expires_at",
+            "created_display", "expires_display"}`` dicts, or an empty
+            list on failure. The ``*_display`` fields are pre-formatted,
+            human-readable strings - there's no date-formatting Jinja
+            filter registered anywhere in this codebase yet, so this is
+            done here rather than introducing one for a single page.
+        """
+        url = f"{self._config.apis_gateway_svc}web/invites"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch pending invites")
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch pending invites (status %s)",
+                response.status_code)
+            return []
+
+        invites = response.body.get("invites", [])
+        for invite in invites:
+            invite["created_display"] = self._format_epoch(
+                invite.get("created_at"))
+            invite["expires_display"] = self._format_epoch(
+                invite.get("expires_at"))
+        return invites
+
+    @staticmethod
+    def _format_epoch(epoch_seconds: Optional[int]) -> str:
+        """Format an epoch-seconds timestamp for display.
+
+        Args:
+            epoch_seconds: Seconds since the Unix epoch, or None.
+
+        Returns:
+            A ``"YYYY-MM-DD HH:MM UTC"`` string, or ``""`` if not given.
+        """
+        if epoch_seconds is None:
+            return ""
+        return datetime.fromtimestamp(
+            epoch_seconds, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")

--- a/items/services/items_web_portal/page_handlers/auth/__init__.py
+++ b/items/services/items_web_portal/page_handlers/auth/__init__.py
@@ -25,6 +25,8 @@ from items.services.items_web_portal.page_handlers.auth.login_post_page_handler 
     import LoginPostPageHandler
 from items.services.items_web_portal.page_handlers.auth.logout_page_handler \
     import LogoutPageHandler
+from items.services.items_web_portal.page_handlers.auth.accept_invite_page_handler \
+    import AcceptInvitePageHandler
 
 
 def create_auth_page_handlers(injections: PageHandlerInjections) -> Blueprint:
@@ -68,6 +70,11 @@ def create_auth_page_handlers(injections: PageHandlerInjections) -> Blueprint:
         injections.logger,
         injections.config,
         injections.rest_client)
+    handler_accept_invite: AcceptInvitePageHandler = AcceptInvitePageHandler(
+        injections.logger,
+        injections.config,
+        injections.rest_client,
+        injections.metadata)
 
     routes = Blueprint('auth_routes', __name__)
 
@@ -96,6 +103,26 @@ def create_auth_page_handlers(injections: PageHandlerInjections) -> Blueprint:
     @routes.route('/login', methods=['GET'])
     async def login_page_request_get():
         return await handler_login_get.login_get()
+
+    # Accept invitation: '/accept_invite'
+    #
+    # Both routes are intentionally unauthenticated - someone following an
+    # invitation link has no account yet, so no session guard can apply. The
+    # invite token authorises the request instead, and is validated by the
+    # gateway rather than trusted from this page.
+    injections.logger.debug("=> %s GET /accept_invite",
+                            "Accept invitation (read page)".ljust(40))
+
+    @routes.route('/accept_invite', methods=['GET'])
+    async def accept_invite_request_get():
+        return await handler_accept_invite.accept_invite_get()
+
+    injections.logger.debug("=> %s POST /accept_invite",
+                            "Accept invitation (create account)".ljust(40))
+
+    @routes.route('/accept_invite', methods=['POST'])
+    async def accept_invite_request_post():
+        return await handler_accept_invite.accept_invite_post()
 
     # Logout page: '/logout'
     injections.logger.debug("=> %s GET /logout",

--- a/items/services/items_web_portal/page_handlers/auth/accept_invite_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/auth/accept_invite_page_handler.py
@@ -1,0 +1,185 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+Copyright 2017-2025 INTMAC Development Team [Defunct]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import logging
+from quart import request
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.configuration import Configuration
+from items.services.items_web_portal.metadata_settings import MetadataSettings
+import items.services.items_web_portal.page_locations as pages
+from items.services.items_web_portal.portal_page_handler import (
+    PortalPageHandler)
+
+_MIN_PASSWORD_LENGTH: int = 8
+
+
+class AcceptInvitePageHandler(PortalPageHandler):
+    """Serves the page an invited person uses to set up their account.
+
+    Deliberately **not** guarded by ``require_session`` or
+    ``require_administrator``: the visitor has no account yet, which is the
+    whole point. The invite token in the link is what authorises them, and it
+    is validated by the gateway rather than trusted here.
+
+    The form intentionally offers a narrow set of fields. The email address is
+    fixed by the invite and displayed read-only, and there is no way to choose
+    roles or projects - a recipient must not be able to grant themselves
+    access. Those remain an administrator's decision.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: Configuration,
+                 rest_client: RestClient,
+                 metadata: MetadataSettings):
+        """Initialise the accept invite page handler.
+
+        Args:
+            logger:      Logger used for diagnostic messages.
+            config:      Application configuration.
+            rest_client: REST client used to talk to the gateway.
+            metadata:    Instance metadata used when rendering pages.
+        """
+        super().__init__(logger, config, rest_client)
+        self._metadata_settings = metadata
+
+    async def accept_invite_get(self):
+        """Render the account setup form for an invitation link.
+
+        Returns:
+            The setup form when the token is valid, otherwise the same page
+            showing that the invitation is no longer usable.
+        """
+        token: str = request.args.get("token", "")
+
+        if not token:
+            return await self._render_invalid("No invitation token supplied.")
+
+        email_address = await self._resolve_token(token)
+        if email_address is None:
+            return await self._render_invalid(
+                "This invitation is no longer valid. It may have expired or "
+                "already been used. Please ask an administrator to send a "
+                "new one.")
+
+        return await self._render_form(token, email_address)
+
+    async def accept_invite_post(self):
+        """Submit the completed form to the gateway to create the account.
+
+        Returns:
+            A redirect to the login page on success, or the form re-rendered
+            with an error message.
+        """
+        form = await request.form
+
+        token: str = form.get("token", "")
+        full_name: str = (form.get("full_name") or "").strip()
+        display_name: str = (form.get("display_name") or "").strip()
+        password: str = form.get("password") or ""
+        confirm_password: str = form.get("confirm_password") or ""
+
+        if not token:
+            return await self._render_invalid("No invitation token supplied.")
+
+        # The address always comes from the invite, never from the form, so a
+        # tampered submission cannot create an account for another address.
+        email_address = await self._resolve_token(token)
+        if email_address is None:
+            return await self._render_invalid(
+                "This invitation is no longer valid. It may have expired or "
+                "already been used.")
+
+        error = self._validate(full_name, display_name, password,
+                               confirm_password)
+        if error:
+            return await self._render_form(token, email_address, error=error)
+
+        base_url: str = self._config.apis_gateway_svc
+        response: ApiResponse = await self._rest_client.post(
+            f"{base_url}web/accept_invite",
+            json_data={"token": token,
+                       "full_name": full_name,
+                       "display_name": display_name,
+                       "password": password})
+
+        if response.status_code != HTTPStatus.CREATED:
+            message = "Your account could not be created. Please try again."
+            if isinstance(response.body, dict) and response.body.get("error"):
+                message = str(response.body["error"])
+
+            self._logger.warning("Invite acceptance failed (status %s): %s",
+                                 response.status_code, message)
+            return await self._render_form(token, email_address, error=message)
+
+        return await self._render_page(
+            pages.PAGE_ACCEPT_INVITE,
+            instance_name=self._metadata_settings.instance_name,
+            account_created=True)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate(full_name: str,
+                  display_name: str,
+                  password: str,
+                  confirm_password: str) -> str | None:
+        """Check the submitted fields, returning an error message or None."""
+        if not full_name or not display_name:
+            return "Please provide both your full name and a display name."
+
+        if len(password) < _MIN_PASSWORD_LENGTH:
+            return (f"Your password must be at least {_MIN_PASSWORD_LENGTH} "
+                    "characters long.")
+
+        if password != confirm_password:
+            return "The passwords entered do not match."
+
+        return None
+
+    async def _resolve_token(self, token: str) -> str | None:
+        """Ask the gateway which address an invite was issued to."""
+        base_url: str = self._config.apis_gateway_svc
+        response: ApiResponse = await self._rest_client.get(
+            f"{base_url}web/invites/token/{token}")
+
+        if response.status_code != HTTPStatus.OK:
+            return None
+
+        return (response.body or {}).get("email_address")
+
+    async def _render_form(self,
+                           token: str,
+                           email_address: str,
+                           error: str | None = None):
+        """Render the account setup form."""
+        return await self._render_page(
+            pages.PAGE_ACCEPT_INVITE,
+            instance_name=self._metadata_settings.instance_name,
+            token=token,
+            email_address=email_address,
+            error_message=error)
+
+    async def _render_invalid(self, message: str):
+        """Render the page explaining the invitation cannot be used."""
+        return await self._render_page(
+            pages.PAGE_ACCEPT_INVITE,
+            instance_name=self._metadata_settings.instance_name,
+            invalid_message=message)

--- a/items/services/items_web_portal/page_locations.py
+++ b/items/services/items_web_portal/page_locations.py
@@ -18,6 +18,9 @@ limitations under the License.
 # Login page template
 TEMPLATE_LOGIN_PAGE: str = "login.html"
 
+# Account setup page reached from an invitation email link
+PAGE_ACCEPT_INVITE: str = "accept_invite.html"
+
 # Dashboard page template
 TEMPLATE_DASHBOARD_PAGE: str = "dashboard.html"
 

--- a/items/services/items_web_portal/static/scripts/instance_admin_users_roles.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_users_roles.js
@@ -1,0 +1,33 @@
+/*
+ * Users & Roles page behaviour.
+ *
+ * Confirmation banners dismiss themselves after a delay set per message by
+ * the server (data-auto-dismiss-ms). Errors deliberately carry no such
+ * attribute and stay until the user closes them: a missed confirmation costs
+ * nothing, whereas a missed error leaves someone believing an action
+ * succeeded when it did not.
+ */
+(function () {
+  var banners = document.querySelectorAll('[data-auto-dismiss-ms]');
+
+  Array.prototype.forEach.call(banners, function (banner) {
+    var delay = parseInt(banner.getAttribute('data-auto-dismiss-ms'), 10);
+
+    // No delay, an unparsable one, or zero means "leave it alone", so a
+    // malformed value fails towards keeping the message rather than hiding
+    // it prematurely.
+    if (!delay || delay <= 0) {
+      return;
+    }
+
+    window.setTimeout(function () {
+      // Bootstrap may not be present in a test harness that renders the
+      // template without the full page; fall back to simply hiding.
+      if (window.bootstrap && window.bootstrap.Alert) {
+        window.bootstrap.Alert.getOrCreateInstance(banner).close();
+      } else {
+        banner.style.display = 'none';
+      }
+    }, delay);
+  });
+})();

--- a/items/services/items_web_portal/templates/accept_invite.html
+++ b/items/services/items_web_portal/templates/accept_invite.html
@@ -1,0 +1,107 @@
+{% extends "bootstrap_enabled_template.html" %}
+{% block title %}Integrated Test Management Suite | Accept Invitation{% endblock %}
+{% block head %}{{ super() }}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/login.css') }}">
+  <style>
+    /* login.css gives the page a dark navy background, against which the
+       default Bootstrap text colours are unreadable. This is a minimal
+       contrast fix only - the page still needs proper styling. */
+    .accept-invite,
+    .accept-invite .form-label,
+    .accept-invite h3,
+    .accept-invite h5 {
+        color: #ffffff;
+    }
+
+    /* .text-muted and .form-text both resolve to a dark grey that vanishes
+       on the navy background. */
+    .accept-invite .form-text,
+    .accept-invite .text-muted {
+        color: #cfd8e3 !important;
+    }
+
+    /* A disabled input is greyed by the browser; keep it legible while still
+       reading as non-editable. */
+    .accept-invite input:disabled {
+        background-color: #e9edf2;
+        color: #33415c;
+        opacity: 1;
+    }
+  </style>
+{% endblock %}
+
+{% block page_body %}
+<div class="container accept-invite" style="max-width: 540px; margin-top: 60px;">
+
+  <h3 class="mb-1">{{ instance_name or 'ITEMS' }}</h3>
+
+  {% if account_created %}
+    <h5 class="text-muted mb-4">Account created</h5>
+    <div class="alert alert-success" role="alert">
+      Your account is ready. A confirmation has been sent to your email
+      address.
+    </div>
+    <a class="btn btn-primary" href="/login">Continue to sign in</a>
+
+  {% elif invalid_message %}
+    <h5 class="text-muted mb-4">Invitation</h5>
+    <div class="alert alert-warning" role="alert">
+      {{ invalid_message }}
+    </div>
+    <a class="btn btn-secondary" href="/login">Go to sign in</a>
+
+  {% else %}
+    <h5 class="text-muted mb-4">Set up your account</h5>
+
+    {% if error_message %}
+    <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+    {% endif %}
+
+    <form method="POST" action="/accept_invite">
+      <input type="hidden" name="token" value="{{ token }}">
+
+      <div class="mb-3">
+        <label for="email_address" class="form-label">Email address</label>
+        {# Fixed by the invitation. Shown so it is clear which invitation is
+           being accepted, but not editable and never submitted - the server
+           takes the address from the invite record regardless. #}
+        <input type="email" class="form-control" id="email_address"
+               value="{{ email_address }}" disabled readonly>
+        <div class="form-text">
+          This is the address your invitation was sent to and cannot be
+          changed.
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <label for="full_name" class="form-label">Full name</label>
+        <input type="text" class="form-control" id="full_name"
+               name="full_name" required autofocus>
+      </div>
+
+      <div class="mb-3">
+        <label for="display_name" class="form-label">Display name</label>
+        <input type="text" class="form-control" id="display_name"
+               name="display_name" required>
+        <div class="form-text">The name other people will see.</div>
+      </div>
+
+      <div class="mb-3">
+        <label for="password" class="form-label">Password</label>
+        <input type="password" class="form-control" id="password"
+               name="password" minlength="8" required>
+        <div class="form-text">At least 8 characters.</div>
+      </div>
+
+      <div class="mb-4">
+        <label for="confirm_password" class="form-label">Confirm password</label>
+        <input type="password" class="form-control" id="confirm_password"
+               name="confirm_password" minlength="8" required>
+      </div>
+
+      <button type="submit" class="btn btn-primary">Create my account</button>
+    </form>
+  {% endif %}
+
+</div>
+{% endblock %}

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -8,6 +8,12 @@
 
 {% block body_params %}id="body-pd"{% endblock %}
 
+{% block postBody %}{{ super() }}
+<script type="text/javascript"
+        src="{{ url_for('static', filename='scripts/instance_admin_users_roles.js') }}">
+</script>
+{% endblock %}
+
 {% block instance_admin_body %}
     <div class="flex-grow-1">
       <h4 class="mb-3">Users & Roles</h4>
@@ -16,6 +22,22 @@
       {% if error_msg_str %}
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
         {{ error_msg_str }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+      {% endif %}
+
+      {# Confirmations clear themselves after a few seconds; errors do not.
+         A missed confirmation costs nothing, whereas a missed error leaves
+         the user believing something worked when it did not.
+
+         The dismiss delay is set per message by the handler: the resend
+         confirmation gets longer, because it reports that the previous
+         invitation link has stopped working - a fact worth reading rather
+         than merely an acknowledgement. #}
+      {% if success_msg_str %}
+      <div class="alert alert-success alert-dismissible fade show" role="alert"
+           data-auto-dismiss-ms="{{ success_dismiss_ms }}">
+        {{ success_msg_str }}
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       </div>
       {% endif %}

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -12,6 +12,14 @@
     <div class="flex-grow-1">
       <h4 class="mb-3">Users & Roles</h4>
       <hr />
+
+      {% if error_msg_str %}
+      <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        {{ error_msg_str }}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+      </div>
+      {% endif %}
+
       <table class="table">
         <thead>
           <tr>
@@ -59,12 +67,80 @@
         {% endfor %}
         </tbody>
       </table>
-      <div class="mt-3">
+      <div class="mt-3 mb-4">
         <button class="btn btn-primary" onclick="window.location.href='/admin/users_roles/add'">+ Add User</button>
+        <button class="btn btn-outline-primary" type="button"
+                data-bs-toggle="modal" data-bs-target="#inviteUserModal">+ Invite User</button>
       </div>
+
+      <h5 class="mb-3">Pending Invites</h5>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">Email Address</th>
+            <th scope="col">Invited</th>
+            <th scope="col">Expires</th>
+            <th scope="col" class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for invite in invites %}
+        <tr>
+          <td>{{ invite.email_address }}</td>
+          <td>{{ invite.created_display }}</td>
+          <td>{{ invite.expires_display }}</td>
+          <td class="text-end">
+            <form class="d-inline" method="POST" action="/admin/users_roles/invite/resend">
+              <input type="hidden" name="email_address" value="{{ invite.email_address }}">
+              <button type="submit" class="btn btn-link text-primary p-1" title="Resend invite">
+                <i class="bi bi-arrow-repeat"></i>
+              </button>
+            </form>
+            <form class="d-inline" method="POST" action="/admin/users_roles/invite/uninvite"
+                  onsubmit="return confirm('Cancel the invite for {{ invite.email_address }}?');">
+              <input type="hidden" name="email_address" value="{{ invite.email_address }}">
+              <button type="submit" class="btn btn-link text-danger p-1" title="Cancel invite">
+                <i class="bi bi-x-circle"></i>
+              </button>
+            </form>
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="4" class="text-muted">No pending invites.</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
     </div>
 
-    {% if error_msg_str %}
-    <div id="error_msg">{{ error_msg_str }}</div>
-    {% endif %}
+<!-- Invite User modal -->
+<div class="modal fade" id="inviteUserModal" tabindex="-1"
+     aria-labelledby="inviteUserModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <form method="POST" action="/admin/users_roles/invite">
+        <div class="modal-header">
+          <h5 class="modal-title" id="inviteUserModalLabel">Invite User</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="invite-email" class="form-label">Email Address</label>
+            <input type="email" class="form-control" id="invite-email" name="email_address"
+                   required placeholder="e.g. jane@example.com">
+            <div class="form-text">
+              An invite link valid for 48 hours will be generated. The
+              invited person completes their own registration.
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Send Invite</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 1
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 8"
+PRE_RELEASE = "Alpha Build 9"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -719,6 +719,25 @@
                 }
               },
               "response": []
+            },
+            {
+              "name": "Get Invite By Token",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/invites/token/{{INVITE_TOKEN}}",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "invites",
+                    "token",
+                    "{{INVITE_TOKEN}}"
+                  ]
+                }
+              },
+              "response": []
             }
           ]
         },
@@ -1528,6 +1547,53 @@
                         "web",
                         "invites",
                         "uninvite"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Get Invite By Token (unauthenticated)",
+                  "request": {
+                    "method": "GET",
+                    "header": [],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/invites/token/{{INVITE_TOKEN}}",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "invites",
+                        "token",
+                        "{{INVITE_TOKEN}}"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Accept Invite (unauthenticated)",
+                  "request": {
+                    "method": "POST",
+                    "header": [],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"token\": \"{{INVITE_TOKEN}}\",\n    \"full_name\": \"Gemma Tester\",\n    \"display_name\": \"Gemma\",\n    \"password\": \"a-strong-password\"\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/accept_invite",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "accept_invite"
                       ]
                     }
                   },

--- a/scripts/lintCms.bat
+++ b/scripts/lintCms.bat
@@ -1,2 +1,2 @@
 SET PYTHONPATH=.
-pylint items/services/items_cms
+python -m pylint items/services/items_cms

--- a/scripts/lintGateway.bat
+++ b/scripts/lintGateway.bat
@@ -1,2 +1,2 @@
 SET PYTHONPATH=.
-pylint items/services/items_gateway
+python -m pylint items/services/items_gateway

--- a/scripts/lintIdentity.bat
+++ b/scripts/lintIdentity.bat
@@ -1,2 +1,2 @@
 SET PYTHONPATH=.
-pylint items/services/items_identity
+python -m pylint items/services/items_identity

--- a/scripts/lintWebPortal.bat
+++ b/scripts/lintWebPortal.bat
@@ -1,3 +1,3 @@
 @echo off
 SET PYTHONPATH=.
-pylint items\services\items_web_portal
+python -m pylint items\services\items_web_portal

--- a/scripts/testCMS.bat
+++ b/scripts/testCMS.bat
@@ -1,5 +1,5 @@
 set PYTHONPATH=unit_tests/items_cms
 set ITEMS_CMS_SVC_CONFIG_FILE=
 
-coverage run --rcfile=.github/workflows/.coveragerc_cms_svc -m unittest -v unit_tests/items_cms/main.py
-coverage report -m
+python -m coverage run --rcfile=.github/workflows/.coveragerc_cms_svc -m unittest -v unit_tests/items_cms/main.py
+python -m coverage report -m

--- a/scripts/testGateway.bat
+++ b/scripts/testGateway.bat
@@ -4,5 +4,5 @@ SET ITEMS_GATEWAY_SVC_CONFIG_FILE=
 SET ITEMS_GATEWAY_SVC_CONFIG_FILE_REQUIRED=
 
 SET PYTHONPATH=items/shared;services/gateway_svc;unit_tests/items_gateway
-coverage run --rcfile=.github/workflows/.coveragerc_gateway_svc -m unittest -v unit_tests/items_gateway/main.py
-coverage report -m
+python -m coverage run --rcfile=.github/workflows/.coveragerc_gateway_svc -m unittest -v unit_tests/items_gateway/main.py
+python -m coverage report -m

--- a/scripts/testIdentity.bat
+++ b/scripts/testIdentity.bat
@@ -1,5 +1,5 @@
 set PYTHONPATH=.;items/services/items_identity;unit_tests/items_identity
 set ITEMS_IDENTITY_CONFIG_FILE=
 
-coverage run --rcfile=.github/workflows/.coveragerc_identity_svc -m unittest -v unit_tests/items_identity/main.py
-coverage report -m
+python -m coverage run --rcfile=.github/workflows/.coveragerc_identity_svc -m unittest -v unit_tests/items_identity/main.py
+python -m coverage report -m

--- a/scripts/testShared.bat
+++ b/scripts/testShared.bat
@@ -1,4 +1,4 @@
 SET PYTHONPATH=.;unit_tests/shared
 
-coverage run --rcfile=.github/workflows/.coveragerc_shared -m unittest -v unit_tests/shared/main.py
-coverage report -m
+python -m coverage run --rcfile=.github/workflows/.coveragerc_shared -m unittest -v unit_tests/shared/main.py
+python -m coverage report -m

--- a/scripts/testWebPortal.bat
+++ b/scripts/testWebPortal.bat
@@ -1,4 +1,4 @@
 rem @echo off
 SET PYTHONPATH=items/shared;services/web_portal_svc;unit_tests/web_portal_svc;common
-coverage run --rcfile=.github/workflows/.coveragerc_web_portal_svc -m unittest -v unit_tests/web_portal_svc/main.py
-coverage report -m
+python -m coverage run --rcfile=.github/workflows/.coveragerc_web_portal_svc -m unittest -v unit_tests/web_portal_svc/main.py
+python -m coverage report -m

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -49,6 +49,11 @@ from test_users_handlers import (
     TestResetPasswordHandler,
     TestResetPasswordHandlerEmail,
 )
+from test_invite_emails import (
+    TestCreateInviteSendsEmail,
+    TestResendInviteSendsEmail,
+    TestInviteBlueprintWiring,
+)
 from test_invites_handlers import (
     TestGetInvitesHandler,
     TestCreateInviteHandler,

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -54,6 +54,10 @@ from test_invite_emails import (
     TestResendInviteSendsEmail,
     TestInviteBlueprintWiring,
 )
+from test_accept_invite_handler import (
+    TestAcceptInviteHandler,
+    TestGetInviteByTokenHandler,
+)
 from test_invites_handlers import (
     TestGetInvitesHandler,
     TestCreateInviteHandler,

--- a/unit_tests/items_gateway/test_accept_invite_handler.py
+++ b/unit_tests/items_gateway/test_accept_invite_handler.py
@@ -161,6 +161,13 @@ class TestAcceptInviteHandler(unittest.IsolatedAsyncioTestCase):
         response = await self._post({**_FORM, "password": ""})
         self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
 
+    async def test_non_json_body_is_rejected(self):
+        async with self.client as c:
+            response = await c.post("/accept_invite", data="not json at all")
+
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.mock_rc.get.assert_not_awaited()
+
     # ------------------------------------------------------------------
     # Success and failure reporting
     # ------------------------------------------------------------------

--- a/unit_tests/items_gateway/test_accept_invite_handler.py
+++ b/unit_tests/items_gateway/test_accept_invite_handler.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for redeeming an invitation:
+  GET  /invites/token/<token>  - GetInviteByTokenHandler
+  POST /accept_invite          - AcceptInviteHandler
+
+Two behaviours here are security properties rather than conveniences, and
+have dedicated tests:
+
+  * The account's email address comes from the invite record, never from the
+    submitted body - otherwise an invitation issued to one address could be
+    redeemed to create an account for another.
+  * The invite is consumed before the account is created, so a failure cannot
+    leave a live invite that is redeemable more than once.
+"""
+import json
+import unittest
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.invites.accept_invite_handler import (
+    AcceptInviteHandler)
+from items.services.items_gateway.routes.web.invites.get_invite_by_token_handler import (
+    GetInviteByTokenHandler)
+from items.services.items_gateway.services.email_service import (
+    EmailServiceError)
+
+_LOGGER = MagicMock()
+_TOKEN = "550e8400-e29b-41d4-a716-446655440000"
+_INVITED = "invitee@example.com"
+_PORTAL = "http://portal.example/"
+
+_FORM = {
+    "token": _TOKEN,
+    "full_name": "Gemma Tester",
+    "display_name": "Gemma",
+    "password": "a-strong-password",
+}
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_identity_svc = "http://identity/"
+    cfg.apis_web_portal_svc = _PORTAL
+    return cfg
+
+
+class TestAcceptInviteHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        self.mock_email = AsyncMock()
+        self.handler = AcceptInviteHandler(_LOGGER, _config(), self.mock_rc,
+                                           self.mock_email)
+
+        app = Quart(__name__)
+
+        @app.route("/accept_invite", methods=["POST"])
+        async def route():
+            return await self.handler.accept_invite()
+
+        self.client = app.test_client()
+
+        # Default happy path: token resolves, consume succeeds, user created.
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"email_address": _INVITED})
+        self._set_post_results(consume_ok=True, create_status=HTTPStatus.CREATED)
+
+    def _set_post_results(self, consume_ok, create_status):
+        """Route POSTs by URL: uninvite consumes, users creates."""
+        async def post(url, json_data=None, **_kwargs):
+            if "uninvite" in url:
+                return ApiResponse(
+                    status_code=HTTPStatus.OK if consume_ok
+                    else HTTPStatus.INTERNAL_SERVER_ERROR,
+                    body={})
+            return ApiResponse(status_code=create_status,
+                               body={"id": "new-user-uuid"})
+
+        self.mock_rc.post.side_effect = post
+
+    async def _post(self, body=None):
+        async with self.client as c:
+            return await c.post("/accept_invite", json=body or _FORM)
+
+    def _posted_urls(self):
+        return [call.args[0] for call in self.mock_rc.post.await_args_list]
+
+    def _create_payload(self):
+        for call in self.mock_rc.post.await_args_list:
+            if "users" in call.args[0]:
+                return call.kwargs["json_data"]
+        return None
+
+    # ------------------------------------------------------------------
+    # Security properties
+    # ------------------------------------------------------------------
+
+    async def test_email_comes_from_the_invite_not_the_request_body(self):
+        """A tampered body must not create an account for another address."""
+        await self._post({**_FORM, "email_address": "attacker@evil.example"})
+
+        payload = self._create_payload()
+        self.assertEqual(payload["email_address"], _INVITED)
+
+    async def test_invite_is_consumed_before_the_account_is_created(self):
+        await self._post()
+
+        urls = self._posted_urls()
+        consume_at = next(i for i, u in enumerate(urls) if "uninvite" in u)
+        create_at = next(i for i, u in enumerate(urls) if "users" in u)
+        self.assertLess(consume_at, create_at,
+                        "the invite must be consumed before the account is "
+                        "created, or a failure leaves it redeemable again")
+
+    async def test_account_is_not_created_if_the_invite_cannot_be_consumed(self):
+        self._set_post_results(consume_ok=False,
+                               create_status=HTTPStatus.CREATED)
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code,
+                         HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertNotIn("users", " ".join(self._posted_urls()))
+
+    # ------------------------------------------------------------------
+    # Token validation
+    # ------------------------------------------------------------------
+
+    async def test_unusable_token_returns_404_and_creates_nothing(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={"error": "nope"})
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.mock_rc.post.assert_not_awaited()
+
+    async def test_identity_unreachable_creates_nothing(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=None, exception_msg="connection refused")
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+        self.mock_rc.post.assert_not_awaited()
+
+    # ------------------------------------------------------------------
+    # Request validation
+    # ------------------------------------------------------------------
+
+    async def test_missing_fields_are_rejected(self):
+        for field in ("token", "full_name", "display_name", "password"):
+            with self.subTest(missing=field):
+                body = {k: v for k, v in _FORM.items() if k != field}
+                async with self.client as c:
+                    response = await c.post("/accept_invite", json=body)
+                self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    async def test_empty_field_is_rejected(self):
+        response = await self._post({**_FORM, "password": ""})
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+    # ------------------------------------------------------------------
+    # Success and failure reporting
+    # ------------------------------------------------------------------
+
+    async def test_success_returns_201(self):
+        response = await self._post()
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+    async def test_welcome_email_is_sent_on_success(self):
+        await self._post()
+
+        self.mock_email.send.assert_awaited_once()
+        kwargs = self.mock_email.send.await_args.kwargs
+        self.assertEqual(kwargs["to"], _INVITED)
+
+    async def test_welcome_email_failure_does_not_fail_the_request(self):
+        """The account exists; reporting failure would be misleading."""
+        self.mock_email.send.side_effect = EmailServiceError("smtp down")
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+    async def test_creation_failure_after_consuming_asks_for_a_new_invite(self):
+        """The invite is spent, so the message must say what to do next."""
+        self._set_post_results(
+            consume_ok=True, create_status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code,
+                         HTTPStatus.INTERNAL_SERVER_ERROR)
+        body = json.loads(await response.get_data())
+        self.assertIn("new invitation", body["error"].lower())
+
+    async def test_no_welcome_email_when_creation_fails(self):
+        self._set_post_results(
+            consume_ok=True, create_status=HTTPStatus.INTERNAL_SERVER_ERROR)
+
+        await self._post()
+
+        self.mock_email.send.assert_not_awaited()
+
+    async def test_works_without_an_email_service(self):
+        handler = AcceptInviteHandler(_LOGGER, _config(), self.mock_rc, None)
+        app = Quart(__name__)
+
+        @app.route("/accept_invite", methods=["POST"])
+        async def route():
+            return await handler.accept_invite()
+
+        async with app.test_client() as client:
+            response = await client.post("/accept_invite", json=_FORM)
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+
+
+class TestGetInviteByTokenHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        self.handler = GetInviteByTokenHandler(_LOGGER, _config(),
+                                                self.mock_rc)
+
+    async def _call(self):
+        return await self.handler.get_invite_by_token(_TOKEN)
+
+    @staticmethod
+    async def _body(response):
+        return json.loads(await response.get_data())
+
+    async def test_valid_token_returns_the_address(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"email_address": _INVITED})
+
+        response = await self._call()
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual((await self._body(response))["email_address"],
+                         _INVITED)
+
+    async def test_unknown_token_returns_404(self):
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={"error": "nope"})
+
+        response = await self._call()
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_identity_unreachable_returns_500(self):
+        """Distinguished from 404 so an outage is not read as a bad token."""
+        self.mock_rc.get.return_value = ApiResponse(
+            status_code=None, exception_msg="connection refused")
+
+        response = await self._call()
+
+        self.assertEqual(response.status_code,
+                         HTTPStatus.INTERNAL_SERVER_ERROR)

--- a/unit_tests/items_gateway/test_invite_emails.py
+++ b/unit_tests/items_gateway/test_invite_emails.py
@@ -1,0 +1,178 @@
+"""
+Unit tests for invitation email delivery.
+
+Creating an invite must email the invitation, and resending must email the
+regenerated link. The identity service has no mail capability, so the gateway
+is solely responsible for delivery - if these handlers do not send, the invite
+is issued and nobody is ever told about it.
+"""
+import json
+import unittest
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+from quart import Quart
+from items.services.items_gateway.routes.web.invites import (
+    create_invite_routes)
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.invites.create_invite_handler import (
+    CreateInviteHandler)
+from items.services.items_gateway.routes.web.invites.resend_invite_handler import (
+    ResendInviteHandler)
+from items.services.items_gateway.services.email_service import (
+    EmailServiceError)
+from items.services.items_gateway.services.invite_email import (
+    INVITE_SUBJECT, build_invite_url)
+
+_LOGGER = MagicMock()
+_RECIPIENT = "newuser@example.com"
+_BODY = {"email_address": _RECIPIENT}
+_TOKEN = "550e8400-e29b-41d4-a716-446655440000"
+_PORTAL = "http://portal.example/"
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_identity_svc = "http://identity/"
+    cfg.apis_web_portal_svc = _PORTAL
+    return cfg
+
+
+class _InviteEmailCase(unittest.IsolatedAsyncioTestCase):
+    """Shared harness; subclasses set HANDLER, PATH, METHOD and OK_STATUS."""
+
+    HANDLER = None
+    PATH = None
+    METHOD = None
+    OK_STATUS = None
+
+    async def asyncSetUp(self):
+        if self.HANDLER is None:
+            self.skipTest("base class")
+
+        self.mock_rc = AsyncMock()
+        self.mock_email = AsyncMock()
+
+        self.handler = self.HANDLER(_LOGGER, _config(), self.mock_rc,
+                                    self.mock_email)
+        app = Quart(__name__)
+        method_name = self.METHOD
+
+        @app.route(self.PATH, methods=["POST"], endpoint="route")
+        async def route():
+            return await getattr(self.handler, method_name)()
+
+        self.client = app.test_client()
+
+    def _identity_returns(self, status, body):
+        self.mock_rc.post.return_value = ApiResponse(status_code=status,
+                                                     body=body)
+
+    async def _post(self, body=None):
+        async with self.client as c:
+            return await c.post(self.PATH, json=body or _BODY)
+
+    # ------------------------------------------------------------------
+
+    async def test_invitation_is_emailed_on_success(self):
+        self._identity_returns(self.OK_STATUS, {"token": _TOKEN})
+
+        await self._post()
+
+        self.mock_email.send.assert_awaited_once()
+        kwargs = self.mock_email.send.await_args.kwargs
+        self.assertEqual(kwargs["to"], _RECIPIENT)
+        self.assertEqual(kwargs["subject"], INVITE_SUBJECT)
+
+    async def test_email_contains_the_token_link(self):
+        self._identity_returns(self.OK_STATUS, {"token": _TOKEN})
+
+        await self._post()
+
+        body = self.mock_email.send.await_args.kwargs["body"]
+        self.assertIn(build_invite_url(_PORTAL, _TOKEN), body)
+        self.assertIn(_TOKEN, body)
+
+    async def test_no_email_when_identity_rejects_the_request(self):
+        self._identity_returns(HTTPStatus.CONFLICT,
+                               {"error": "already invited"})
+
+        await self._post()
+
+        self.mock_email.send.assert_not_awaited()
+
+    async def test_no_email_when_identity_is_unreachable(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=None, exception_msg="connection refused")
+
+        await self._post()
+
+        self.mock_email.send.assert_not_awaited()
+
+    async def test_no_email_when_response_has_no_token(self):
+        self._identity_returns(self.OK_STATUS, {})
+
+        await self._post()
+
+        self.mock_email.send.assert_not_awaited()
+
+    async def test_delivery_failure_does_not_fail_the_request(self):
+        """The invite exists; reporting failure would be misleading."""
+        self._identity_returns(self.OK_STATUS, {"token": _TOKEN})
+        self.mock_email.send.side_effect = EmailServiceError("smtp down")
+
+        response = await self._post()
+
+        self.assertEqual(response.status_code, self.OK_STATUS)
+        body = json.loads(await response.get_data())
+        self.assertEqual(body["token"], _TOKEN)
+
+    async def test_works_when_no_email_service_is_configured(self):
+        """Mail being unconfigured must not break invite creation."""
+        handler = self.HANDLER(_LOGGER, _config(), self.mock_rc, None)
+        app = Quart(__name__)
+        method_name = self.METHOD
+
+        @app.route(self.PATH, methods=["POST"], endpoint="route_no_mail")
+        async def route():
+            return await getattr(handler, method_name)()
+
+        self._identity_returns(self.OK_STATUS, {"token": _TOKEN})
+
+        async with app.test_client() as client:
+            response = await client.post(self.PATH, json=_BODY)
+
+        self.assertEqual(response.status_code, self.OK_STATUS)
+
+
+class TestCreateInviteSendsEmail(_InviteEmailCase):
+    HANDLER = CreateInviteHandler
+    PATH = "/invites"
+    METHOD = "create_invite"
+    OK_STATUS = HTTPStatus.CREATED
+
+
+class TestResendInviteSendsEmail(_InviteEmailCase):
+    HANDLER = ResendInviteHandler
+    PATH = "/invites/resend"
+    METHOD = "resend_invite"
+    OK_STATUS = HTTPStatus.OK
+
+
+class TestInviteBlueprintWiring(unittest.IsolatedAsyncioTestCase):
+    """The original defect was here: the handlers were constructed without the
+    email service, so no invitation was ever sent."""
+
+    async def test_create_and_resend_receive_the_email_service(self):
+        injections = MagicMock()
+        injections.email_service = MagicMock(name="email_service")
+
+        with patch("items.services.items_gateway.routes.web.invites"
+                   ".CreateInviteHandler") as create_cls, \
+             patch("items.services.items_gateway.routes.web.invites"
+                   ".ResendInviteHandler") as resend_cls:
+            create_invite_routes(injections)
+
+        for name, cls in (("CreateInviteHandler", create_cls),
+                          ("ResendInviteHandler", resend_cls)):
+            self.assertIn(injections.email_service, cls.call_args.args,
+                          f"{name} was not given the email service")

--- a/unit_tests/items_gateway/test_invite_emails.py
+++ b/unit_tests/items_gateway/test_invite_emails.py
@@ -176,3 +176,44 @@ class TestInviteBlueprintWiring(unittest.IsolatedAsyncioTestCase):
                           ("ResendInviteHandler", resend_cls)):
             self.assertIn(injections.email_service, cls.call_args.args,
                           f"{name} was not given the email service")
+
+    async def test_accept_invite_route_is_registered_and_dispatches(self):
+        """A handler that exists but is never registered is unreachable."""
+        from quart import Response as QuartResponse
+
+        injections = MagicMock()
+        handler = MagicMock()
+        handler.accept_invite = AsyncMock(return_value=QuartResponse(
+            json.dumps({"id": "new"}), status=HTTPStatus.CREATED,
+            content_type="application/json"))
+
+        with patch("items.services.items_gateway.routes.web.invites"
+                   ".AcceptInviteHandler", return_value=handler):
+            app = Quart(__name__)
+            app.register_blueprint(create_invite_routes(injections))
+
+            async with app.test_client() as client:
+                response = await client.post("/accept_invite", json={})
+
+        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        handler.accept_invite.assert_awaited_once()
+
+    async def test_token_lookup_route_is_registered_and_dispatches(self):
+        from quart import Response as QuartResponse
+
+        injections = MagicMock()
+        handler = MagicMock()
+        handler.get_invite_by_token = AsyncMock(return_value=QuartResponse(
+            json.dumps({"email_address": _RECIPIENT}), status=HTTPStatus.OK,
+            content_type="application/json"))
+
+        with patch("items.services.items_gateway.routes.web.invites"
+                   ".GetInviteByTokenHandler", return_value=handler):
+            app = Quart(__name__)
+            app.register_blueprint(create_invite_routes(injections))
+
+            async with app.test_client() as client:
+                response = await client.get("/invites/token/some-token")
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        handler.get_invite_by_token.assert_awaited_once_with("some-token")

--- a/unit_tests/items_identity/main.py
+++ b/unit_tests/items_identity/main.py
@@ -24,6 +24,10 @@ from test_apis_invite_management import (
     TestResendInviteHandler,
     TestUninviteHandler,
 )
+from test_invite_token_lookup import (
+    TestGetInviteByTokenService,
+    TestGetInviteByTokenHandler,
+)
 from test_create_routes import (TestCreateAuthRoutes, TestCreateSystemRoutes,
                                 TestCreateInviteRoutes, TestCreateUsersRoutes,
                                 TestCreateRoutes)

--- a/unit_tests/items_identity/test_create_routes.py
+++ b/unit_tests/items_identity/test_create_routes.py
@@ -452,6 +452,33 @@ class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.get_invites.assert_called_once()
 
+    @patch("routes.invites.GetInviteByTokenHandler")
+    @patch("routes.invites.UninviteHandler")
+    @patch("routes.invites.ResendInviteHandler")
+    @patch("routes.invites.CreateInviteHandler")
+    @patch("routes.invites.GetInvitesHandler")
+    async def test_get_invite_by_token_is_registered_and_dispatches(
+            self, _get, _create, _resend, _uninvite, mock_by_token_cls):
+        """The route an invitation link relies on must actually be wired up.
+
+        A handler that exists but is never registered is unreachable, and
+        every other test in this file would still pass.
+        """
+        mock_handler = MagicMock()
+        mock_handler.get_invite_by_token = AsyncMock(
+            return_value=self._ok_response({"email_address": "a@b.com"}))
+        mock_by_token_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_invite_routes(self.mock_logger, self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            response = await client.get("/invites/token/some-token")
+
+        self.assertEqual(response.status_code, 200)
+        mock_handler.get_invite_by_token.assert_called_once_with("some-token")
+
 
 class TestCreateRoutes(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):

--- a/unit_tests/items_identity/test_invite_token_lookup.py
+++ b/unit_tests/items_identity/test_invite_token_lookup.py
@@ -1,0 +1,145 @@
+"""
+Unit tests for resolving an invitation link to the address it was issued to:
+  InviteManagementService.get_invite_by_token
+  GET /invites/token/<token>  - GetInviteByTokenHandler
+
+The address an account is created for comes from here, so a token that is
+unknown, cancelled or expired must never resolve. All three are reported
+identically, so the endpoint cannot be used to probe for valid tokens.
+"""
+import json
+import logging
+import time
+import unittest
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock, patch
+from services.invite_management_service import InviteManagementService
+
+_TOKEN = "550e8400-e29b-41d4-a716-446655440000"
+_EMAIL = "invitee@example.com"
+_NOW = 1_800_000_000
+
+# Row shape: (id, token, email_address, created_at, expires_at,
+#             is_expired, expired_at)
+def _row(is_expired=0, expires_at=_NOW + 3600):
+    return (1, _TOKEN, _EMAIL, _NOW - 3600, expires_at, is_expired, None)
+
+
+class TestGetInviteByTokenService(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.logger = MagicMock(spec=logging.Logger)
+        self.logger.getChild.return_value = MagicMock(spec=logging.Logger)
+        self.invite_repo = MagicMock()
+        self.invite_repo.get_invite_by_token = AsyncMock()
+        self.user_repo = MagicMock()
+
+        self.service = InviteManagementService(
+            self.logger, self.invite_repo, self.user_repo)
+
+        patcher = patch("services.invite_management_service.time.time",
+                        return_value=_NOW)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+    async def test_valid_token_returns_the_invited_address(self):
+        self.invite_repo.get_invite_by_token.return_value = _row()
+
+        result = await self.service.get_invite_by_token(_TOKEN)
+
+        self.assertTrue(result.valid)
+        self.assertEqual(result.email_address, _EMAIL)
+
+    async def test_unknown_token_is_not_valid(self):
+        self.invite_repo.get_invite_by_token.return_value = None
+
+        result = await self.service.get_invite_by_token("nope")
+
+        self.assertFalse(result.valid)
+        self.assertIsNone(result.email_address)
+
+    async def test_cancelled_invite_is_not_valid(self):
+        """is_expired is set by an admin uninvite as well as by timeout."""
+        self.invite_repo.get_invite_by_token.return_value = _row(is_expired=1)
+
+        result = await self.service.get_invite_by_token(_TOKEN)
+
+        self.assertFalse(result.valid)
+
+    async def test_elapsed_invite_is_not_valid(self):
+        self.invite_repo.get_invite_by_token.return_value = _row(
+            expires_at=_NOW - 1)
+
+        result = await self.service.get_invite_by_token(_TOKEN)
+
+        self.assertFalse(result.valid)
+
+    async def test_invite_expiring_exactly_now_is_not_valid(self):
+        self.invite_repo.get_invite_by_token.return_value = _row(
+            expires_at=_NOW)
+
+        result = await self.service.get_invite_by_token(_TOKEN)
+
+        self.assertFalse(result.valid)
+
+    async def test_no_address_leaks_for_any_invalid_case(self):
+        """An unusable token must not reveal who was invited."""
+        for label, row in (("unknown", None),
+                           ("cancelled", _row(is_expired=1)),
+                           ("expired", _row(expires_at=_NOW - 1))):
+            with self.subTest(case=label):
+                self.invite_repo.get_invite_by_token.return_value = row
+                result = await self.service.get_invite_by_token(_TOKEN)
+                self.assertIsNone(result.email_address)
+
+
+class TestGetInviteByTokenHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        from routes.invites.get_invite_by_token_handler import (
+            GetInviteByTokenHandler)
+
+        self.logger = MagicMock(spec=logging.Logger)
+        self.logger.getChild.return_value = MagicMock(spec=logging.Logger)
+
+        with patch("routes.invites.get_invite_by_token_handler."
+                   "InviteRepository"), \
+             patch("routes.invites.get_invite_by_token_handler."
+                   "UserRepository"), \
+             patch("routes.invites.get_invite_by_token_handler."
+                   "InviteManagementService") as svc_cls:
+            self.svc = MagicMock()
+            svc_cls.return_value = self.svc
+            self.handler = GetInviteByTokenHandler(self.logger, MagicMock())
+
+    @staticmethod
+    async def _body(response):
+        return json.loads(await response.get_data())
+
+    async def test_valid_token_returns_200_and_address(self):
+        result = MagicMock(valid=True, email_address=_EMAIL)
+        self.svc.get_invite_by_token = AsyncMock(return_value=result)
+
+        response = await self.handler.get_invite_by_token(_TOKEN)
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual((await self._body(response))["email_address"], _EMAIL)
+
+    async def test_invalid_token_returns_404(self):
+        result = MagicMock(valid=False, email_address=None)
+        self.svc.get_invite_by_token = AsyncMock(return_value=result)
+
+        response = await self.handler.get_invite_by_token("nope")
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_404_body_does_not_reveal_why(self):
+        """Expired, cancelled and unknown must be indistinguishable."""
+        result = MagicMock(valid=False, email_address=None)
+        self.svc.get_invite_by_token = AsyncMock(return_value=result)
+
+        response = await self.handler.get_invite_by_token("nope")
+
+        error = (await self._body(response))["error"].lower()
+        for leak in ("expired", "cancelled", "used", "unknown"):
+            self.assertNotIn(leak, error)

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -15,6 +15,7 @@ from test_service import (
     TestServiceTasksAndShutdown,
     TestGetMetadata,
 )
+from test_accept_invite_page_handler import TestAcceptInvitePageHandler
 from test_auth_handlers import (
     TestIndexPageHandler,
     TestLoginGetPageHandler,

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -27,7 +27,6 @@ from test_admin_stub_handlers import (
     TestAdminIntegrationsPageHandler,
     TestAdminManageDataPageHandler,
     TestAdminSiteSettingsPageHandler,
-    TestAdminUsersAndRolesPageHandler,
 )
 from test_admin_customisations_page_handler import (
     TestCustomisationsRead,
@@ -36,6 +35,13 @@ from test_admin_customisations_page_handler import (
     TestCaseFieldDelete,
     TestCaseFieldMove,
     TestRowToField,
+)
+from test_admin_users_and_roles_page_handler import (
+    TestUsersAndRolesRead,
+    TestInviteUser,
+    TestResendInvite,
+    TestUninvite,
+    TestFormatEpoch,
 )
 from test_admin_projects_handlers import (
     TestAdminProjectsPageHandlers,

--- a/unit_tests/web_portal_svc/test_accept_invite_page_handler.py
+++ b/unit_tests/web_portal_svc/test_accept_invite_page_handler.py
@@ -1,0 +1,195 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock
+from weaver_framework.microservice.api_response import ApiResponse
+from _test_utils import make_app
+from items.services.items_web_portal.page_handlers.auth\
+    .accept_invite_page_handler import AcceptInvitePageHandler
+
+_LOGGER = MagicMock()
+_TOKEN = "550e8400-e29b-41d4-a716-446655440000"
+_INVITED = "invitee@example.com"
+
+_VALID_FORM = {
+    "token": _TOKEN,
+    "full_name": "Gemma Tester",
+    "display_name": "Gemma",
+    "password": "a-strong-password",
+    "confirm_password": "a-strong-password",
+}
+
+
+def _config():
+    config = MagicMock()
+    config.apis_gateway_svc = "http://gateway/"
+    return config
+
+
+class TestAcceptInvitePageHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        metadata = MagicMock()
+        metadata.instance_name = "ITEMS"
+
+        handler = AcceptInvitePageHandler(
+            _LOGGER, _config(), self.mock_rest_client, metadata)
+
+        app = make_app()
+
+        @app.route("/accept_invite", methods=["GET"])
+        async def accept_get():
+            return await handler.accept_invite_get()
+
+        @app.route("/accept_invite", methods=["POST"])
+        async def accept_post():
+            return await handler.accept_invite_post()
+
+        self.client = app.test_client()
+
+        # Default: the token resolves to an invited address.
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"email_address": _INVITED})
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.CREATED, body={"id": "new-uuid"})
+
+    def _token_invalid(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND, body={"error": "nope"})
+
+    async def _get(self, query=""):
+        async with self.client as c:
+            response = await c.get(f"/accept_invite{query}")
+            return await response.get_data(as_text=True)
+
+    async def _post(self, form=None):
+        async with self.client as c:
+            response = await c.post("/accept_invite", form=form or _VALID_FORM)
+            return await response.get_data(as_text=True)
+
+    # ------------------------------------------------------------------
+    # GET
+    # ------------------------------------------------------------------
+
+    async def test_valid_token_shows_the_form_with_the_invited_address(self):
+        text = await self._get(f"?token={_TOKEN}")
+
+        self.assertIn(_INVITED, text)
+        self.assertIn("Create my account", text)
+
+    async def test_invited_address_is_not_editable(self):
+        text = await self._get(f"?token={_TOKEN}")
+
+        self.assertIn("disabled", text)
+
+    async def test_form_offers_no_role_or_project_selection(self):
+        """An invitee must not be able to grant themselves access."""
+        text = (await self._get(f"?token={_TOKEN}")).lower()
+
+        self.assertNotIn("is_administrator", text)
+        self.assertNotIn("project", text)
+
+    async def test_missing_token_shows_no_form(self):
+        text = await self._get()
+
+        self.assertNotIn("Create my account", text)
+        self.mock_rest_client.get.assert_not_awaited()
+
+    async def test_unusable_token_shows_no_form(self):
+        self._token_invalid()
+
+        text = await self._get(f"?token={_TOKEN}")
+
+        self.assertNotIn("Create my account", text)
+        self.assertIn("no longer valid", text)
+
+    # ------------------------------------------------------------------
+    # POST - validation
+    # ------------------------------------------------------------------
+
+    async def test_mismatched_passwords_are_rejected_without_calling_gateway(self):
+        text = await self._post({**_VALID_FORM,
+                                 "confirm_password": "something-else"})
+
+        self.assertIn("do not match", text)
+        self.mock_rest_client.post.assert_not_awaited()
+
+    async def test_short_password_is_rejected(self):
+        text = await self._post({**_VALID_FORM,
+                                 "password": "short",
+                                 "confirm_password": "short"})
+
+        self.assertIn("at least 8", text)
+        self.mock_rest_client.post.assert_not_awaited()
+
+    async def test_missing_names_are_rejected(self):
+        for field in ("full_name", "display_name"):
+            with self.subTest(missing=field):
+                self.mock_rest_client.post.reset_mock()
+                text = await self._post({**_VALID_FORM, field: "   "})
+                self.assertIn("full name", text.lower())
+                self.mock_rest_client.post.assert_not_awaited()
+
+    async def test_rejected_submission_redisplays_the_form(self):
+        text = await self._post({**_VALID_FORM,
+                                 "confirm_password": "something-else"})
+
+        self.assertIn("Create my account", text)
+        self.assertIn(_INVITED, text)
+
+    # ------------------------------------------------------------------
+    # POST - submission
+    # ------------------------------------------------------------------
+
+    async def test_successful_submission_confirms_the_account(self):
+        text = await self._post()
+
+        self.assertIn("Account created", text)
+        self.assertNotIn("Create my account", text)
+
+    async def test_submission_never_sends_an_email_address(self):
+        """The address is the gateway's to determine, from the invite."""
+        await self._post()
+
+        payload = self.mock_rest_client.post.await_args.kwargs["json_data"]
+        self.assertNotIn("email_address", payload)
+        self.assertEqual(payload["token"], _TOKEN)
+
+    async def test_token_is_revalidated_on_submission(self):
+        """A token valid when the page loaded may not be at submit time."""
+        self._token_invalid()
+
+        text = await self._post()
+
+        self.assertIn("no longer valid", text)
+        self.mock_rest_client.post.assert_not_awaited()
+
+    async def test_gateway_error_is_shown_to_the_user(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            body={"error": "Please ask an administrator for a new invitation."})
+
+        text = await self._post()
+
+        self.assertIn("new invitation", text)
+
+    async def test_missing_token_on_submission_is_rejected(self):
+        text = await self._post({**_VALID_FORM, "token": ""})
+
+        self.assertNotIn("Account created", text)
+        self.mock_rest_client.post.assert_not_awaited()

--- a/unit_tests/web_portal_svc/test_admin_stub_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_stub_handlers.py
@@ -26,8 +26,6 @@ from items.services.items_web_portal.page_handlers.admin.\
     admin_manage_data_page_handler import AdminManageDataPageHandler
 from items.services.items_web_portal.page_handlers.admin.\
     admin_site_settings_page_handler import AdminSiteSettingsPageHandler
-from items.services.items_web_portal.page_handlers.admin.\
-    admin_users_and_roles_page_handler import AdminUsersAndRolesPageHandler
 
 _LOGGER = MagicMock()
 
@@ -112,56 +110,6 @@ TestAdminManageDataPageHandler = _make_stub_test(
     AdminManageDataPageHandler, "manage_data", "/admin/manage_data")
 TestAdminSiteSettingsPageHandler = _make_stub_test(
     AdminSiteSettingsPageHandler, "site_settings", "/admin/site_settings")
-class TestAdminUsersAndRolesPageHandler(unittest.IsolatedAsyncioTestCase):
-    """Users & Roles list page — now fetches users from gateway."""
-
-    async def asyncSetUp(self):
-        self.mock_rest_client = AsyncMock()
-        self.mock_rest_client.post.return_value = ApiResponse(
-            status_code=HTTPStatus.OK,
-            body={"status": "VALID", "is_administrator": True})
-        handler = AdminUsersAndRolesPageHandler(
-            _LOGGER, _config(), self.mock_rest_client, _metadata())
-
-        app = make_app()
-
-        @app.route("/admin/users_roles", methods=["GET"])
-        async def route():
-            return await handler.users_and_roles()
-
-        self.client = app.test_client()
-
-    async def _get(self, headers=_AUTH_HEADERS):
-        async with self.client as c:
-            return await c.get("/admin/users_roles", headers=headers)
-
-    async def test_renders_page_with_users(self):
-        self.mock_rest_client.get.return_value = ApiResponse(
-            status_code=HTTPStatus.OK,
-            body={"users": [{"id": 1, "full_name": "Alice"}]})
-        response = await self._get()
-        self.assertEqual(response.status_code, 200)
-
-    async def test_gateway_failure_renders_error_message(self):
-        self.mock_rest_client.get.return_value = ApiResponse(
-            status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})
-        response = await self._get()
-        self.assertEqual(response.status_code, 200)
-        text = await response.get_data(as_text=True)
-        self.assertIn("Could not load users", text)
-
-    async def test_redirects_when_not_authenticated(self):
-        response = await self._get(headers={})
-        text = await response.get_data(as_text=True)
-        self.assertIn("Refresh", text)
-
-    async def test_redirects_when_not_administrator(self):
-        self.mock_rest_client.post.return_value = ApiResponse(
-            status_code=HTTPStatus.OK,
-            body={"status": "VALID", "is_administrator": False})
-        response = await self._get()
-        text = await response.get_data(as_text=True)
-        self.assertIn("Refresh", text)
 
 
 if __name__ == "__main__":

--- a/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
+++ b/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
@@ -1,0 +1,303 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from http import HTTPStatus
+from weaver_framework.microservice.api_response import ApiResponse
+from _test_utils import make_app
+from items.services.items_web_portal.page_handlers.admin.\
+    admin_users_and_roles_page_handler import AdminUsersAndRolesPageHandler
+
+_LOGGER = MagicMock()
+_AUTH_HEADERS = {"Cookie": "items_token=abc; items_user=bob"}
+_SESSION_VALID = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"status": "VALID", "is_administrator": True})
+
+_USERS_OK = ApiResponse(
+    status_code=HTTPStatus.OK, body={"users": [{"id": 1, "full_name": "Alice"}]})
+_INVITES_OK = ApiResponse(
+    status_code=HTTPStatus.OK, body={"invites": [
+        {"email_address": "new@b.com", "created_at": 1700000000,
+         "expires_at": 1700172800}]})
+
+
+def _config():
+    config = MagicMock()
+    config.apis_gateway_svc = "http://gateway/"
+    return config
+
+
+def _metadata():
+    metadata = MagicMock()
+    metadata.instance_name = "INSTANCE"
+    return metadata
+
+
+class TestUsersAndRolesRead(unittest.IsolatedAsyncioTestCase):
+    """GET /admin/users_roles"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        # Default happy path: a single dict body works for both the users
+        # and invites GET calls, since each side only reads its own key.
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"users": _USERS_OK.body["users"],
+                 "invites": _INVITES_OK.body["invites"]})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles", methods=["GET"])
+        async def route():
+            return await handler.users_and_roles()
+
+        self.client = app.test_client()
+
+    async def _get(self, headers=_AUTH_HEADERS):
+        async with self.client as c:
+            return await c.get("/admin/users_roles", headers=headers)
+
+    async def test_renders_page_with_users(self):
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Alice", text)
+
+    async def test_renders_page_with_pending_invites(self):
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("new@b.com", text)
+        self.assertIn("2023-11-14", text)  # formatted created_at
+
+    async def test_no_pending_invites_shows_placeholder(self):
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK,
+            ApiResponse(status_code=HTTPStatus.OK, body={"invites": []})]
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("No pending invites", text)
+
+    async def test_users_gateway_failure_renders_error_message(self):
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={}),
+            _INVITES_OK]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Could not load users", text)
+
+    async def test_invites_fetch_failure_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK,
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("No pending invites", text)
+
+    async def test_invites_fetch_exception_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [_USERS_OK, RuntimeError("boom")]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("No pending invites", text)
+
+    async def test_redirects_when_not_authenticated(self):
+        response = await self._get(headers={})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+    async def test_redirects_when_not_administrator(self):
+        self.mock_rest_client.post.return_value = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"status": "VALID", "is_administrator": False})
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Refresh", text)
+
+
+class TestInviteUser(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/invite"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/invite", methods=["POST"])
+        async def route():
+            return await handler.invite_user()
+
+        self.client = app.test_client()
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post(
+                "/admin/users_roles/invite", form=form, headers=_AUTH_HEADERS)
+
+    async def test_missing_email_renders_error(self):
+        response = await self._post({})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Email address is required", text)
+        self.mock_rest_client.post.assert_called_once()  # only session check
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        response = await self._post({"email_address": "new@b.com"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_email_forwarded_to_gateway(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        await self._post({"email_address": "new@b.com"})
+        url, kwargs = self.mock_rest_client.post.call_args_list[1][0][0], \
+            self.mock_rest_client.post.call_args_list[1][1]
+        self.assertEqual(url, "http://gateway/web/invites")
+        self.assertEqual(kwargs["json_data"], {"email_address": "new@b.com"})
+
+    async def test_already_invited_shows_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT,
+                       body={"error": "A pending invite already exists"})]
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("A pending invite already exists", text)
+
+    async def test_error_without_body_uses_fallback_message(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={})]
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("could not be completed", text)
+
+
+class TestResendInvite(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/invite/resend"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/invite/resend", methods=["POST"])
+        async def route():
+            return await handler.resend_invite()
+
+        self.client = app.test_client()
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post(
+                "/admin/users_roles/invite/resend", form=form,
+                headers=_AUTH_HEADERS)
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        response = await self._post({"email_address": "new@b.com"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_no_pending_invite_shows_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND,
+                       body={"error": "No pending invite found"})]
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("No pending invite found", text)
+
+
+class TestUninvite(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/invite/uninvite"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/invite/uninvite", methods=["POST"])
+        async def route():
+            return await handler.uninvite()
+
+        self.client = app.test_client()
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post(
+                "/admin/users_roles/invite/uninvite", form=form,
+                headers=_AUTH_HEADERS)
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        response = await self._post({"email_address": "new@b.com"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_email_forwarded_to_gateway(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+        await self._post({"email_address": "new@b.com"})
+        call = self.mock_rest_client.post.call_args_list[1]
+        self.assertEqual(call[0][0], "http://gateway/web/invites/uninvite")
+        self.assertEqual(call[1]["json_data"], {"email_address": "new@b.com"})
+
+    async def test_no_pending_invite_shows_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND,
+                       body={"error": "No pending invite found"})]
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("No pending invite found", text)
+
+
+class TestFormatEpoch(unittest.TestCase):
+    """Direct unit tests for the _format_epoch helper."""
+
+    def test_none_returns_empty_string(self):
+        self.assertEqual(
+            AdminUsersAndRolesPageHandler._format_epoch(None), "")
+
+    def test_formats_epoch_seconds(self):
+        result = AdminUsersAndRolesPageHandler._format_epoch(1700000000)
+        self.assertEqual(result, "2023-11-14 22:13 UTC")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
+++ b/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
@@ -196,6 +196,25 @@ class TestInviteUser(unittest.IsolatedAsyncioTestCase):
         text = await response.get_data(as_text=True)
         self.assertIn("could not be completed", text)
 
+    async def test_success_confirms_the_invitation(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn("alert-success", text)
+        self.assertIn("sent to new@b.com", text)
+
+    async def test_invite_banner_uses_the_default_dismiss_delay(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn('data-auto-dismiss-ms="10000"', text)
+
 
 class TestResendInvite(unittest.IsolatedAsyncioTestCase):
     """POST /admin/users_roles/invite/resend"""
@@ -237,6 +256,62 @@ class TestResendInvite(unittest.IsolatedAsyncioTestCase):
         text = await response.get_data(as_text=True)
         self.assertIn("No pending invite found", text)
 
+    async def test_success_confirms_the_resend(self):
+        """Without this the page looks identical to having done nothing."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn("alert-success", text)
+        self.assertIn("resent to new@b.com", text)
+
+    async def test_success_warns_the_previous_link_is_dead(self):
+        """Resending regenerates the token, invalidating any earlier link."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn("no longer valid", text)
+
+    async def test_failure_shows_no_success_banner(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND,
+                       body={"error": "No pending invite found"})]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn("alert-danger", text)
+        self.assertNotIn("alert-success", text)
+
+    async def test_resend_banner_stays_longer_than_the_default(self):
+        """It reports the previous link is dead, so it needs reading time."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn('data-auto-dismiss-ms="20000"', text)
+
+    async def test_error_banner_has_no_auto_dismiss(self):
+        """A missed error is worse than a missed confirmation."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.NOT_FOUND,
+                       body={"error": "No pending invite found"})]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        # The attribute drives auto-dismissal; errors must not carry it.
+        self.assertNotIn("data-auto-dismiss-ms", text)
+
 
 class TestUninvite(unittest.IsolatedAsyncioTestCase):
     """POST /admin/users_roles/invite/uninvite"""
@@ -276,6 +351,17 @@ class TestUninvite(unittest.IsolatedAsyncioTestCase):
         call = self.mock_rest_client.post.call_args_list[1]
         self.assertEqual(call[0][0], "http://gateway/web/invites/uninvite")
         self.assertEqual(call[1]["json_data"], {"email_address": "new@b.com"})
+
+    async def test_success_confirms_the_cancellation(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.OK)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn("alert-success", text)
+        self.assertIn("new@b.com", text)
+        self.assertIn("cancelled", text)
 
     async def test_no_pending_invite_shows_error(self):
         self.mock_rest_client.post.side_effect = [

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -85,6 +85,30 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
             response = await c.get("/login")
         self.assertNotEqual(response.status_code, 405)
 
+    async def test_accept_invite_get_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/accept_invite?token=abc")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_accept_invite_post_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/accept_invite", form={"token": "abc"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_accept_invite_routes_are_not_session_guarded(self):
+        """Someone redeeming an invitation has no session yet.
+
+        If either route were wrapped in require_session/require_administrator
+        it would redirect to the login page, and the invitation link would be
+        unusable for exactly the people it is meant for.
+        """
+        async with self.client as c:
+            get_response = await c.get("/accept_invite?token=abc")
+            get_body = await get_response.get_data(as_text=True)
+
+        # A guarded route answers with a meta-refresh redirect to /login.
+        self.assertNotIn("url='http://localhost/login'", get_body)
+
     async def test_login_post_route_is_reachable(self):
         async with self.client as c:
             response = await c.post(

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -49,6 +49,7 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
                 "show_announcement_on_overview": False,
                 "projects": [],
                 "users": [],
+                "invites": [],
                 "folders": [],
                 "test_cases": [],
             })
@@ -108,6 +109,27 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     async def test_admin_users_roles_route_is_reachable(self):
         async with self.client as c:
             response = await c.get("/admin/users_roles")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_invite_user_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/invite",
+                form={"email_address": "a@b.com"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_resend_invite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/invite/resend",
+                form={"email_address": "a@b.com"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_uninvite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/invite/uninvite",
+                form={"email_address": "a@b.com"})
         self.assertNotEqual(response.status_code, 405)
 
     async def test_admin_manage_data_route_is_reachable(self):


### PR DESCRIPTION
# User invites: accept-invite flow (Identity → Gateway → Web Portal)

**Branch:** `portal_user_invite` → `main`
**Stats:** 42 files changed, +2821/-93

## Summary

Completes the user-invite feature end to end: an administrator sends an
invite from the Users & Roles admin page, the invitee gets an email with a
link, and following that link lets them set their own name/password and
create their own account — without an administrator ever creating the
account or handling the invitee's password.

Builds on the already-merged invite plumbing (`identity_user_invite_initial`,
`gateway_user_invite`, `identity_gateway_list_invites`): the "Pending
Invites" admin UI, invite email sending, and the self-service accept-invite
flow are all new in this branch.

## Identity

- `routes/invites/get_invite_by_token_handler.py` (new) — `GET
  /invites/token/<token>`. Resolves a token to the invited email address.
  Unknown, cancelled, and expired tokens are all reported identically as
  404, so the endpoint can't be used to probe for valid tokens.
- `services/invite_management_service.py` — new `get_invite_by_token()`,
  returning an `InviteLookupResult(valid, email_address)`. Treats a token as
  invalid if the row is missing, already consumed/cancelled
  (`is_expired`), or past `expires_at` — the last check is defense in depth
  against the few-minute lag in the background expiry sweep.
- `service.py` — added `SERVICE_NAME = "Identity"` (first step towards the
  health-check service-identity item already tracked in `future.md`).

## Gateway

- `routes/web/invites/accept_invite_handler.py` (new) — `POST
  /web/accept_invite`, unauthenticated by design (the invitee has no
  session yet). Resolves the token server-side to get the email address
  (never trusts a client-submitted email), consumes the invite, then
  creates the user. Invite consumption happens *before* account creation:
  documented in the handler as a deliberate tradeoff — a wasted invite
  needing reissue is a safer failure than a replayable invite. Sends a
  best-effort welcome email on success; email failure never fails the
  request.
- `routes/web/invites/get_invite_by_token_handler.py` (new) — thin
  unauthenticated proxy for the Identity token-lookup endpoint above.
- `services/invite_email.py` (new) — shared plain-text email builders
  (`build_invite_url`, `build_invite_body`, `build_welcome_body`) and
  senders (`send_invite_email`, `send_welcome_email`). `send_invite_email`
  only fires after confirming the proxied create/resend actually succeeded,
  so a failed create doesn't email an invite that doesn't exist. Both
  senders swallow `EmailServiceError` and log rather than raise, so email
  outages never block the underlying action.
- `create_invite_handler.py` / `resend_invite_handler.py` — now take an
  optional `email_service` and call the new shared `send_invite_email`
  after a successful proxy response, so create and resend can't drift
  apart on email content.
- `routes/web/invites/__init__.py` — wires up the two new handlers and
  registers `GET /web/invites/token/<token>` and `POST
  /web/accept_invite`. Docstring explicitly calls out that these two
  routes are deliberately unauthenticated, tying into the Gateway
  admin-enforcement gap already tracked in `future.md`.

## Web Portal

- `page_handlers/auth/accept_invite_page_handler.py` (new) — the
  invitee-facing page. Deliberately not wrapped in
  `require_session`/`require_administrator` — the visitor has no account
  yet. `GET` resolves the token and renders the setup form (or an
  "invite no longer valid" state); `POST` re-resolves the token
  server-side again before submitting (covers an admin cancelling the
  invite in the gap between the visitor loading the form and submitting
  it), validates both names are present and the password is ≥8 characters
  and matches confirmation, then proxies to the Gateway.
- `templates/accept_invite.html` (new) — three render states (form,
  success, invalid). The email field is shown but rendered
  `disabled readonly` with no `name` attribute, so it can't be submitted
  even by tampering with the form — matches the handler re-deriving the
  email from the token server-side rather than trusting the form.
- `admin_users_and_roles_page_handler.py` — adds the "Pending Invites"
  table to the existing Users & Roles page: invite/resend/cancel actions,
  plus success-banner messages (with a longer auto-dismiss for resend,
  since it explains the old link is now dead).
- `static/scripts/instance_admin_users_roles.js` (new) — auto-dismisses
  the new success banners after their configured delay.
- `page_handlers/auth/__init__.py` — registers `GET`/`POST
  /accept_invite`, with an inline comment on why it's intentionally
  unguarded.

## Postman collection

`+66` lines, purely additive — new invite / accept-invite / token-lookup
requests. Existing requests untouched.

## future.md

Added one new low-priority entry from a prior review pass: a narrow TOCTOU
race in invite consumption (`InviteManagementService.uninvite()` does a
SELECT then a separate UPDATE rather than one atomic statement). Flagged
as low priority — the existing `create_user` email-uniqueness constraint
already makes the worst case a confusing error rather than a duplicate
account or takeover — and deliberately left unfixed for now.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

- Identity: 277 tests, OK. 100% coverage.
- Gateway: 296 tests, OK. 100% coverage.
- Web Portal: 236 tests, OK. 100% coverage.
- Pylint: 10.00/10 on Identity, Gateway, Web Portal, and CMS.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
