### PR TITLE
[Portal] Admin access tab

### DIFF
--- a/future.md
+++ b/future.md
@@ -228,3 +228,42 @@ a service method enforcing whatever business rules apply (e.g. can an
 administrator delete themselves? the last remaining administrator?), a
 Gateway route, and an admin-page action on Users & Roles. Sizeable enough
 to be its own small PR rather than a squeeze-in - candidate for 0.3.0.
+
+## Gateway: deactivating a user does not touch their existing session
+
+**Where:** `Sessions` (`items_gateway/sessions.py`) is a pure in-memory
+`email_address -> SessionEntry` map. `ValidateSessionHandler.validate_session`
+only checks that an entry exists and the token matches - it never asks
+Identity whether the account is still active. `SessionEntry.session_expiry`
+is declared but not read anywhere either, so today nothing ever
+invalidates a session except an explicit logout or a server restart.
+
+**Problem:** the design doc (`user_roles_design.md` §5.3.3) already commits
+to different behaviour: "existing sessions are invalidated at next
+validate call". That was never built. An administrator who deactivates a
+user (the "Active" toggle added in `portal_admin_access_tab`) only blocks
+*future* logins - anyone with an already-open session keeps working
+normally until they happen to log out themselves.
+
+**Fix:** proactive delete, not a lazy per-request check. A lazy check (ask
+Identity "is this account still active" on every `validate_session` call)
+would add a permanent Gateway->Identity round trip to every single
+authenticated request, forever, to guard against something rare and
+deliberate - a bad trade. Proactive delete costs nothing extra on the hot
+path and can piggyback on a call that already happens:
+
+- **Identity**: include `email_address` in the success response of
+  `PATCH /users/<id>` (`modify_user_handler.py` /
+  `UserManagementService.update_user`) - it doesn't today.
+- **Gateway**: `ModifyUserHandler.modify_user` already sees both the
+  outgoing request body (so it knows if `account_status` was set to `0`)
+  and Identity's response for the same call. On a 200 with
+  `account_status == 0` in the request, call
+  `sessions.delete_session(response.body["email_address"])`. No new
+  network call anywhere.
+
+Small and well-defined - no open design questions - but deliberately not
+folded into `portal_admin_access_tab` (which only added the UI checkbox)
+or decided yet against the gateway admin-route enforcement piece. Both
+touch Gateway session/authorization code, so worth doing whichever one
+lands first.

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
@@ -78,6 +78,11 @@ class AdminAddUserPageHandler(PortalPageHandler):
         display_name: str = form.get("display_name", "").strip()
         email_address: str = form.get("email_address", "").strip()
         password: str = form.get("password", "").strip()
+        is_administrator: bool = form.get("is_administrator") == "1"
+
+        # Re-inject for template re-population - an unchecked checkbox is
+        # simply absent from form_data, unlike the text fields above.
+        form_data["is_administrator"] = is_administrator
 
         if not all([full_name, display_name, email_address]):
             return await self._render(
@@ -94,6 +99,7 @@ class AdminAddUserPageHandler(PortalPageHandler):
             "display_name": display_name,
             "email_address": email_address,
             "password": password,
+            "is_administrator": is_administrator,
         }
 
         url = f"{self._config.apis_gateway_svc}web/users"

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
@@ -85,6 +85,7 @@ class AdminModifyUserPageHandler(PortalPageHandler):
             "display_name": user.get("display_name", ""),
             "email_address": user.get("email_address", ""),
             "account_status": user.get("account_status", 1),
+            "is_administrator": bool(user.get("is_administrator", False)),
         }
         return await self._render(user_id=user_id, form_data=form_data)
 
@@ -109,9 +110,12 @@ class AdminModifyUserPageHandler(PortalPageHandler):
         full_name: str = form.get("full_name", "").strip()
         display_name: str = form.get("display_name", "").strip()
         account_status: int = 1 if form.get("account_status") == "1" else 0
+        is_administrator: bool = form.get("is_administrator") == "1"
 
-        # Re-inject account_status as int for template re-population
+        # Re-inject checkbox fields for template re-population - unlike text
+        # inputs, an unchecked checkbox is simply absent from form_data.
         form_data["account_status"] = account_status
+        form_data["is_administrator"] = is_administrator
 
         if not all([full_name, display_name]):
             return await self._render(
@@ -123,6 +127,7 @@ class AdminModifyUserPageHandler(PortalPageHandler):
             "full_name": full_name,
             "display_name": display_name,
             "account_status": account_status,
+            "is_administrator": is_administrator,
         }
 
         url = f"{self._config.apis_gateway_svc}web/users/{user_id}"
