### PR TITLE
Testcase project scoping

### DIFF
--- a/future.md
+++ b/future.md
@@ -3,61 +3,6 @@
 Running list of known, deliberately-deferred items — not urgent, but worth
 tracking so they don't get lost.
 
-## Gateway: admin-only routes are not actually enforced
-
-**This one is a security issue rather than a tidy-up**, and is listed first
-for that reason.
-
-**Where:** every route under `items_gateway/routes/web/`. There is no
-authorisation check anywhere in the Gateway — no session validation, no
-`is_administrator` check, no decorator. The invites blueprint states the
-position outright:
-
-```python
-"""All routes are admin-only and must be enforced at this layer or by the
-caller (the web portal, which checks ``is_administrator`` before calling)."""
-```
-
-It is currently the second of those: the Gateway trusts that the caller was
-the web portal and that the portal checked.
-
-**Problem:** in production the Gateway is the *only* externally visible
-service — CMS and Identity bind to `127.0.0.1`. So the Gateway is the public
-attack surface, and nothing about a request proves it came from the portal.
-`POST /web/users` is therefore a publicly reachable, unauthenticated
-account-creation endpoint: anyone who can reach the Gateway can create
-themselves an account, including an administrator one, with a single `curl`
-and without ever loading the portal. The same applies to every other
-admin-only route (project deletion, custom field changes, invites, user
-modification).
-
-The portal's `require_administrator` decorator is real and works, but it
-guards the *portal's* pages. Hiding a button is a user-experience decision,
-not a security boundary — exactly the point already made in §9.1 of
-`design_docs/user_roles_design.md`, which names the Gateway as the
-enforcement point. That part was never implemented.
-
-**Fix:** enforce at the Gateway. It already holds the session table
-(`sessions.py`), and `SessionEntry` already carries `is_administrator`, so
-the pieces exist — what is missing is a check on the request path. Broadly:
-
-- Require session credentials on `/web/*` requests and validate them against
-  the session store.
-- Gate admin-only routes on the session's `is_administrator` flag.
-- Decide how the portal passes the caller's session to the Gateway; it
-  currently forwards none, so this is the main design question.
-
-**Two routes must be explicitly exempted**, and this is easy to get wrong
-with a blanket rule:
-
-- `GET  /web/invites/token/<token>`
-- `POST /web/accept_invite`
-
-Both are deliberately unauthenticated, because somebody redeeming an
-invitation has no account yet — the invite token authorises them instead.
-This is documented in the invites blueprint docstring so it is not
-"corrected" by mistake.
-
 ## CMS: `linked_projects` encoding is ambiguous
 
 **Where:** `items_cms.repositories.testcase_custom_fields_repository`'s

--- a/items/services/items_cms/repositories/testcase_repository.py
+++ b/items/services/items_cms/repositories/testcase_repository.py
@@ -180,14 +180,14 @@ class TestcaseRepository:
             case_id: Primary key of the test case.
 
         Returns:
-            A dict with ``id``, ``folder_id``, ``name``, and
+            A dict with ``id``, ``project_id``, ``folder_id``, ``name``, and
             ``description`` if found, or None if no row matches.
 
         Raises:
             SqliteInterfaceException: If the database query fails.
         """
         query = (
-            f"SELECT id, folder_id, name, description "
+            f"SELECT id, project_id, folder_id, name, description "
             f"FROM {cms_tables.TC_TEST_CASES} WHERE id = ?"
         )
         row = await self._db.run_query(query, (case_id,), fetch_one=True)
@@ -195,9 +195,10 @@ class TestcaseRepository:
         if not row:
             return None
 
-        test_id, folder_id, name, description = row
+        test_id, project_id, folder_id, name, description = row
         return {
             'id': test_id,
+            'project_id': project_id,
             'folder_id': folder_id,
             'name': name,
             'description': description

--- a/items/services/items_cms/routes/testcases/get_testcase_handler.py
+++ b/items/services/items_cms/routes/testcases/get_testcase_handler.py
@@ -16,7 +16,7 @@ limitations under the License.
 import json
 import logging
 from http import HTTPStatus
-from quart import Response
+from quart import request, Response
 from weaver_framework.microservice.base_api_route import BaseApiRoute
 from items.services.items_cms.services.testcase_service import TestcaseService
 
@@ -45,12 +45,26 @@ class GetTestcaseHandler(BaseApiRoute):
 
         Returns:
             200 with the test case details dict on success.
-            404 if no test case exists with the given ID.
+            400 if the optional ``project_id`` query parameter is present
+            but not a valid integer.
+            404 if no test case exists with the given ID, or one does but
+            ``project_id`` was supplied and doesn't match.
             500 on an internal database error.
         """
         # pylint: disable=duplicate-code
 
