### PR TITLE
Changes to protect gateway endpoints

### DIFF
--- a/future.md
+++ b/future.md
@@ -267,3 +267,49 @@ folded into `portal_admin_access_tab` (which only added the UI checkbox)
 or decided yet against the gateway admin-route enforcement piece. Both
 touch Gateway session/authorization code, so worth doing whichever one
 lands first.
+
+## Web Portal: session cookies are missing HttpOnly and SameSite
+
+**Where:** `login_post_page_handler.py:114-115` -
+`login_response.set_cookie(self.COOKIE_USER, user_email)` and
+`.set_cookie(self.COOKIE_TOKEN, response.body.get("token"))`, both called
+with no extra arguments. Quart's `set_cookie` defaults every
+security-relevant flag off: `secure=False`, `httponly=False`,
+`samesite=None`.
+
+**Problem:** the session token itself is fine - generated as
+`uuid.uuid4().hex` (`new_session_password_handler.py:122`), 122 bits from
+`os.urandom`, not predictable. The cookie carrying it isn't locked down
+though:
+
+- No `HttpOnly` - JavaScript can read `items_token` via `document.cookie`.
+  Any XSS anywhere on the site hands over the session token outright.
+- No explicit `SameSite` - left to browser default rather than a
+  deliberate choice.
+
+**Fix:** add `httponly=True` and `samesite="Lax"` to both `set_cookie`
+calls. Neither depends on HTTPS or any environment detection - safe to do
+immediately, independent of everything else here. (The third flag,
+`Secure`, is deliberately not part of this item - see the HTTPS entry
+below.)
+
+## Move to HTTPS
+
+**Where:** deployment-wide. Flagged while discussing session cookie
+hardening (above) - `Secure` can't be set on the session cookies until
+there's always a TLS connection to require it over, and setting it
+unconditionally today would silently break login on any current non-HTTPS
+setup (including local dev on `http://localhost`).
+
+**Problem:** scope is genuinely unknown right now - "possibly massive" per
+the conversation that raised it. At minimum it touches: the `Secure`
+cookie flag (blocked on this), any hardcoded `http://` URLs, CORS/cookie
+`SameSite` interactions once `Secure` is involved, and cert/reverse-proxy
+setup for however this actually gets deployed. Likely more once someone
+sits down and lists it properly.
+
+**Fix:** not scoped yet - deliberately just a placeholder so it isn't
+lost. Needs its own focused pass to turn "possibly massive" into an actual
+list before any code changes. Do this before making `Secure` conditional
+on an environment flag (above) - guessing at the environment-detection
+shape now risks redoing it once the real migration is scoped.

