### PR TITLE
Update Design Documents with concepts

### DIFF
--- a/design_docs/user_roles_design.md
+++ b/design_docs/user_roles_design.md
@@ -438,7 +438,7 @@ at the gateway, but CMS needs to know *who* acted in order to record it —
 required by the audit concerns in §10.5 (who purged what, and when). That is
 a distinct concern from enforcement and should not be conflated with it.
 
-### 9.2 Project scope must be in the route
+### 9.2 Project scope must be in the request
 
 For the gateway to authorise a project-scoped permission, it must know which
 project the target entity belongs to — **without asking CMS**. Otherwise
@@ -447,17 +447,42 @@ downstream of a data lookup.
 
 Current route shapes are inconsistent on this point:
 
-| Route | Project scope in path? | Gateway can authorise? |
-| ----- | ---------------------- | ---------------------- |
-| `/<int:project_id>/testcases` | Yes | Yes, from the path |
+| Route | Project scope in the request? | Gateway can authorise? |
+| ----- | ------------------------------ | ---------------------- |
+| `/<int:project_id>/testcases` | Yes, in the path | Yes |
 | `/testcases/<int:case_id>` | **No** | **No** — owning project unknown |
 | `/testcase_custom_fields/<int:field_id>` | N/A (instance-level) | Yes, admin flag only |
 
-**Decision needed:** entity routes that are project-scoped should carry the
-project in the path, e.g. `/projects/<project_id>/testcases/<case_id>`. The
-gateway then authorises from the path alone, and CMS verifies only that the
-entity genuinely belongs to that project — an integrity check, not an
-authorisation decision.
+**Decision: `project_id` travels as an explicit parameter on entity routes,
+not nested in the path.** `GET /testcases/<case_id>?project_id=<id>` for
+reads; a `project_id` body field for writes (`PATCH`/`DELETE`). The gateway
+authorises from that parameter directly - no extra hop - and CMS verifies
+only that the entity genuinely belongs to the stated project (an integrity
+check, not an authorisation decision), 404ing on a mismatch rather than
+trusting the caller's claim.
+
+**Nested path (`/projects/<project_id>/testcases/<case_id>`) was
+considered and rejected.** Nesting is the right call when a child's ID
+isn't meaningful without its parent (GitHub issue numbers restart at 1 per
+repo, so the repo *must* be in the path to identify one). It's not the
+right call here: a testcase `id` is a single globally-unique primary key
+across `tc_test_cases`, not scoped per project, so nesting would add a path
+segment without adding anything needed to identify the resource. The
+existing route shapes already draw this line correctly without anyone
+having decided it on purpose - `/<project_id>/testcases` (a list, genuinely
+scoped to its parent) is nested, `/testcases/<case_id>` (a single entity,
+already globally identified) is flat. The explicit-parameter approach
+extends that same line to authorisation instead of abandoning it.
+
+This also matches precedent already in the codebase rather than
+introducing a new mechanism: `POST /testcases` already requires
+`project_id` in its body (`add_testcase_handler.py`), and
+`DELETE /web/projects/<id>?hard_delete=true` already puts a meaningful
+parameter on a `DELETE` request as a query string, not a body field.
+
+`testcase_custom_fields` needs no change - those are instance-wide
+definitions, not per-project, so "N/A" in the table above is correct as
+is, not a gap to close.
 
 This is cheap to change now and a breaking API change once clients depend on
 the current shapes, so it is worth settling before further routes are added.
@@ -716,3 +741,4 @@ Settled during design discussion:
 | v1 is **users-only** | Groups are a scale convenience, not a capability requirement; hooks in place so they are additive |
 | Roles live in `identity.db` | Rides along with existing session validation; no extra hop per request |
 | No negative/deny permissions | Keeps effective access predictable |
+| `project_id` is an explicit parameter, not a nested path segment (§9.2) | Testcase `id`s are already globally unique, so nesting adds a path segment without adding anything needed to identify the resource; matches precedent already in the codebase (`POST /testcases` body, `DELETE /projects/<id>?hard_delete=` query) |

--- a/future.md
+++ b/future.md
@@ -208,26 +208,39 @@ and pass `email_service=None` instead. The invite handlers already treat
 call sites need no changes - this is purely a startup-wiring change plus a
 config flag.
 
-## Identity: no soft-delete for users (admin)
+## Identity: no erasure path for users (deferred, not a gap)
 