-        result = await self._service.get_testcase(case_id)
+        project_id: int | None = None
+        raw_project_id = request.args.get("project_id")
+        if raw_project_id is not None:
+            try:
+                project_id = int(raw_project_id)
+            except ValueError:
+                return Response(
+                    json.dumps({"error": "project_id must be an integer"}),
+                    status=HTTPStatus.BAD_REQUEST,
+                    content_type="application/json")
+
+        result = await self._service.get_testcase(case_id, project_id)
 
         if not result.success:
             status = (HTTPStatus.INTERNAL_SERVER_ERROR

--- a/items/services/items_cms/services/testcase_service.py
+++ b/items/services/items_cms/services/testcase_service.py
@@ -95,15 +95,23 @@ class TestcaseService:
 
         return TestcaseResult(success=True, data=data)
 
-    async def get_testcase(self, case_id: int) -> TestcaseResult:
+    async def get_testcase(self, case_id: int,
+                           project_id: Optional[int] = None) -> TestcaseResult:
         """Retrieve full details for a single test case.
 
         Args:
             case_id: ID of the test case to retrieve.
+            project_id: If supplied, the test case must belong to this
+                project - a mismatch is reported identically to the test
+                case not existing at all (see below), rather than as a
+                distinct error. Callers that don't need this check (direct
+                CMS callers, existing tests) can omit it and get the
+                previous behaviour unchanged.
 
         Returns:
             TestcaseResult with data set to the test case dict on success,
-            or an appropriate error result if not found or a DB failure
+            or an appropriate error result if not found, owned by a
+            different project than the one supplied, or a DB failure
             occurs.
         """
         if not self._state.is_available():
@@ -121,7 +129,15 @@ class TestcaseService:
                                   error_msg="Internal error in CMS",
                                   is_internal=True)
 
-        if testcase is None:
+        # Deliberately the same "not found" outcome as a missing row. This
+        # is a data-integrity check, not an authorisation decision - CMS
+        # stays permission-agnostic (see user_roles_design.md §9.1) - but a
+        # test case that exists under a different project than the one the
+        # caller stated isn't "the test case the caller asked for" either
+        # way, so there's no useful distinct response to give here.
+        if testcase is None or (
+                project_id is not None
+                and testcase["project_id"] != project_id):
             return TestcaseResult(success=False,
                                   error_msg="Test case not found",
                                   not_found=True)

--- a/items/services/items_gateway/routes/web/testcases/get_testcase_handler.py
+++ b/items/services/items_gateway/routes/web/testcases/get_testcase_handler.py
@@ -17,7 +17,7 @@ limitations under the License.
 from http import HTTPStatus
 import json
 import logging
-from quart import Response
+from quart import request, Response
 from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.base_api_route import BaseApiRoute
 from weaver_framework.microservice.rest_client import RestClient
@@ -51,10 +51,12 @@ class GetTestcaseHandler(BaseApiRoute):
     async def get_testcase(self, case_id: int) -> Response:
         """Retrieve the details of a single testcase.
 
-        The request is forwarded to the CMS service. A successful response is
-        returned directly to the client. If the testcase cannot be found, a
-        404 response is returned. Any other CMS error is treated as an internal
-        server error.
+        Requires a ``project_id`` query parameter - unlike CMS's own route,
+        which treats it as optional, the gateway needs it to authorise the
+        request (see ``user_roles_design.md`` §9.2) and has no other source
+        for it, so it can't be inferred or skipped here. The request is
+        forwarded to CMS, which enforces that the testcase actually belongs
+        to the stated project.
 
         Args:
             case_id: Unique identifier of the testcase to retrieve.
@@ -62,10 +64,31 @@ class GetTestcaseHandler(BaseApiRoute):
         Returns:
             Response: A JSON response containing the testcase details or an
             error message.
+
+            400 if ``project_id`` is missing or not a valid integer.
+            404 if the testcase doesn't exist, or exists under a different
+            project than the one supplied.
+            500 on an unexpected CMS error.
         """