--- a/items/services/items_gateway/auth_decorators.py
+++ b/items/services/items_gateway/auth_decorators.py
@@ -1,0 +1,114 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from functools import wraps
+from http import HTTPStatus
+import json
+from quart import request, Response
+from items.services.items_gateway.sessions import Sessions, SessionEntry
+
+# Headers the web portal attaches to every internal call it makes to the
+# gateway, carrying the caller's already-authenticated session. Named to
+# mirror the ``items_user``/``items_token`` cookies they are read from.
+HEADER_USER = "X-Items-User"
+HEADER_TOKEN = "X-Items-Token"
+
+
+def _unauthorized() -> Response:
+    """Build the standard 401 response for a missing/invalid session."""
+    return Response(json.dumps({"error": "Unauthorized"}),
+                    status=HTTPStatus.UNAUTHORIZED,
+                    content_type="application/json")
+
+
+def _forbidden() -> Response:
+    """Build the standard 403 response for a valid session lacking rights."""
+    return Response(json.dumps({"error": "Forbidden"}),
+                    status=HTTPStatus.FORBIDDEN,
+                    content_type="application/json")
+
+
+async def _resolve_session(sessions: Sessions) -> SessionEntry | None:
+    """Resolve the caller's session from the request's auth headers.
+
+    Args:
+        sessions: The gateway's in-memory session store.
+
+    Returns:
+        The matching ``SessionEntry`` if both headers are present and match
+        an active session, otherwise ``None``.
+    """
+    email_address = request.headers.get(HEADER_USER)
+    token = request.headers.get(HEADER_TOKEN)
+
+    if not email_address or not token:
+        return None
+
+    return await sessions.get_session_entry(email_address, token)
+
+
+def require_session(sessions: Sessions):
+    """Decorator factory requiring any valid, currently active session.
+
+    Intended to wrap the small delegate closures registered against each
+    route in the ``routes/web/*/__init__.py`` blueprint factories - not the
+    handler classes themselves, which are also called directly (bypassing
+    HTTP) from unit tests and should stay authorization-agnostic.
+
+    Args:
+        sessions: The gateway's in-memory session store, captured once at
+            blueprint-registration time.
+
+    Returns:
+        A decorator that 401s the request if no valid session is presented,
+        otherwise calls the wrapped route function unchanged.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            entry = await _resolve_session(sessions)
+            if entry is None:
+                return _unauthorized()
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def require_administrator(sessions: Sessions):
+    """Decorator factory requiring a valid session with administrator rights.
+
+    Same wrapping point as :func:`require_session`, with an additional
+    check on ``SessionEntry.is_administrator``.
+
+    Args:
+        sessions: The gateway's in-memory session store, captured once at
+            blueprint-registration time.
+
+    Returns:
+        A decorator that 401s the request if no valid session is presented,
+        403s if the session is valid but not an administrator, otherwise
+        calls the wrapped route function unchanged.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            entry = await _resolve_session(sessions)
+            if entry is None:
+                return _unauthorized()
+            if not entry.is_administrator:
+                return _forbidden()
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/items/services/items_gateway/routes/web/__init__.py
+++ b/items/services/items_gateway/routes/web/__init__.py
@@ -55,7 +55,8 @@ def create_web_routes(injections: RouteInjections) -> quart.Blueprint:
     routes_bp.register_blueprint(create_projects_routes(
         injections.logger,
         injections.configuration,
-        injections.rest_client))
+        injections.rest_client,
+        injections.sessions))
 
     # Register sessions routes.
     routes_bp.register_blueprint(create_sessions_routes(injections.logger,

--- a/items/services/items_gateway/routes/web/invites/__init__.py
+++ b/items/services/items_gateway/routes/web/invites/__init__.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from quart import Blueprint
+from items.services.items_gateway.auth_decorators import require_administrator
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes.web.invites.get_invites_handler import (
     GetInvitesHandler)
@@ -32,22 +33,24 @@ from items.services.items_gateway.routes.web.invites.get_invite_by_token_handler
 def create_invite_routes(injections: RouteInjections) -> Blueprint:
     """Create the Blueprint containing invite management web routes.
 
-    The management routes are admin-only and must be enforced at this layer or
-    by the caller (the web portal, which checks ``is_administrator`` before
-    calling).
+    The management routes are admin-only, enforced here via
+    ``@require_administrator`` rather than trusted to the caller - the web
+    portal also checks ``is_administrator`` before calling, but that is UX,
+    not the security boundary.
 
-    ``POST /accept_invite`` is the exception: it is **deliberately
-    unauthenticated**, because the person redeeming an invitation does not yet
-    have an account. The invite token authorises that request instead. When
-    authorisation is enforced at this layer, this route must be explicitly
-    exempted rather than being caught by a blanket rule.
+    ``GET /invites/token/<token>`` and ``POST /accept_invite`` are the
+    exceptions: both are **deliberately unauthenticated**, because the
+    person redeeming an invitation does not yet have an account. The invite
+    token authorises those requests instead - they are explicitly left
+    undecorated rather than being caught by a blanket rule.
 
     Registered routes:
-        GET  /invites              List all pending invites.
-        POST /invites              Create a new pending invite.
-        POST /invites/resend       Refresh token and expiry on an existing invite.
-        POST /invites/uninvite     Cancel (soft-expire) a pending invite.
-        POST /accept_invite        Redeem an invitation (unauthenticated).
+        GET  /invites              List all pending invites. (admin)
+        POST /invites              Create a new pending invite. (admin)
+        POST /invites/resend       Refresh token and expiry on an existing invite. (admin)
+        POST /invites/uninvite     Cancel (soft-expire) a pending invite. (admin)
+        GET  /invites/token/<token> Resolve an invite token. (unauthenticated)
+        POST /accept_invite        Redeem an invitation. (unauthenticated)
 
     Args:
         injections: Shared application dependencies.
@@ -85,6 +88,7 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
                             "List pending invites".ljust(40))
 
     @routes.route('/invites', methods=['GET'])
+    @require_administrator(injections.sessions)
     async def get_invites_request():
         return await handler_get.get_invites()
 
@@ -92,6 +96,7 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
                             "Create invite".ljust(40))
 
     @routes.route('/invites', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def create_invite_request():
         return await handler_create.create_invite()
 
@@ -99,6 +104,7 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
                             "Resend invite".ljust(40))
 
     @routes.route('/invites/resend', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def resend_invite_request():
         return await handler_resend.resend_invite()
 
@@ -120,6 +126,7 @@ def create_invite_routes(injections: RouteInjections) -> Blueprint:
                             "Uninvite".ljust(40))
 
     @routes.route('/invites/uninvite', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def uninvite_request():
         return await handler_uninvite.uninvite()
 

--- a/items/services/items_gateway/routes/web/projects/__init__.py
+++ b/items/services/items_gateway/routes/web/projects/__init__.py
@@ -17,8 +17,11 @@ limitations under the License.
 import logging
 from quart import Blueprint
 from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.auth_decorators import (
+    require_administrator, require_session)
 from items.services.items_gateway.gateway_configuration import (
     GatewayConfiguration)
+from items.services.items_gateway.sessions import Sessions
 from items.services.items_gateway.routes.web.projects.add_project_handler \
     import AddProjectHandler
 from items.services.items_gateway.routes.web.projects.delete_project_handler \
@@ -33,20 +36,28 @@ from items.services.items_gateway.routes.web.projects.update_project_handler \
 
 def create_projects_routes(logger: logging.Logger,
                            config: GatewayConfiguration,
-                           rest_client: RestClient) -> Blueprint:
+                           rest_client: RestClient,
+                           sessions: Sessions) -> Blueprint:
     """Create the project management API routes.
 
     Creates and configures the Blueprint containing all project-related
     gateway endpoints. Each route delegates request handling to a dedicated
     handler class responsible for communicating with the CMS service.
 
+    The two read routes require only a valid session (``@require_session``)
+    - they are called by both the regular dashboard/project-overview pages
+    and the admin projects page, so they can't require administrator
+    rights. The three write routes are admin-only
+    (``@require_administrator``) - only the admin add/modify/delete project
+    pages call them.
+
     The following endpoints are registered:
 
-    - ``GET /projects`` - List all accessible projects.
-    - ``GET /projects/<project_id>`` - Retrieve a specific project.
-    - ``POST /projects`` - Create a new project.
-    - ``PATCH /projects/<project_id>`` - Update an existing project.
-    - ``DELETE /projects/<project_id>`` - Delete a project.
+    - ``GET /projects`` - List all accessible projects. (any session)
+    - ``GET /projects/<project_id>`` - Retrieve a specific project. (any session)
+    - ``POST /projects`` - Create a new project. (admin)
+    - ``PATCH /projects/<project_id>`` - Update an existing project. (admin)
+    - ``DELETE /projects/<project_id>`` - Delete a project. (admin)
 
     Args:
         logger: Parent logger used for route registration logging and for
@@ -55,6 +66,8 @@ def create_projects_routes(logger: logging.Logger,
             information.
         rest_client: REST client used by the route handlers to communicate
             with backend services.
+        sessions: The gateway's in-memory session store, used to enforce
+            the access levels described above.
 
     Returns:
         A configured Quart ``Blueprint`` containing all project-related API
@@ -86,6 +99,7 @@ def create_projects_routes(logger: logging.Logger,
                  "Get project details".ljust(40))
 
     @projects_routes.route('/projects/<int:project_id>', methods=['GET'])
+    @require_session(sessions)
     async def get_project(project_id: int):
         return await handler_get_project.get_project(project_id)
 
@@ -94,6 +108,7 @@ def create_projects_routes(logger: logging.Logger,
                  "List accessible projects".ljust(40))
 
     @projects_routes.route('/projects', methods=['GET'])
+    @require_session(sessions)
     async def list_projects():
         return await handler_get_all_projects.list_all_projects()
 
@@ -102,6 +117,7 @@ def create_projects_routes(logger: logging.Logger,
                  "Add new project".ljust(40))
 
     @projects_routes.route('/projects', methods=['POST'])
+    @require_administrator(sessions)
     async def add_project():
         # pylint: disable=no-value-for-parameter
         return await handler_add_project.add_project()
@@ -111,6 +127,7 @@ def create_projects_routes(logger: logging.Logger,
                  "Update project".ljust(40))
 
     @projects_routes.route('/projects/<int:project_id>', methods=['PATCH'])
+    @require_administrator(sessions)
     async def update_project(project_id: int):
         # pylint: disable=no-value-for-parameter
         return await handler_update_project.update_project(project_id)
@@ -120,6 +137,7 @@ def create_projects_routes(logger: logging.Logger,
                  "Delete a project".ljust(40))
 
     @projects_routes.route('/projects/<int:project_id>', methods=['DELETE'])
+    @require_administrator(sessions)
     async def delete_project(project_id: int):
         return await handler_delete_project.delete_project(project_id)
 

--- a/items/services/items_gateway/routes/web/testcase_custom_fields/__init__.py
+++ b/items/services/items_gateway/routes/web/testcase_custom_fields/__init__.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from quart import Blueprint
+from items.services.items_gateway.auth_decorators import require_administrator
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes.web.testcase_custom_fields.\
     add_custom_field_handler import AddCustomFieldHandler
@@ -38,6 +39,11 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
     custom field definitions through the web interface. It instantiates the
     required request handlers, registers the available endpoints, and logs the
     registered routes during application startup.
+
+    All routes are admin-only (the Customisations page they back is entirely
+    ``@require_administrator`` in the web portal, including its read view),
+    enforced here via ``@require_administrator`` rather than trusted to the
+    caller.
 
     Registered routes:
         - GET /testcase_custom_fields/:
@@ -88,6 +94,7 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
                             "Get all TC custom fields".ljust(40))
 
     @routes.route('/testcase_custom_fields/', methods=['GET'])
+    @require_administrator(injections.sessions)
     async def get_all_custom_fields_request():
         return await handler_get_all_fields.get_all_custom_fields()
 
@@ -96,6 +103,7 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
         "Get single TC custom field".ljust(40))
 
     @routes.route('/testcase_custom_fields/<int:field_id>', methods=['GET'])
+    @require_administrator(injections.sessions)
     async def get_custom_field_request(field_id: int):
         return await handler_get_custom_field.get_custom_field(field_id)
 
@@ -103,6 +111,7 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
                             "Modify Testcase Custom Fields".ljust(40))
 
     @routes.route('/testcase_custom_fields/<int:field_id>', methods=['PUT'])