@@ -133,7 +138,9 @@ class AdminModifyUserPageHandler(PortalPageHandler):
             return await self._render(
                 user_id=user_id,
                 form_data=form_data,
-                error_msg_str="Cannot deactivate the last active administrator.")
+                error_msg_str="This change would leave no active "
+                             "administrator - there must always be at "
+                             "least one.")
 
         if response.status_code == http.HTTPStatus.NOT_FOUND:
             return await self._render(

--- a/items/services/items_web_portal/templates/instance_admin_add_user.html
+++ b/items/services/items_web_portal/templates/instance_admin_add_user.html
@@ -114,9 +114,23 @@
 
       <!-- ACCESS TAB -->
       <div class="tab-pane" id="tab-access">
-        <p class="text-muted mt-3">
-          Role and access configuration will be available in a future release.
-          New users are created as standard (non-administrator) users by default.
+
+        <div class="mb-3 mt-3">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="is_administrator"
+                   name="is_administrator" value="1"
+                   {% if form_data.get('is_administrator') %}checked{% endif %}>
+            <label class="form-check-label" for="is_administrator">This user is an administrator</label>
+          </div>
+          <div class="form-text text-muted">
+            Administrators can manage projects, users, and instance settings.
+            Leave unchecked to create a standard user.
+          </div>
+        </div>
+
+        <p class="text-muted mt-4">
+          Per-project access configuration will be available in a future
+          release.
         </p>
       </div>
 

--- a/items/services/items_web_portal/templates/instance_admin_modify_user.html
+++ b/items/services/items_web_portal/templates/instance_admin_modify_user.html
@@ -53,15 +53,6 @@
           <div class="form-text text-muted">Email address cannot be changed.</div>
         </div>
 
-        <div class="mb-3">
-          <div class="form-check form-switch">
-            <input class="form-check-input" type="checkbox" id="account_status"
-                   name="account_status" value="1"
-                   {% if form_data.get('account_status') == 1 %}checked{% endif %}>
-            <label class="form-check-label" for="account_status">Active</label>
-          </div>
-        </div>
-
         <hr class="my-4">
 
         <div class="mb-3">
@@ -92,8 +83,38 @@
 
       <!-- ACCESS TAB -->
       <div class="tab-pane" id="tab-access">
-        <p class="text-muted mt-3">
-          Role and access configuration will be available in a future release.
+
+        <div class="mb-3 mt-3">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="account_status"
+                   name="account_status" value="1"
+                   {% if form_data.get('account_status') == 1 %}checked{% endif %}>
+            <label class="form-check-label" for="account_status">This user is active</label>
+          </div>
+          <div class="form-text text-muted">
+            Every active user can log in. Deactivate a user who no longer
+            needs access rather than deleting their account.
+          </div>
+        </div>
+
+        <hr class="my-4">
+
+        <div class="mb-3">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" id="is_administrator"
+                   name="is_administrator" value="1"
+                   {% if form_data.get('is_administrator') %}checked{% endif %}>
+            <label class="form-check-label" for="is_administrator">This user is an administrator</label>
+          </div>
+          <div class="form-text text-muted">
+            Administrators can manage projects, users, and instance settings.
+            There must always be at least one active administrator.
+          </div>
+        </div>
+
+        <p class="text-muted mt-4">
+          Per-project access configuration will be available in a future
+          release.
         </p>
       </div>
 

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -17,11 +17,11 @@ limitations under the License.
 
 # Semantic version components
 MAJOR = 0
-MINOR = 2
+MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build"
+PRE_RELEASE = "Alpha Build 1"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/unit_tests/web_portal_svc/test_admin_users_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_users_handlers.py
@@ -180,6 +180,37 @@ class TestAdminAddUserPageHandler(unittest.IsolatedAsyncioTestCase):
         text = await response.get_data(as_text=True)
         self.assertIn("Refresh", text)
 
+    async def test_post_is_administrator_checked_is_sent_to_gateway(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 2}),
+        ]
+        form = dict(_VALID_ADD_FORM)
+        form["is_administrator"] = "1"
+        await self._post(form)
+        create_call = self.mock_rest_client.post.await_args_list[1]
+        self.assertTrue(create_call.kwargs["json_data"]["is_administrator"])
+
+    async def test_post_is_administrator_unchecked_is_sent_as_false(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 2}),
+        ]
+        await self._post(_VALID_ADD_FORM)
+        create_call = self.mock_rest_client.post.await_args_list[1]
+        self.assertFalse(create_call.kwargs["json_data"]["is_administrator"])
+
+    async def test_post_validation_error_re_populates_is_administrator(self):
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        form = dict(_VALID_ADD_FORM)
+        form["is_administrator"] = "1"
+        del form["full_name"]
+        response = await self._post(form)
+        text = await response.get_data(as_text=True)
+        checkbox_start = text.index('id="is_administrator"')
+        checkbox_tag = text[checkbox_start:text.index(">", checkbox_start)]
+        self.assertIn("checked", checkbox_tag)
+
 
 # ---------------------------------------------------------------------------
 # AdminModifyUserPageHandler