+        raw_project_id = request.args.get("project_id")
+        if raw_project_id is None:
+            response_json = {"error": "project_id query parameter is required"}
+            return Response(json.dumps(response_json),
+                            status=HTTPStatus.BAD_REQUEST,
+                            content_type="application/json")
+
+        try:
+            project_id = int(raw_project_id)
+        except ValueError:
+            response_json = {"error": "project_id must be an integer"}
+            return Response(json.dumps(response_json),
+                            status=HTTPStatus.BAD_REQUEST,
+                            content_type="application/json")
+
         cms_svc: str = self._config.apis_cms_svc
 
-        details_url: str = f"{cms_svc}testcases/{case_id}"
+        details_url: str = (
+            f"{cms_svc}testcases/{case_id}?project_id={project_id}")
 
         api_response: ApiResponse = await self._rest_client.get(details_url)
 

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 2"
+PRE_RELEASE = "Alpha Build 3"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -1218,7 +1218,7 @@
                     "method": "GET",
                     "header": [],
                     "url": {
-                      "raw": "{{GATEWAY_SVC_URL}}/web/testcases/1",
+                      "raw": "{{GATEWAY_SVC_URL}}/web/testcases/1?project_id=6",
                       "host": [
                         "{{GATEWAY_SVC_URL}}"
                       ],
@@ -1226,6 +1226,12 @@
                         "web",
                         "testcases",
                         "1"
+                      ],
+                      "query": [
+                        {
+                          "key": "project_id",
+                          "value": "6"
+                        }
                       ]
                     }
                   },

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -1011,7 +1011,18 @@
                   },
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"name\": \"Project Gamma\",\n    \"announcement\": \"This is test project Gamma\",\n    \"announcement_on_overview\": false\n}",
@@ -1039,7 +1050,18 @@
                   "name": "List all projects",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/projects?value_fields=name&count_fields=no_of_test_runs,no_of_milestones",
                       "host": [
@@ -1067,7 +1089,18 @@
                   "name": "Add Project",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"name\": \"test project35\",\n    \"announcement\": \"Test that announcement are written\",\n    \"announcement_on_overview\": true\n}",
@@ -1094,7 +1127,18 @@
                   "name": "Delete Project",
                   "request": {
                     "method": "DELETE",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"name\": \"Beta Project\"\n}",
@@ -1128,7 +1172,18 @@
                   "name": "Update a Project",
                   "request": {
                     "method": "PATCH",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"name\": \"Project bob\",\n    \"announcement\": \"This is test project Gamma\",\n    \"announcement_on_overview\": false\n}",
@@ -1197,7 +1252,18 @@
                   "name": "Get testcases for Project",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/1/testcases",
                       "host": [
@@ -1216,7 +1282,18 @@
                   "name": "Get a test case",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/testcases/1?project_id=6",
                       "host": [
@@ -1244,6 +1321,29 @@
               "item": [
                 {
                   "name": "Create Session (Password)",
+                  "event": [
+                    {
+                      "listen": "test",
+                      "script": {
+                        "type": "text/javascript",
+                        "exec": [
+                          "// On a successful login, capture the token and the",
+                          "// email address that was sent, so every other Gateway",
+                          "// Web request in this collection can reference",
+                          "// {{ITEMS_USER}} / {{ITEMS_TOKEN}} in its headers",
+                          "// without manual copy-paste after each login.",
+                          "if (pm.response.code === 200) {",
+                          "    const body = pm.response.json();",
+                          "    if (body.token) {",
+                          "        pm.collectionVariables.set('ITEMS_TOKEN', body.token);",
+                          "        const sentBody = JSON.parse(pm.request.body.raw);",
+                          "        pm.collectionVariables.set('ITEMS_USER', sentBody.email_address);",
+                          "    }",
+                          "}"
+                        ]
+                      }
+                    }
+                  ],
                   "request": {
                     "method": "POST",
                     "header": [],
@@ -1335,7 +1435,18 @@
                   },
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{}",
@@ -1362,7 +1473,18 @@
                   "name": "Get Testcase Field",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/testcase_custom_fields/1",
                       "host": [
@@ -1381,7 +1503,18 @@
                   "name": "Update Testcase Field",
                   "request": {
                     "method": "PUT",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\r\n  \"field_name\": \"Dry Wall\",\r\n  \"description\": \"A human-readable description of the field.\",\r\n  \"system_name\": \"unsafe\",\r\n  \"field_type\": \"Integer\",\r\n  \"enabled\": false,\r\n  \"is_required\": true,\r\n  \"default_value\": \"123\",\r\n  \"applies_to_all_projects\": true\r\n}",
@@ -1409,7 +1542,18 @@
                   "name": "Move Custom Testcase field",
                   "request": {
                     "method": "PATCH",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\r\n    \"direction\": \"up\"\r\n}",
@@ -1437,7 +1581,18 @@
                   "name": "Delete Custom Testcase Field Copy",
                   "request": {
                     "method": "DELETE",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/testcase_custom_fields/2",
                       "host": [
@@ -1461,7 +1616,18 @@
                   "name": "List Invites",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/invites",
                       "host": [
@@ -1479,7 +1645,18 @@
                   "name": "Create Invite",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
@@ -1506,7 +1683,18 @@
                   "name": "Resend Invite",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
@@ -1534,7 +1722,18 @@
                   "name": "Uninvite",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"email_address\": \"newuser@localhost\"\n}",
@@ -1614,7 +1813,18 @@
                   "name": "List Users",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/users",
                       "host": [
@@ -1632,7 +1842,18 @@
                   "name": "Get User",
                   "request": {
                     "method": "GET",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "url": {
                       "raw": "{{GATEWAY_SVC_URL}}/web/users/{{USER_UUID}}",
                       "host": [
@@ -1651,7 +1872,18 @@
                   "name": "Create User (generated password)",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"email_address\": \"gemma@localhost\",\n    \"full_name\": \"Gemma Tester\",\n    \"display_name\": \"Gemma\"\n}",
@@ -1678,7 +1910,18 @@
                   "name": "Create User (explicit password, administrator)",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"email_address\": \"second.admin@localhost\",\n    \"full_name\": \"Second Admin\",\n    \"display_name\": \"Admin2\",\n    \"is_administrator\": true,\n    \"password\": \"change-me-please\"\n}",
@@ -1705,7 +1948,18 @@
                   "name": "Update User",
                   "request": {
                     "method": "PATCH",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"display_name\": \"Gem\"\n}",
@@ -1733,7 +1987,18 @@
                   "name": "Deactivate User",
                   "request": {
                     "method": "PATCH",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"account_status\": 0\n}",
@@ -1761,7 +2026,18 @@
                   "name": "Reset User Password",
                   "request": {
                     "method": "POST",
-                    "header": [],
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
                     "body": {
                       "mode": "raw",
                       "raw": "{\n    \"new_password\": \"a-new-password\"\n}",

--- a/unit_tests/items_cms/test_testcase_handlers.py
+++ b/unit_tests/items_cms/test_testcase_handlers.py
@@ -102,6 +102,32 @@ class TestGetTestcaseHandler(unittest.IsolatedAsyncioTestCase):
             response = await c.get("/testcases/1")
         self.assertEqual(response.status_code, 500)
 
+    async def test_get_testcase_without_project_id_passes_none(self):
+        self.mock_service.get_testcase.return_value = _ok(data={"id": 10})
+        async with self.client as c:
+            await c.get("/testcases/10")
+        self.mock_service.get_testcase.assert_awaited_once_with(10, None)
+
+    async def test_get_testcase_with_valid_project_id_passes_it_through(self):
+        self.mock_service.get_testcase.return_value = _ok(data={"id": 10})
+        async with self.client as c:
+            await c.get("/testcases/10?project_id=5")
+        self.mock_service.get_testcase.assert_awaited_once_with(10, 5)
+
+    async def test_get_testcase_project_id_mismatch_returns_404(self):
+        """Same outcome as case_id not existing at all - see the service
+        layer's reasoning for treating the two identically."""
+        self.mock_service.get_testcase.return_value = _not_found()
+        async with self.client as c:
+            response = await c.get("/testcases/10?project_id=999")
+        self.assertEqual(response.status_code, 404)
+
+    async def test_get_testcase_non_integer_project_id_returns_400(self):
+        async with self.client as c:
+            response = await c.get("/testcases/10?project_id=abc")
+        self.assertEqual(response.status_code, 400)
+        self.mock_service.get_testcase.assert_not_called()
+
 
 # ------------------------------------------------------------------
 # ListTestcasesHandler

--- a/unit_tests/items_cms/test_testcase_repository.py
+++ b/unit_tests/items_cms/test_testcase_repository.py
@@ -310,6 +310,7 @@ class TestTestcaseRepository(unittest.IsolatedAsyncioTestCase):
         result = await self.repo.get_testcase(tc_id)
         self.assertIsNotNone(result)
         self.assertEqual(result["id"], tc_id)
+        self.assertEqual(result["project_id"], pid)
         self.assertEqual(result["name"], "Login Test")
         self.assertEqual(result["description"], "Verify login")
         self.assertIsNone(result["folder_id"])

--- a/unit_tests/items_cms/test_testcase_service.py
+++ b/unit_tests/items_cms/test_testcase_service.py
@@ -108,12 +108,33 @@ class TestTestcaseService(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.not_found)
 
     async def test_get_testcase_success(self):
-        tc = {"id": 42, "folder_id": 1, "name": "Login test",
+        tc = {"id": 42, "project_id": 5, "folder_id": 1, "name": "Login test",
               "description": "Verify login works"}
         self.mock_repo.get_testcase.return_value = tc
         result = await self.service.get_testcase(42)
         self.assertTrue(result.success)
         self.assertEqual(result.data, tc)
+
+    async def test_get_testcase_no_project_id_check_returns_regardless(self):
+        """Omitting project_id keeps existing behaviour unchanged - direct
+        CMS callers and other services don't need to opt in to the check."""
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        result = await self.service.get_testcase(1)
+        self.assertTrue(result.success)
+
+    async def test_get_testcase_matching_project_id_succeeds(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        result = await self.service.get_testcase(
+            1, project_id=_TESTCASE["project_id"])
+        self.assertTrue(result.success)
+        self.assertEqual(result.data, _TESTCASE)
+
+    async def test_get_testcase_mismatched_project_id_reports_not_found(self):
+        self.mock_repo.get_testcase.return_value = _TESTCASE
+        result = await self.service.get_testcase(
+            1, project_id=_TESTCASE["project_id"] + 1)
+        self.assertFalse(result.success)
+        self.assertTrue(result.not_found)
 
     # ------------------------------------------------------------------
     # create_testcase

--- a/unit_tests/items_gateway/test_admin_route_enforcement.py
+++ b/unit_tests/items_gateway/test_admin_route_enforcement.py
@@ -76,7 +76,7 @@ _SESSION_ONLY_ROUTES = [
     ("GET", "/web/projects", None),
     ("GET", "/web/projects/1", None),
     ("GET", "/web/1/testcases", None),
-    ("GET", "/web/testcases/1", None),
+    ("GET", "/web/testcases/1?project_id=1", None),
 ]
 
 # (method, path, json_body) - routes that must stay reachable with no

--- a/unit_tests/items_gateway/test_route_factories.py
+++ b/unit_tests/items_gateway/test_route_factories.py
@@ -166,7 +166,8 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_get_testcase_route_is_reachable(self):
         async with self.client as c:
-            response = await c.get("/web/testcases/1", headers=_AUTH_HEADERS)
+            response = await c.get("/web/testcases/1?project_id=1",
+                                   headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
     # ------------------------------------------------------------------

--- a/unit_tests/items_gateway/test_testcases_handlers.py
+++ b/unit_tests/items_gateway/test_testcases_handlers.py
@@ -49,30 +49,47 @@ class TestGetTestcaseHandler(unittest.IsolatedAsyncioTestCase):
 
         self.client = app.test_client()
 
-    async def _get(self):
+    async def _get(self, query=""):
         async with self.client as c:
-            return await c.get("/testcases/1")
+            return await c.get(f"/testcases/1{query}")
 
     async def test_not_found_returns_404(self):
         self.mock_rest_client.get.return_value = ApiResponse(
             status_code=404, body={"error": "Test case not found"})
-        response = await self._get()
+        response = await self._get("?project_id=5")
         self.assertEqual(response.status_code, 404)
         data = await response.get_json()
         self.assertEqual(data["error"], "Test case not found")
 
     async def test_other_error_returns_500(self):
         self.mock_rest_client.get.return_value = ApiResponse(status_code=503)
-        response = await self._get()
+        response = await self._get("?project_id=5")
         self.assertEqual(response.status_code, 500)
 
     async def test_success_returns_200(self):
         self.mock_rest_client.get.return_value = ApiResponse(
             status_code=200, body={"id": 1, "name": "Login test"})
-        response = await self._get()
+        response = await self._get("?project_id=5")
         self.assertEqual(response.status_code, 200)
         data = await response.get_json()
         self.assertEqual(data["name"], "Login test")
+
+    async def test_forwards_project_id_to_cms(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"id": 1})
+        await self._get("?project_id=5")
+        called_url = self.mock_rest_client.get.await_args.args[0]
+        self.assertIn("project_id=5", called_url)
+
+    async def test_missing_project_id_returns_400_without_calling_cms(self):
+        response = await self._get()
+        self.assertEqual(response.status_code, 400)
+        self.mock_rest_client.get.assert_not_called()
+
+    async def test_non_integer_project_id_returns_400_without_calling_cms(self):
+        response = await self._get("?project_id=abc")
+        self.assertEqual(response.status_code, 400)
+        self.mock_rest_client.get.assert_not_called()
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
# CMS + Gateway: project-scope the single-testcase route

**Branch:** `testcase_project_scoping` → `main`
**Commits:** `Test case enforcement`, `Postman updates`, `Bumped version`

## Summary

Implements the §9.2 decision recorded in `design_docs_route_scoping`:
`project_id` travels as an explicit parameter on `GET /testcases/<id>`,
not nested in the path. Single combined branch, same reasoning as the
gateway-enforcement work - CMS's half is safe alone (an optional,
backward-compatible parameter), but the Gateway's half would break the
testcase detail view for every user if deployed before the caller sends
`project_id`, so there's no safe order to split it into.

Turned out narrower than expected once scoped: the Web Portal doesn't
call `GET /web/testcases/<case_id>` anywhere yet (only the list route),
so this ended up touching two services, not three.

## CMS

`project_id` was already a real column on `tc_test_cases` (set at
creation, independent of `folder_id` which can be `NULL`) - no folder
lookup indirection needed, simpler than initially expected.

- `testcase_repository.py::get_testcase` - now selects and returns
  `project_id` alongside the existing fields. Purely additive to the
  response shape.
- `testcase_service.py::get_testcase` - new optional `project_id`
  parameter. When supplied and it doesn't match the test case's actual
  project, reports the same outcome as the test case not existing at all
  (`not_found`) rather than a distinct error - this is a data-integrity
  check, not an authorisation decision (CMS stays permission-agnostic per
  §9.1), but a test case under a different project than the caller stated
  isn't "the one they asked for" either way, so there's nothing useful to
  say beyond not found.
- `get_testcase_handler.py` - reads `project_id` from an **optional**
  query parameter (`?project_id=`), 400s only if present but not a valid
  integer. Optional and backward-compatible deliberately - existing
  direct CMS callers and tests keep working unchanged.

## Gateway

`get_testcase_handler.py` - `project_id` is **required** here, unlike
CMS: 400 if missing or not an integer. This is the boundary where the
value actually gets used for something (eventually gating access, once
project membership exists), so unlike CMS it has no reason to make it
optional. Forwards it straight through to CMS as the same query
parameter.


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

New/updated tests across both services cover: `project_id` omitted
(existing behaviour unchanged), supplied and matching, supplied and
mismatched (404, same as not-found), and non-integer (400) - at the
repository, service, and handler layer for CMS, and required-vs-missing
plus forwarding at the Gateway handler layer. Also updated the two
gateway-wide test files (`test_route_factories.py`,
`test_admin_route_enforcement.py`) that hit this route without a
`project_id`, so they keep exercising the real success path instead of
short-circuiting on the new validation.

**CMS: 472 tests, OK, 100% coverage, pylint 10.00/10.**
**Gateway: 318 tests, OK, 100% coverage, pylint 10.00/10.**

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [x] Documentation updated (if applicable)