+    @require_administrator(injections.sessions)
     async def modify_custom_field_request(field_id: int):
         # pylint: disable=no-value-for-parameter
         return await handler_modify_custom_field.modify_custom_field(field_id)
@@ -112,6 +121,7 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
         "Move Testcase Custom Fields Position".ljust(40))
 
     @routes.route('/testcase_custom_fields/<int:field_id>', methods=['PATCH'])
+    @require_administrator(injections.sessions)
     async def move_custom_field_request(field_id: int):
         # pylint: disable=no-value-for-parameter
         return await handler_move_custom_field.move_custom_field(field_id)
@@ -120,11 +130,13 @@ def create_testcase_custom_fields_routes(injections: RouteInjections) \
                             "Add Testcase Custom Field".ljust(40))
 
     @routes.route('/testcase_custom_fields/', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def add_custom_field_request():
         # pylint: disable=no-value-for-parameter
         return await handler_add_custom_field.add_custom_field()
 
     @routes.route('/testcase_custom_fields/<int:field_id>', methods=['DELETE'])
+    @require_administrator(injections.sessions)
     async def delete_custom_field_request(field_id: int):
         # pylint: disable=no-value-for-parameter
         return await handler_delete_custom_field.delete_custom_field(field_id)

--- a/items/services/items_gateway/routes/web/testcases/__init__.py
+++ b/items/services/items_gateway/routes/web/testcases/__init__.py
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from quart import Blueprint
+from items.services.items_gateway.auth_decorators import require_session
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes.web.testcases.get_testcase_handler \
     import GetTestcaseHandler
@@ -29,6 +30,12 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
     information through the web interface. It instantiates the required request
     handlers, registers the available endpoints, and logs the registered routes
     during application startup.
+
+    Both routes require a valid session (``@require_session``) but not
+    administrator rights - any authenticated user with access to the portal
+    can browse testcases, not just admins. (There is no per-project
+    membership check yet - see ``user_roles_design.md`` and the
+    `future.md` items tracking that work.)
 
     Registered routes:
         - GET /<project_id>/testcases:
@@ -62,6 +69,7 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
 
     @routes.route('/<int:project_id>/testcases',
                   methods=['GET'])
+    @require_session(injections.sessions)
     async def testcases_details_request(project_id: int):
         return await handler_get_testcases.get_testcases(project_id)
 
@@ -71,6 +79,7 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
 
     @routes.route('/testcases/<int:case_id>',
                   methods=['GET'])
+    @require_session(injections.sessions)
     async def get_case_request(case_id: int):
         # pylint: disable=unused-variable
         return await handler_get_testcase.get_testcase(case_id)

--- a/items/services/items_gateway/routes/web/users/__init__.py
+++ b/items/services/items_gateway/routes/web/users/__init__.py
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from quart import Blueprint
+from items.services.items_gateway.auth_decorators import require_administrator
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes.web.users.list_users_handler import (
     ListUsersHandler)
@@ -30,8 +31,8 @@ from items.services.items_gateway.routes.web.users.reset_password_handler import
 def create_users_routes(injections: RouteInjections) -> Blueprint:
     """Create the Blueprint containing user management web routes.
 
-    All routes are admin-only and must be enforced at this layer or by the
-    caller (the web portal, which checks ``is_administrator`` before calling).
+    All routes are admin-only, enforced here via ``@require_administrator``
+    rather than trusted to the caller.
 
     Registered routes:
         GET  /users              List all user accounts.
@@ -72,6 +73,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
                             "List users".ljust(40))
 
     @routes.route('/users', methods=['GET'])
+    @require_administrator(injections.sessions)
     async def list_users_request():
         return await handler_list.list_users()
 
@@ -79,6 +81,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
                             "Create user".ljust(40))
 
     @routes.route('/users', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def create_user_request():
         return await handler_create.create_user()
 
@@ -86,6 +89,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
                             "Get user".ljust(40))
 
     @routes.route('/users/<string:user_id>', methods=['GET'])
+    @require_administrator(injections.sessions)
     async def get_user_request(user_id: str):
         return await handler_get.get_user(user_id)
 
@@ -93,6 +97,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
                             "Modify user".ljust(40))
 
     @routes.route('/users/<string:user_id>', methods=['PATCH'])
+    @require_administrator(injections.sessions)
     async def modify_user_request(user_id: str):
         return await handler_modify.modify_user(user_id)
 
@@ -100,6 +105,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
                             "Reset user password".ljust(40))
 
     @routes.route('/users/<string:user_id>/password', methods=['POST'])
+    @require_administrator(injections.sessions)
     async def reset_password_request(user_id: str):
         return await handler_reset_password.reset_password(user_id)
 

--- a/items/services/items_web_portal/authenticated_rest_client.py
+++ b/items/services/items_web_portal/authenticated_rest_client.py
@@ -1,0 +1,133 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from quart import request
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.rest_client import RestClient
+
+# Headers attached to every outgoing gateway call, carrying the caller's
+# already-authenticated session so the gateway can enforce admin-only
+# routes itself rather than trusting that only the portal calls it. Names
+# mirror the ``items_user``/``items_token`` cookies they are read from -
+# kept in sync with items_gateway.auth_decorators.HEADER_USER/HEADER_TOKEN.
+HEADER_USER = "X-Items-User"
+HEADER_TOKEN = "X-Items-Token"
+
+COOKIE_USER = "items_user"
+COOKIE_TOKEN = "items_token"
+
+
+class AuthenticatedRestClient:
+    """Wraps a ``RestClient``, forwarding the caller's session to the gateway.
+
+    Page handlers already read ``items_user``/``items_token`` from the
+    browser's cookies to validate the session with the gateway
+    (``SessionAuthMixin``). This wrapper reads the same two cookies and
+    attaches them as headers on every *other* gateway call a handler makes,
+    so the gateway does not have to be told the caller is authenticated
+    twice - once to validate the session, and again to actually act on
+    their behalf.
+
+    Every method's parameter order deliberately mirrors ``RestClient``'s
+    exactly (``url, json_data, headers, params, timeout`` - or
+    ``url, headers, params, timeout`` for ``get``, which has no body).
+    Existing call sites in this codebase call these methods both
+    positionally and by keyword (e.g. ``rest_client.post(url, body)`` as
+    well as ``rest_client.put(url, json_data=body)``) - a wrapper with a
+    different parameter order would silently misroute a positional
+    argument into the wrong parameter rather than raising, which is worse
+    than just matching the original signature exactly.
+
+    Must only be used from within an active Quart request context - it
+    reads ``quart.request`` on every call. It is not safe for
+    background/startup calls that have no request to read from (e.g. the
+    web portal's own webhook-metadata retrieval in ``service.py``, which
+    uses the unwrapped ``RestClient`` and its own HMAC signature instead).
+    """
+
+    def __init__(self, rest_client: RestClient) -> None:
+        """Initialise the wrapper.
+
+        Args:
+            rest_client: The underlying client used to actually perform
+                requests, once the auth headers have been attached.
+        """
+        self._rest_client = rest_client
+
+    @staticmethod
+    def _with_auth_headers(headers: dict | None) -> dict:
+        """Merge the caller's session credentials into a headers dict.
+
+        Args:
+            headers: Headers already supplied by the call site, if any.
+
+        Returns:
+            A new dict with the session headers added. If the browser
+            didn't send both session cookies (e.g. an unauthenticated page
+            like accept-invite), the headers are simply omitted rather than
+            sent empty - the gateway treats a missing header the same as an
+            invalid one, so there is no difference in outcome.
+        """
+        merged = dict(headers) if headers else {}
+        user = request.cookies.get(COOKIE_USER)
+        token = request.cookies.get(COOKIE_TOKEN)
+        if user and token:
+            merged[HEADER_USER] = user
+            merged[HEADER_TOKEN] = token
+        return merged
+
+    async def get(self, url: str, headers: dict | None = None,
+                  params: dict | None = None, timeout: int = 2
+                  ) -> ApiResponse:
+        """Send an authenticated GET request. See ``RestClient.get``."""
+        return await self._rest_client.get(
+            url, headers=self._with_auth_headers(headers), params=params,
+            timeout=timeout)
+
+    async def post(self, url: str, json_data: dict | None = None,
+                   headers: dict | None = None, params: dict | None = None,
+                   timeout: int = 2) -> ApiResponse:
+        """Send an authenticated POST request. See ``RestClient.post``."""
+        return await self._rest_client.post(
+            url, json_data=json_data,
+            headers=self._with_auth_headers(headers), params=params,
+            timeout=timeout)
+
+    async def put(self, url: str, json_data: dict | None = None,
+                  headers: dict | None = None, params: dict | None = None,
+                  timeout: int = 2) -> ApiResponse:
+        """Send an authenticated PUT request. See ``RestClient.put``."""
+        return await self._rest_client.put(
+            url, json_data=json_data,
+            headers=self._with_auth_headers(headers), params=params,
+            timeout=timeout)
+
+    async def patch(self, url: str, json_data: dict | None = None,
+                    headers: dict | None = None, params: dict | None = None,
+                    timeout: int = 2) -> ApiResponse:
+        """Send an authenticated PATCH request. See ``RestClient.patch``."""
+        return await self._rest_client.patch(
+            url, json_data=json_data,
+            headers=self._with_auth_headers(headers), params=params,
+            timeout=timeout)
+
+    async def delete(self, url: str, json_data: dict | None = None,
+                     headers: dict | None = None, params: dict | None = None,
+                     timeout: int = 2) -> ApiResponse:
+        """Send an authenticated DELETE request. See ``RestClient.delete``."""
+        return await self._rest_client.delete(
+            url, json_data=json_data,
+            headers=self._with_auth_headers(headers), params=params,
+            timeout=timeout)

--- a/items/services/items_web_portal/service.py
+++ b/items/services/items_web_portal/service.py
@@ -24,6 +24,8 @@ from weaver_framework.microservice.base_microservice import BaseMicroservice
 from weaver_framework.configuration_system.configuration_manager import (
     ConfigurationError)
 from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_web_portal.authenticated_rest_client import (
+    AuthenticatedRestClient)
 from items.services.items_web_portal.metadata_settings import MetadataSettings
 from items.services.items_web_portal.page_handlers import create_page_handlers
 from items.shared import LICENSE_TEXT, SERVICE_COPYRIGHT_TEXT, __version__
@@ -71,11 +73,19 @@ class Service(BaseMicroservice):
         self._metadata_settings: MetadataSettings = MetadataSettings()
         self._rest_client: RestClient = RestClient(self._http_session)
 
+        # Page handlers get a wrapped client that forwards the caller's
+        # session as headers on every gateway call, so the gateway can
+        # enforce admin-only routes itself. The raw client above stays
+        # unwrapped for _get_metadata below, which runs at startup with no
+        # request context to read cookies from, and authenticates via its
+        # own HMAC signature instead.
+        page_handler_rest_client = AuthenticatedRestClient(self._rest_client)
+
         injections: PageHandlerInjections = PageHandlerInjections(
             self._config,
             self.logger,
             self._metadata_settings,
-            self._rest_client)
+            page_handler_rest_client)
 
         try:
             metadata_retrieved: bool = await self._get_metadata(

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 1"
+PRE_RELEASE = "Alpha Build 2"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -70,6 +70,8 @@ from test_email_service import (
     TestSmtpEmailServiceSend,
 )
 from test_webhook_handler import TestGetMetadataHandler
+from test_auth_decorators import TestRequireSession, TestRequireAdministrator
+from test_admin_route_enforcement import TestAdminRouteEnforcement
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/items_gateway/test_admin_route_enforcement.py
+++ b/unit_tests/items_gateway/test_admin_route_enforcement.py
@@ -1,0 +1,217 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from http import HTTPStatus
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.auth_decorators import (
+    HEADER_TOKEN, HEADER_USER)
+from items.services.items_gateway.route_injections import RouteInjections
+from items.services.items_gateway.routes import create_routes
+from items.services.items_gateway.sessions import Sessions
+from items.shared.account_logon_type import AccountLogonType
+
+_VALID_PROJECT_BODY = {
+    "name": "EnforcementTest",
+    "announcement": "",
+    "announcement_on_overview": False,
+}
+
+_VALID_FIELD_BODY = {
+    "field_name": "Enforcement Field",
+    "description": "",
+    "system_name": "enforcement_field",
+    "field_type": "String",
+    "enabled": True,
+    "is_required": False,
+    "default_value": "",
+    "applies_to_all_projects": True,
+}
+
+_USER_TOKEN = "a" * 32
+_ADMIN_TOKEN = "b" * 32
+_USER_HEADERS = {HEADER_USER: "user@x.com", HEADER_TOKEN: _USER_TOKEN}
+_ADMIN_HEADERS = {HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN}
+
+# (method, path, json_body) - every admin-only /web/* route.
+_ADMIN_ONLY_ROUTES = [
+    ("GET", "/web/users", None),
+    ("POST", "/web/users",
+     {"email_address": "a@b.com", "full_name": "A", "display_name": "A"}),
+    ("GET", "/web/users/1", None),
+    ("PATCH", "/web/users/1", {"display_name": "New"}),
+    ("POST", "/web/users/1/password", {"new_password": "newpass123"}),
+    ("GET", "/web/invites", None),
+    ("POST", "/web/invites", {"email_address": "a@b.com"}),
+    ("POST", "/web/invites/resend", {"email_address": "a@b.com"}),
+    ("POST", "/web/invites/uninvite", {"email_address": "a@b.com"}),
+    ("POST", "/web/projects", _VALID_PROJECT_BODY),
+    ("PATCH", "/web/projects/1", _VALID_PROJECT_BODY),
+    ("DELETE", "/web/projects/1", None),
+    ("GET", "/web/testcase_custom_fields/", None),
+    ("GET", "/web/testcase_custom_fields/1", None),
+    ("PUT", "/web/testcase_custom_fields/1", _VALID_FIELD_BODY),
+    ("PATCH", "/web/testcase_custom_fields/1", {"direction": "up"}),
+    ("POST", "/web/testcase_custom_fields/", _VALID_FIELD_BODY),
+    ("DELETE", "/web/testcase_custom_fields/1", None),
+]
+
+# (method, path, json_body) - routes that need a valid session but not
+# administrator rights.
+_SESSION_ONLY_ROUTES = [
+    ("GET", "/web/projects", None),
+    ("GET", "/web/projects/1", None),
+    ("GET", "/web/1/testcases", None),
+    ("GET", "/web/testcases/1", None),
+]
+
+# (method, path, json_body) - routes that must stay reachable with no
+# X-Items-* session at all, each for its own documented reason (see the
+# individual blueprint docstrings).
+#
+# /web/webhook/metadata is deliberately not in this list: it is also
+# unauthenticated with respect to sessions, but it enforces its own HMAC
+# signature and correctly 401s an unsigned request for that unrelated
+# reason - which this table can't distinguish from a session-enforcement
+# 401. Its own auth is covered by test_webhook_handler.py; its wiring is
+# covered by test_route_factories.py.
+_EXEMPT_ROUTES = [
+    ("POST", "/web/sessions",
+     {"email_address": "a@b.com", "password": "x"}),
+    ("POST", "/web/sessions/validate",
+     {"email_address": "a@b.com", "token": "a" * 32}),
+    ("POST", "/web/sessions/refresh", None),
+    ("DELETE", "/web/sessions",
+     {"email_address": "a@b.com", "token": "a" * 32}),
+    ("GET", "/web/invites/token/abc123", None),
+    ("POST", "/web/accept_invite",
+     {"token": "abc123", "full_name": "A", "display_name": "A",
+      "password": "password1"}),
+]
+
+
+class TestAdminRouteEnforcement(unittest.IsolatedAsyncioTestCase):
+    """Confirms every /web/* route enforces the access level it should.
+
+    Complements test_route_factories.py (which proves every route wires
+    through to its handler when authorized) and test_auth_decorators.py
+    (which proves the decorators themselves are correct in isolation) with
+    the piece neither of those covers: that the *right* decorator, or none,
+    was actually attached to each specific route. Getting this wrong in
+    either direction is the whole point of the change - too strict locks
+    out real users, too loose leaves the gap this work exists to close.
+    """
+
+    async def asyncSetUp(self):
+        logger = MagicMock()
+        self.sessions = Sessions()
+        await self.sessions.add_session(
+            "user@x.com", _USER_TOKEN, AccountLogonType.BASIC,
+            is_administrator=False)
+        await self.sessions.add_session(
+            "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
+            is_administrator=True)
+        configuration = MagicMock()
+        configuration.apis_cms_svc = "http://cms/"
+        configuration.apis_identity_svc = "http://identity/"
+        configuration.general_api_signing_secret = "secret"
+        rest_client = AsyncMock()
+        rest_client.get.return_value = ApiResponse(status_code=200, body={})
+        rest_client.post.return_value = ApiResponse(status_code=200, body={})
+        rest_client.put.return_value = ApiResponse(status_code=200, body={})
+        rest_client.patch.return_value = ApiResponse(status_code=200, body={})
+        rest_client.delete.return_value = ApiResponse(status_code=200, body={})
+        metadata_handler = MagicMock()
+        metadata_handler.build_metadata_dictionary.return_value = {}
+
+        injections = RouteInjections(
+            logger=logger,
+            sessions=self.sessions,
+            configuration=configuration,
+            rest_client=rest_client,
+            metadata_handler=metadata_handler)
+
+        blueprint = create_routes(injections)
+
+        app = Quart(__name__)
+        app.register_blueprint(blueprint)
+        self.client = app.test_client()
+
+    async def _call(self, method, path, json_body, headers=None):
+        async with self.client as c:
+            return await c.open(path, method=method, json=json_body,
+                                headers=headers)
+
+    async def test_admin_only_routes_reject_no_session(self):
+        for method, path, body in _ADMIN_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(method, path, body)
+                self.assertEqual(response.status_code,
+                                 HTTPStatus.UNAUTHORIZED)
+
+    async def test_admin_only_routes_reject_non_administrator(self):
+        for method, path, body in _ADMIN_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, body, headers=_USER_HEADERS)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    async def test_admin_only_routes_accept_administrator(self):
+        for method, path, body in _ADMIN_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, body, headers=_ADMIN_HEADERS)
+                self.assertNotIn(
+                    response.status_code,
+                    (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    async def test_session_only_routes_reject_no_session(self):
+        for method, path, body in _SESSION_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(method, path, body)
+                self.assertEqual(response.status_code,
+                                 HTTPStatus.UNAUTHORIZED)
+
+    async def test_session_only_routes_accept_non_administrator(self):
+        for method, path, body in _SESSION_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, body, headers=_USER_HEADERS)
+                self.assertNotIn(
+                    response.status_code,
+                    (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    async def test_session_only_routes_accept_administrator(self):
+        for method, path, body in _SESSION_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, body, headers=_ADMIN_HEADERS)
+                self.assertNotIn(
+                    response.status_code,
+                    (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    async def test_exempt_routes_accept_no_session(self):
+        for method, path, body in _EXEMPT_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(method, path, body)
+                self.assertNotIn(
+                    response.status_code,
+                    (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_gateway/test_auth_decorators.py
+++ b/unit_tests/items_gateway/test_auth_decorators.py
@@ -1,0 +1,127 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from http import HTTPStatus
+from quart import Quart
+from items.services.items_gateway.auth_decorators import (
+    require_administrator, require_session, HEADER_TOKEN, HEADER_USER)
+from items.services.items_gateway.sessions import Sessions
+from items.shared.account_logon_type import AccountLogonType
+
+_USER_TOKEN = "a" * 32
+_ADMIN_TOKEN = "b" * 32
+
+
+def _make_app(sessions: Sessions) -> Quart:
+    app = Quart(__name__)
+
+    @app.route('/session-only')
+    @require_session(sessions)
+    async def session_only():
+        return "ok"
+
+    @app.route('/admin-only')
+    @require_administrator(sessions)
+    async def admin_only():
+        return "ok"
+
+    return app
+
+
+class TestRequireSession(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.sessions = Sessions()
+        await self.sessions.add_session(
+            "user@x.com", _USER_TOKEN, AccountLogonType.BASIC)
+        self.client = _make_app(self.sessions).test_client()
+
+    async def test_no_headers_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/session-only')
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_only_user_header_returns_401(self):
+        async with self.client as c:
+            response = await c.get(
+                '/session-only', headers={HEADER_USER: "user@x.com"})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_only_token_header_returns_401(self):
+        async with self.client as c:
+            response = await c.get(
+                '/session-only', headers={HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_unknown_email_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/session-only', headers={
+                HEADER_USER: "nobody@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_wrong_token_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/session-only', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: "c" * 32})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_valid_session_calls_through(self):
+        async with self.client as c:
+            response = await c.get('/session-only', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(await response.get_data(as_text=True), "ok")
+
+
+class TestRequireAdministrator(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.sessions = Sessions()
+        await self.sessions.add_session(
+            "user@x.com", _USER_TOKEN, AccountLogonType.BASIC,
+            is_administrator=False)
+        await self.sessions.add_session(
+            "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
+            is_administrator=True)
+        self.client = _make_app(self.sessions).test_client()
+
+    async def test_no_headers_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/admin-only')
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_invalid_session_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/admin-only', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: "wrong"})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_valid_non_administrator_session_returns_403(self):
+        async with self.client as c:
+            response = await c.get('/admin-only', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    async def test_valid_administrator_session_calls_through(self):
+        async with self.client as c:
+            response = await c.get('/admin-only', headers={
+                HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.assertEqual(await response.get_data(as_text=True), "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_gateway/test_route_factories.py
+++ b/unit_tests/items_gateway/test_route_factories.py
@@ -17,9 +17,12 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock
 from quart import Quart
 from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.auth_decorators import (
+    HEADER_TOKEN, HEADER_USER)
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes import create_routes
 from items.services.items_gateway.sessions import Sessions
+from items.shared.account_logon_type import AccountLogonType
 
 _VALID_PROJECT_BODY = {
     "name": "WiringTest",
@@ -38,6 +41,16 @@ _VALID_FIELD_BODY = {
     "applies_to_all_projects": True,
 }
 
+# Every route in this file is exercised as an authenticated administrator.
+# The point of this test class is coverage of the route-registration
+# closures themselves - whether a given route *should* require a session or
+# administrator rights is covered separately in
+# test_admin_route_enforcement.py. Using an admin session for everything
+# here means both admin-only and merely-authenticated routes are reachable
+# with the same fixture, so no route needs special-casing to get through.
+_ADMIN_TOKEN = "a" * 32
+_AUTH_HEADERS = {HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN}
+
 
 class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     """
@@ -52,6 +65,9 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         logger = MagicMock()
         sessions = Sessions()
+        await sessions.add_session(
+            "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
+            is_administrator=True)
         configuration = MagicMock()
         configuration.apis_cms_svc = "http://cms/"
         configuration.apis_identity_svc = "http://identity/"
@@ -114,27 +130,29 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_project_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/projects/1")
+            response = await c.get("/web/projects/1", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_list_projects_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/projects")
+            response = await c.get("/web/projects", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_add_project_route_is_reachable(self):
         async with self.client as c:
-            response = await c.post("/web/projects", json=_VALID_PROJECT_BODY)
+            response = await c.post("/web/projects", json=_VALID_PROJECT_BODY,
+                                    headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_update_project_route_is_reachable(self):
         async with self.client as c:
-            response = await c.patch("/web/projects/1", json=_VALID_PROJECT_BODY)
+            response = await c.patch("/web/projects/1", json=_VALID_PROJECT_BODY,
+                                     headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_delete_project_route_is_reachable(self):
         async with self.client as c:
-            response = await c.delete("/web/projects/1")
+            response = await c.delete("/web/projects/1", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
@@ -143,12 +161,12 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_testcases_for_project_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/1/testcases")
+            response = await c.get("/web/1/testcases", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_get_testcase_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/testcases/1")
+            response = await c.get("/web/testcases/1", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
@@ -158,35 +176,41 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_all_custom_fields_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/testcase_custom_fields/")
+            response = await c.get("/web/testcase_custom_fields/",
+                                   headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_get_custom_field_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/testcase_custom_fields/1")
+            response = await c.get("/web/testcase_custom_fields/1",
+                                   headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_add_custom_field_route_is_reachable(self):
         async with self.client as c:
             response = await c.post("/web/testcase_custom_fields/",
-                                    json=_VALID_FIELD_BODY)
+                                    json=_VALID_FIELD_BODY,
+                                    headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_modify_custom_field_route_is_reachable(self):
         async with self.client as c:
             response = await c.put("/web/testcase_custom_fields/1",
-                                   json=_VALID_FIELD_BODY)
+                                   json=_VALID_FIELD_BODY,
+                                   headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_move_custom_field_route_is_reachable(self):
         async with self.client as c:
             response = await c.patch("/web/testcase_custom_fields/1",
-                                     json={"direction": "up"})
+                                     json={"direction": "up"},
+                                     headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_delete_custom_field_route_is_reachable(self):
         async with self.client as c:
-            response = await c.delete("/web/testcase_custom_fields/1")
+            response = await c.delete("/web/testcase_custom_fields/1",
+                                      headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
@@ -195,12 +219,12 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_list_users_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/users")
+            response = await c.get("/web/users", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_get_user_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/users/1")
+            response = await c.get("/web/users/1", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_create_user_route_is_reachable(self):
@@ -208,19 +232,22 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
             response = await c.post("/web/users",
                                     json={"email_address": "a@b.com",
                                           "full_name": "A",
-                                          "display_name": "A"})
+                                          "display_name": "A"},
+                                    headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_modify_user_route_is_reachable(self):
         async with self.client as c:
             response = await c.patch("/web/users/1",
-                                     json={"display_name": "New"})
+                                     json={"display_name": "New"},
+                                     headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_reset_password_route_is_reachable(self):
         async with self.client as c:
             response = await c.post("/web/users/1/password",
-                                    json={"new_password": "newpass123"})
+                                    json={"new_password": "newpass123"},
+                                    headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------
@@ -229,25 +256,41 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_invites_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/invites")
+            response = await c.get("/web/invites", headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_create_invite_route_is_reachable(self):
         async with self.client as c:
             response = await c.post(
-                "/web/invites", json={"email_address": "a@b.com"})
+                "/web/invites", json={"email_address": "a@b.com"},
+                headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_resend_invite_route_is_reachable(self):
         async with self.client as c:
             response = await c.post(
-                "/web/invites/resend", json={"email_address": "a@b.com"})
+                "/web/invites/resend", json={"email_address": "a@b.com"},
+                headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     async def test_uninvite_route_is_reachable(self):
         async with self.client as c:
             response = await c.post(
-                "/web/invites/uninvite", json={"email_address": "a@b.com"})
+                "/web/invites/uninvite", json={"email_address": "a@b.com"},
+                headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_get_invite_by_token_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/web/invites/token/abc123")
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_accept_invite_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/web/accept_invite",
+                json={"token": "abc123", "full_name": "A",
+                     "display_name": "A", "password": "password1"})
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -2,6 +2,7 @@ import unittest
 from test_configuration import TestConfiguration
 from test_metadata_settings import TestMetadataSettings
 from test_page_handler_injections import TestPageHandlerInjections
+from test_authenticated_rest_client import TestAuthenticatedRestClient
 from test_decorators import TestRequireSession
 from test_portal_page_handler import (
     TestSessionAuthMixinGenerateRedirect,

--- a/unit_tests/web_portal_svc/test_authenticated_rest_client.py
+++ b/unit_tests/web_portal_svc/test_authenticated_rest_client.py
@@ -1,0 +1,160 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import unittest
+from unittest.mock import AsyncMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_web_portal.authenticated_rest_client import (
+    AuthenticatedRestClient, HEADER_TOKEN, HEADER_USER)
+
+_AUTH_COOKIE = "items_token=abc123; items_user=alice@x.com"
+
+
+def _make_app():
+    app = Quart(__name__)
+
+    inner = AsyncMock()
+    for method in ("get", "post", "put", "patch", "delete"):
+        getattr(inner, method).return_value = ApiResponse(
+            status_code=200, body={})
+    wrapped = AuthenticatedRestClient(inner)
+
+    @app.route('/probe-get')
+    async def probe_get():
+        await wrapped.get("http://gateway/web/projects")
+        return "ok"
+
+    @app.route('/probe-post-keyword', methods=['POST'])
+    async def probe_post_keyword():
+        await wrapped.post("http://gateway/web/projects",
+                          json_data={"name": "x"})
+        return "ok"
+
+    @app.route('/probe-post-positional', methods=['POST'])
+    async def probe_post_positional():
+        # Matches the real call-site pattern in
+        # admin_add_project_page_handlers.py: the JSON body passed as the
+        # second positional argument, not as a json_data= keyword. This is
+        # exactly the shape that broke when the wrapper's second positional
+        # parameter was `headers` instead of `json_data`.
+        await wrapped.post("http://gateway/web/projects", {"name": "x"})
+        return "ok"
+
+    @app.route('/probe-patch-positional', methods=['POST'])
+    async def probe_patch_positional():
+        # Matches admin_modify_project_page_handlers.py's call shape.
+        await wrapped.patch("http://gateway/web/projects/1", {"name": "x"})
+        return "ok"
+
+    @app.route('/probe-put', methods=['POST'])
+    async def probe_put():
+        # Matches admin_customisations_page_handler.py's call shape.
+        await wrapped.put("http://gateway/web/testcase_custom_fields/1",
+                          json_data={"field_name": "x"})
+        return "ok"
+
+    @app.route('/probe-delete', methods=['POST'])
+    async def probe_delete():
+        await wrapped.delete("http://gateway/web/projects/1")
+        return "ok"
+
+    @app.route('/probe-with-headers')
+    async def probe_with_headers():
+        await wrapped.get("http://gateway/web/projects",
+                          headers={"X-Custom": "1"})
+        return "ok"
+
+    return app, inner
+
+
+class TestAuthenticatedRestClient(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.app, self.inner = _make_app()
+        self.client = self.app.test_client()
+
+    async def test_get_attaches_session_headers_from_cookies(self):
+        async with self.client as c:
+            await c.get("/probe-get", headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.get.await_args
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_post_with_keyword_json_data_forwards_it_unchanged(self):
+        async with self.client as c:
+            await c.post("/probe-post-keyword",
+                         headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.post.await_args
+        self.assertEqual(call.kwargs["json_data"], {"name": "x"})
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_post_with_positional_json_data_forwards_it_unchanged(self):
+        """Regression test: a positional body must land in json_data, not
+        be silently swallowed into headers."""
+        async with self.client as c:
+            await c.post("/probe-post-positional",
+                         headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.post.await_args
+        self.assertEqual(call.kwargs["json_data"], {"name": "x"})
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_patch_with_positional_json_data_forwards_it_unchanged(self):
+        async with self.client as c:
+            await c.post("/probe-patch-positional",
+                         headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.patch.await_args
+        self.assertEqual(call.kwargs["json_data"], {"name": "x"})
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_put_attaches_session_headers_and_forwards_json_data(self):
+        async with self.client as c:
+            await c.post("/probe-put", headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.put.await_args
+        self.assertEqual(call.kwargs["json_data"], {"field_name": "x"})
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_delete_attaches_session_headers(self):
+        async with self.client as c:
+            await c.post("/probe-delete", headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.delete.await_args
+        self.assertEqual(call.kwargs["headers"],
+                         {HEADER_USER: "alice@x.com", HEADER_TOKEN: "abc123"})
+
+    async def test_no_cookies_means_no_session_headers(self):
+        """An unauthenticated page (e.g. accept-invite) has no session
+        cookies to forward - the gateway call still goes out, just without
+        the session headers, exactly as it did before this wrapper existed.
+        """
+        async with self.client as c:
+            await c.get("/probe-get")
+        call = self.inner.get.await_args
+        self.assertEqual(call.kwargs["headers"], {})
+
+    async def test_existing_headers_are_preserved_alongside_session_headers(self):
+        async with self.client as c:
+            await c.get("/probe-with-headers", headers={"Cookie": _AUTH_COOKIE})
+        call = self.inner.get.await_args
+        self.assertEqual(call.kwargs["headers"], {
+            "X-Custom": "1", HEADER_USER: "alice@x.com",
+            HEADER_TOKEN: "abc123"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Gateway: enforce admin-only routes

**Branch:** `admin_route_enforcement` → `main`
**Theme:** User Roles and Management (0.3.0) — piece 2 of 3
**Stats:** 16 files changed, +951/-45

## Summary

Closes the top item in `future.md`: the Gateway trusted that only the web
portal called it, and that the portal had already checked
`is_administrator` before doing so. In production the Gateway is the only
externally-visible service (CMS and Identity bind to `127.0.0.1`), so this
meant every admin-only route - including `POST /web/users`, unauthenticated
account creation - was reachable directly by anyone who could reach the
Gateway.

Design settled before implementation (see design discussion): a single
combined branch rather than the two-step "portal forwards, then gateway
enforces" split originally considered - splitting it has a real deployment
hazard neither direction survives safely (portal-alone is inert but
pointless; gateway-alone locks out every user, including admins, if the
portal isn't already sending credentials). Doing both atomically removes
the ordering risk entirely.

## Mechanism

The portal forwards the caller's already-validated session as two headers,
`X-Items-User` / `X-Items-Token`, mirroring the `items_user`/`items_token`
cookie names they're read from. Headers rather than a body field
deliberately - the design doc's own §9.4 already hit the "reader must
tolerate before writer emits" problem once, for the `is_administrator`
response field, with several gateway routes using
`"additionalProperties": false` request schemas that would have rejected
an unrecognised body field outright. Headers aren't schema-validated, so
there's no equivalent hazard.

## Gateway

`auth_decorators.py` (new) - `require_session(sessions)` and
`require_administrator(sessions)` decorator factories. Wrap the small
delegate closures registered in each `routes/web/*/__init__.py` blueprint
factory, not the handler classes themselves - those are also called
directly (bypassing HTTP) from existing unit tests and should stay
authorization-agnostic. 401 on a missing/invalid session, 403 on a valid
session lacking admin rights.

Applied across every `/web/*` blueprint, classified by cross-referencing
which portal page handlers call each route and whether those are
`@require_administrator` or `@require_session`:

| Access level | Routes |
|---|---|
| Admin-only | All of Users, all of Invites except the two exemptions below, Testcase Custom Fields (including its GET - the Customisations page it backs is entirely admin-only), Projects add/update/delete |
| Session-only | Projects list/get, Testcases list/get - both called by non-admin pages too, so can't require admin |
| Exempt (unchanged) | Sessions (self-contained via body credentials), invite token lookup and accept-invite (invite token is the authorisation), webhook metadata (its own HMAC signature) |

`routes/web/projects/__init__.py` - factory signature extended to take
`sessions`, since it previously received individual config params rather
than the full `RouteInjections`.

Docstrings on the `invites` and `users` blueprints updated - they
previously said enforcement was the caller's job; now they say it's
enforced here.

## Web Portal

`authenticated_rest_client.py` (new) - `AuthenticatedRestClient` wraps
`RestClient`, attaching the session headers (read fresh from
`quart.request.cookies` on every call) to every gateway request. Wired in
at `service.py` only for the client handed to `PageHandlerInjections` - the
raw, unwrapped client stays in use for the portal's own webhook-metadata
retrieval, which runs at startup with no request context to read cookies
from and authenticates via its own signature instead.

**Bug found and fixed during manual testing** (thank you): the wrapper's
first version had `post`/`patch`/`delete` signatures with `headers` as the
second positional parameter, but `RestClient`'s real signatures have
`json_data` there. Two existing call sites
(`admin_add_project_page_handlers.py`, `admin_modify_project_page_handlers.py`)
pass the body positionally, so it was silently landing in `headers`
instead - `aiohttp` throwing on a non-string header value produced the 500
on `/admin/add_project`. Separately, the wrapper had no `put()` method at
all, which would have broken Customisations' "Modify Custom Field" the
moment anyone tried it. Fixed by rewriting every method to mirror
`RestClient`'s real signature exactly, and added regression tests that
call `post`/`patch` positionally (the exact shape that broke) plus new
`put` coverage.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

New: `test_auth_decorators.py` (decorator behaviour in isolation - no
headers, wrong token, unknown session, non-admin, admin), and
`test_admin_route_enforcement.py` (a full table-driven pass over every
`/web/*` route, confirming each one enforces the *right* level - admin-only
routes 401 with no session and 403 for a non-admin, session-only routes
401 with no session but pass for a non-admin, exempt routes need nothing).
This is the piece that actually catches "forgot to decorate a route" or
"used the wrong decorator", which the other two test files can't on their
own.

`test_route_factories.py` updated to authenticate as an administrator on
every call, so the route-closure coverage it exists for isn't lost now
that unauthenticated calls short-circuit before reaching the handler.

`test_authenticated_rest_client.py` (new) - header forwarding for every
method, cookie-absent behaviour, existing-header preservation, and the two
positional-argument regression cases described above.

**Gateway: 315 tests, OK, 100% coverage, pylint 10.00/10.**
**Web Portal: 253 tests, OK, 100% coverage, pylint 10.00/10.**

## future.md

Also carries two entries added earlier in the same branch, before this
piece was implemented: session cookies missing `HttpOnly`/`SameSite`, and
a placeholder for the (unscoped) move to HTTPS. Docs-only, unrelated to
the enforcement code - flagged separately in case you'd rather split them
out.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