@@ -261,7 +292,7 @@ class TestAdminModifyUserPageHandler(unittest.IsolatedAsyncioTestCase):
         response = await self._post(_VALID_MODIFY_FORM)
         self.assertEqual(response.status_code, 200)
         text = await response.get_data(as_text=True)
-        self.assertIn("last active administrator", text)
+        self.assertIn("no active administrator", text)
 
     async def test_post_not_found_renders_error(self):
         self.mock_rest_client.patch.return_value = ApiResponse(
@@ -292,6 +323,41 @@ class TestAdminModifyUserPageHandler(unittest.IsolatedAsyncioTestCase):
             response = await c.get(f"/admin/users_roles/{_UUID}/modify")
         text = await response.get_data(as_text=True)
         self.assertIn("Refresh", text)
+
+    async def test_get_pre_populates_is_administrator_when_true(self):
+        admin_user = dict(_USER, is_administrator=True)
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=admin_user)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        checkbox_start = text.index('id="is_administrator"')
+        checkbox_tag = text[checkbox_start:text.index(">", checkbox_start)]
+        self.assertIn("checked", checkbox_tag)
+
+    async def test_get_does_not_pre_populate_is_administrator_when_false(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body=_USER)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        checkbox_start = text.index('id="is_administrator"')
+        checkbox_tag = text[checkbox_start:text.index(">", checkbox_start)]
+        self.assertNotIn("checked", checkbox_tag)
+
+    async def test_post_is_administrator_checked_is_sent_to_gateway(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={})
+        form = dict(_VALID_MODIFY_FORM)
+        form["is_administrator"] = "1"
+        await self._post(form)
+        patch_call = self.mock_rest_client.patch.await_args
+        self.assertTrue(patch_call.kwargs["json_data"]["is_administrator"])
+
+    async def test_post_is_administrator_unchecked_is_sent_as_false(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={})
+        await self._post(_VALID_MODIFY_FORM)
+        patch_call = self.mock_rest_client.patch.await_args
+        self.assertFalse(patch_call.kwargs["json_data"]["is_administrator"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Web Portal: Access tab — administrator toggle

**Branch:** `portal_admin_access_tab` → `main`
**Theme:** User Roles and Management (0.3.0) — piece 1 of 3
**Stats:** 5 files changed, +131/-17

## Summary

Fills in the "Access" tab on the Add User and Modify User admin pages,
which has existed as a placeholder ("Role and access configuration will be
available in a future release") since those forms were built. Identity and
the Gateway already fully supported `is_administrator` end to end — the
Web Portal was the only layer not exposing it.

Reference: TestRail's Edit User → Access tab, specifically its pattern of
pairing each toggle with a short description line explaining what it does.
Adopted that presentation; did not adopt TestRail's Role dropdown/Groups
model, since ITEMS' data model is a single `is_administrator` boolean, not
graded named roles - that's a separate, much larger design conversation
(overlaps with the project-membership/permission-grid work already parked
in `future.md` and the design doc).

## Web Portal only

No Identity or Gateway changes were needed - both already accept and act
on `is_administrator`:

- Identity's `PATCH /users/<id>` already applies `is_administrator` and
  already enforces the "can't leave zero active administrators" guard
  (403 `forbidden`), from the original user-management work.
- The Gateway's create/modify user handlers are schema-less pass-throughs
  - whatever JSON body the portal sends already reaches Identity untouched.

`templates/instance_admin_modify_user.html`

- Moved the existing "Active" checkbox out of the User tab and into
  Access, alongside the new "This user is an administrator" checkbox.
  Grouping them makes sense together - "can this user log in" and "what
  can they do" are both access questions, not profile fields.
- Both checkboxes now carry a description line underneath (the
  TestRail-style pattern), including a reminder that there must always be
  at least one active administrator.

`templates/instance_admin_add_user.html`

- Added the same administrator checkbox to its Access tab. No Active
  checkbox here - new users are always created active server-side, so
  there's nothing to toggle at creation time.

`admin_modify_user_page_handler.py`

- `modify_user_get` now includes `is_administrator` in `form_data` so the
  checkbox pre-populates correctly.
- `modify_user_post` reads the checkbox and includes it in the PATCH body.
- The existing 403 error message ("Cannot deactivate the last active
  administrator") only covered one of the two ways to trigger the guard.
  Reworded to cover both: "This change would leave no active administrator
  - there must always be at least one."

`admin_add_user_page_handler.py`

- `add_user_post` reads the checkbox and includes it in the create body.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

`test_admin_users_handlers.py` - new cases for both handlers: checkbox
checked/unchecked correctly sent to the gateway, GET pre-population from
the gateway's response, and re-population after a validation error (so a
checked box doesn't silently uncheck itself if the form round-trips on an
error). Updated the existing forbidden-response assertion for the reworded
error message.

**245 tests, OK. 100% line coverage maintained across the Web Portal
suite** (1265/1265 statements). Pylint: 10.00/10.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