-**Where:** `items_identity` has no delete path for users at all today -
-only create, list/get, modify, reset/change password
-(`services/user_management_service.py`, `routes/users/`). Projects already
-have a soft-delete-plus-background-purge convention
-(`is_deleted`/background expiry task); users have no equivalent.
+**Where:** `items_identity` has no delete or anonymise path for users
+today - only create, list/get, modify, reset/change password
+(`services/user_management_service.py`, `routes/users/`).
+
+**This entry originally proposed a soft-delete column for users, mirroring
+the project/invite `is_deleted`/`is_expired` pattern.** That turned out to
+be the wrong shape: `user_roles_design.md` §10.6 ("User accounts are
+deactivated, never deleted") already made a considered decision against
+any delete-like concept for users, for reasons that still hold - every
+reference to a user outside `identity.db` is cross-database and
+unenforced (no foreign key), so removing a row wouldn't remove the
+references, it would just make them dangle silently. Deactivation
+(`account_status = DISABLED`) already covers "this person shouldn't have
+access any more" end to end (Identity, Gateway, and the Portal toggle in
+`portal_admin_access_tab`), and was never a placeholder waiting for a
+real delete to arrive later.
 
 **Problem:** an administrator who invites/creates the wrong person, or
 needs to offboard someone, has no way to remove their account short of
 direct database access. Given the existing soft-delete convention
 elsewhere in the codebase, a hard delete would also be inconsistent with
-how the rest of the system handles removal.
+how the rest of the system handles removal
 
-**Fix:** add a soft-delete column to the user table (mirroring the
-project/invite `is_deleted`/`is_expired` pattern), a repository method,
-a service method enforcing whatever business rules apply (e.g. can an
-administrator delete themselves? the last remaining administrator?), a
-Gateway route, and an admin-page action on Users & Roles. Sizeable enough
-to be its own small PR rather than a squeeze-in - candidate for 0.3.0.
+**If a genuine need appears** - a right-to-erasure request being the
+likely trigger - the design doc's answer is **anonymise in place**: keep
+the `id`, overwrite the personal data (email becomes
+`deleted-user-<id>@invalid`, names become "Deleted User"), revoke
+credentials. That preserves referential integrity automatically (the `id`
+never disappears) and keeps history attributable, unlike a shared
+tombstone account. Not scoped further than that - deliberately deferred,
+no timeline.
 
 ## Gateway: deactivating a user does not touch their existing session
 


### PR DESCRIPTION
## What does this PR do?

# Design docs: settle project-scope routing + user erasure framing

**Branch:** `design_docs_route_scoping` → `main`
**Stats:** docs-only, 2 files changed (`design_docs/user_roles_design.md`,
`future.md`)

## Summary

No code in this branch - two design decisions recorded so they don't get
re-litigated later, both surfaced while scoping the next piece of the
"User Roles and Management" theme.

## design_docs/user_roles_design.md

§9.2 ("Project scope must be in the route") previously ended in "Decision
needed" with a proposed nested path
(`/projects/<project_id>/testcases/<case_id>`). Settled instead on
**`project_id` as an explicit parameter, not a nested path segment** -
`?project_id=<id>` on `GET`, a `project_id` body field on `PATCH`/`DELETE`.
Reasoning now recorded in the doc:

- A testcase `id` is already a single globally-unique primary key across
  `tc_test_cases`, not scoped per project (unlike, say, GitHub issue
  numbers, which restart per repo and genuinely require the parent in the
  path to identify one). Nesting would add a path segment without adding
  anything needed to identify the resource.
- The existing route shapes already draw this line correctly without
  anyone deciding it on purpose - `/<project_id>/testcases` (a list,
  genuinely scoped to its parent) is nested, `/testcases/<case_id>` (a
  single entity, already globally identified) is flat. The explicit
  parameter extends that same line to authorisation rather than
  abandoning it for a nested shape.
- Matches precedent already in the codebase: `POST /testcases` already
  requires `project_id` in its body, and
  `DELETE /web/projects/<id>?hard_delete=` already puts a meaningful
  parameter on a `DELETE` request as a query string.

`testcase_custom_fields` needs no change under this decision - confirmed
those stay instance-wide, not per-project.

Added a row to the decisions log at the bottom of the document for
consistency with how every other settled call in that doc is recorded.

**Not implemented here** - this is the design decision only. Actually
changing the Gateway route, CMS's entity-lookup validation, the Web
Portal's testcase URLs, and the Postman collection is follow-up work, not
part of this branch.

## future.md

Retitled and rewrote the "no soft-delete for users" entry to "no erasure
path for users (deferred, not a gap)". That entry, written earlier, turned
out to propose the wrong shape: `user_roles_design.md` §10.6 already made
a considered decision against any delete-like concept for users (cross-
database references would go silently dangling), and deactivation already
covers the actual need end to end. Reframed to point at anonymise-in-place
(the design doc's own answer for genuine erasure requests) if this is ever
revisited, rather than soft-delete. No longer a candidate for 0.3.0 -
deliberately deferred with no timeline.

## Theme status

"User Roles and Management" (0.3.0): admin-toggle UI and gateway
enforcement are shipped. User erasure is now explicitly deferred out of
this theme rather than a pending third piece. The route-scoping decision
here unblocks project membership / the permission grid as a *future*
theme, but implementing either is still out of scope for 0.3.0.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

<!-- How have you tested this change? -->

## Checklist

- [ ] Code follows the project style guidelines
- [ ] Self-review completed
- [ ] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
