### PR TITLE
[Identity] roles changes

### DIFF
--- a/items/services/items_identity/data_access/role_repository.py
+++ b/items/services/items_identity/data_access/role_repository.py
@@ -1,0 +1,224 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterface
+from items.services.items_identity.identity_configuration import \
+    IdentityConfiguration
+
+
+class RoleRepository:
+    """
+    Provides persistence operations for named roles and their per-area
+    permission grids.
+
+    A role's grid (`role_permissions`) is always replaced as a whole -
+    there is no per-area upsert. Callers send the complete grid they want;
+    existing rows for the role are deleted and the new set inserted. This
+    matches how a checkbox-grid form naturally submits (full state, not a
+    diff) and avoids needing separate insert/update/delete logic per area.
+    """
+
+    GET_ALL_ROLES_QUERY: str = "SELECT id, name FROM roles ORDER BY name"
+
+    GET_ROLE_BY_ID_QUERY: str = "SELECT id, name FROM roles WHERE id = ?"
+
+    ROLE_NAME_EXISTS_QUERY: str = "SELECT id FROM roles WHERE name = ?"
+
+    INSERT_ROLE_QUERY: str = "INSERT INTO roles (name) VALUES (?)"
+
+    UPDATE_ROLE_NAME_QUERY: str = "UPDATE roles SET name = ? WHERE id = ?"
+
+    DELETE_ROLE_QUERY: str = "DELETE FROM roles WHERE id = ?"
+
+    GET_ROLE_PERMISSIONS_QUERY: str = (
+        "SELECT area, can_read, can_add_modify, can_delete "
+        "FROM role_permissions WHERE role_id = ? ORDER BY area")
+
+    DELETE_ROLE_PERMISSIONS_QUERY: str = (
+        "DELETE FROM role_permissions WHERE role_id = ?")
+
+    INSERT_ROLE_PERMISSION_QUERY: str = (
+        "INSERT INTO role_permissions "
+        "(role_id, area, can_read, can_add_modify, can_delete) "
+        "VALUES (?, ?, ?, ?, ?)")
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: IdentityConfiguration) -> None:
+        """Initialise a RoleRepository instance.
+
+        Args:
+            logger: Parent logger used for repository and database logging.
+            config: Identity service configuration containing database
+                connection settings.
+        """
+        self._logger: logging.Logger = logger.getChild(__name__)
+        self._config: IdentityConfiguration = config
+
+        self._db: SqliteInterface = SqliteInterface(
+            self._logger,
+            self._config.backend_db_filename)
+
+    async def get_all_roles(self) -> list:
+        """Retrieve all roles ordered by name.
+
+        Returns:
+            A list of ``(id, name)`` tuples. Empty list if no roles exist.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        rows = await self._db.run_query(self.GET_ALL_ROLES_QUERY, ())
+        return rows if rows else []
+
+    async def get_role_by_id(self, role_id: int) -> Optional[tuple[int, str]]:
+        """Retrieve a single role's ``(id, name)`` by its primary key.
+
+        Args:
+            role_id: The role's primary key.
+
+        Returns:
+            A ``(id, name)`` tuple if found, otherwise ``None``.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        return await self._db.run_query(self.GET_ROLE_BY_ID_QUERY,
+                                        (role_id,), fetch_one=True)
+
+    async def role_name_exists(self, name: str) -> bool:
+        """Return True if a role with this exact name already exists.
+
+        Args:
+            name: Role name to check.
+
+        Returns:
+            True if a row in ``roles`` has this name.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        row = await self._db.run_query(self.ROLE_NAME_EXISTS_QUERY,
+                                       (name,), fetch_one=True)
+        return row is not None
+
+    async def get_role_permissions(self, role_id: int) -> list:
+        """Retrieve a role's per-area permission grid.
+
+        Args:
+            role_id: The role's primary key.
+
+        Returns:
+            A list of ``(area, can_read, can_add_modify, can_delete)``
+            tuples, one per area the role has any row for. An area with no
+            row has no access, same as an explicit all-false row - the
+            caller does not need to distinguish the two.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        rows = await self._db.run_query(self.GET_ROLE_PERMISSIONS_QUERY,
+                                        (role_id,))
+        return rows if rows else []
+
+    async def create_role(self, name: str,
+                          permissions: list[tuple]) -> int:
+        """Insert a new role and its permission grid.
+
+        Args:
+            name: The role's name (must be unique - check via
+                :meth:`role_name_exists` first; this method does not
+                re-check).
+            permissions: List of ``(area, can_read, can_add_modify,
+                can_delete)`` tuples to insert for the new role. May be
+                empty (a role with no granted areas).
+
+        Returns:
+            The internal ``id`` of the newly inserted role.
+
+        Raises:
+            SqliteInterfaceException: If either insert fails.
+        """
+        role_id = await self._db.insert_query(self.INSERT_ROLE_QUERY, (name,))
+        await self._replace_permissions(role_id, permissions)
+        return role_id
+
+    async def update_role(self,
+                          role_id: int,
+                          name: Optional[str],
+                          permissions: Optional[list[tuple]]) -> None:
+        """Update a role's name and/or replace its permission grid.
+
+        Patch-style: ``name`` is only changed if not ``None``.
+        ``permissions``, when not ``None``, *replaces* the role's entire
+        grid - see the class docstring for why there is no partial/upsert
+        path.
+
+        Args:
+            role_id: The role's primary key.
+            name: New name, or ``None`` to leave unchanged.
+            permissions: New complete grid, or ``None`` to leave the
+                existing grid unchanged.
+
+        Raises:
+            SqliteInterfaceException: If any update/insert fails.
+        """
+        if name is not None:
+            await self._db.run_query(self.UPDATE_ROLE_NAME_QUERY,
+                                     (name, role_id), commit=True)
+
+        if permissions is not None:
+            await self._replace_permissions(role_id, permissions)
+
+    async def delete_role(self, role_id: int) -> None:
+        """Delete a role.
+
+        Its `role_permissions` rows cascade-delete at the database level
+        (``ON DELETE CASCADE``). Any `project_members` rows pointing at
+        this role have their `role_id` cleared to ``NULL`` rather than
+        being deleted (``ON DELETE SET NULL``) - those memberships remain,
+        just with no role assigned (a valid state, see §4.3 of
+        user_roles_design.md).
+
+        Args:
+            role_id: The role's primary key.
+
+        Raises:
+            SqliteInterfaceException: If the delete fails.
+        """
+        await self._db.delete_query(self.DELETE_ROLE_QUERY, (role_id,))
+
+    async def _replace_permissions(self, role_id: int,
+                                   permissions: list[tuple]) -> None:
+        """Delete a role's existing grid and insert a new one.
+
+        Args:
+            role_id: The role's primary key.
+            permissions: List of ``(area, can_read, can_add_modify,
+                can_delete)`` tuples. May be empty.
+
+        Raises:
+            SqliteInterfaceException: If the delete or insert fails.
+        """
+        await self._db.delete_query(self.DELETE_ROLE_PERMISSIONS_QUERY,
+                                    (role_id,))
+        if permissions:
+            await self._db.bulk_insert_query(
+                self.INSERT_ROLE_PERMISSION_QUERY,
+                [(role_id, area, can_read, can_add_modify, can_delete)
+                 for area, can_read, can_add_modify, can_delete
+                 in permissions])

--- a/items/services/items_identity/routes/__init__.py
+++ b/items/services/items_identity/routes/__init__.py
@@ -20,6 +20,7 @@ from items.services.items_identity.identity_configuration import (
     IdentityConfiguration)
 from .auth import create_auth_routes
 from .invites import create_invite_routes
+from .roles import create_roles_routes
 from .system import create_system_routes
 from .users import create_users_routes
 
@@ -39,6 +40,7 @@ def create_routes(logger: logging.Logger,
 
     * Authentication routes
     * Invite management routes
+    * Role management routes
     * System and health monitoring routes
     * User routes
 
@@ -62,6 +64,8 @@ def create_routes(logger: logging.Logger,
 
     routes_bp.register_blueprint(create_auth_routes(logger, state, configuration))
     routes_bp.register_blueprint(create_invite_routes(logger, configuration))
+    routes_bp.register_blueprint(create_roles_routes(logger, state,
+                                                     configuration))
     routes_bp.register_blueprint(create_system_routes(logger, state))
     routes_bp.register_blueprint(create_users_routes(logger, state,
                                                     configuration))

--- a/items/services/items_identity/routes/roles/__init__.py
+++ b/items/services/items_identity/routes/roles/__init__.py
@@ -1,0 +1,102 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import quart
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.shared.service_state import ServiceState
+from .list_roles_handler import ListRolesHandler
+from .get_role_handler import GetRoleHandler
+from .create_role_handler import CreateRoleHandler
+from .modify_role_handler import ModifyRoleHandler
+from .delete_role_handler import DeleteRoleHandler
+
+
+def create_roles_routes(logger: logging.Logger,
+                        service_state: ServiceState,
+                        config: IdentityConfiguration) -> quart.Blueprint:
+    """
+    Create and configure role-related routes.
+
+    Registered routes:
+
+    * ``GET    /roles``           - List all roles (name only).
+    * ``POST   /roles``           - Create a new role.
+    * ``GET    /roles/<role_id>`` - Retrieve a single role's full grid.
+    * ``PATCH  /roles/<role_id>`` - Update a role's name and/or grid.
+    * ``DELETE /roles/<role_id>`` - Delete a role.
+
+    This is role *definitions* only - assigning a role to a project
+    membership is a separate concern, not covered by these routes.
+
+    Args:
+        logger:
+            Logger used for route registration and request handling.
+
+        service_state:
+            Shared service state used by handlers to determine service
+            availability and operational status.
+
+        config:
+            Identity service configuration used to initialize components.
+
+    Returns:
+        A configured Quart blueprint containing all registered role routes.
+    """
+    roles_routes = quart.Blueprint("roles_routes", __name__)
+
+    handler_list = ListRolesHandler(logger, service_state, config)
+    handler_get = GetRoleHandler(logger, service_state, config)
+    handler_create = CreateRoleHandler(logger, service_state, config)
+    handler_modify = ModifyRoleHandler(logger, service_state, config)
+    handler_delete = DeleteRoleHandler(logger, service_state, config)
+
+    logger.debug("Registering Roles API routes:")
+
+    logger.debug("=> %s GET  /roles",
+                 'List roles'.ljust(40))
+    logger.debug("=> %s POST /roles",
+                 'Create role'.ljust(40))
+    logger.debug("=> %s GET  /roles/<role_id>",
+                 'Get role'.ljust(40))
+    logger.debug("=> %s PATCH /roles/<role_id>",
+                 'Modify role'.ljust(40))
+    logger.debug("=> %s DELETE /roles/<role_id>",
+                 'Delete role'.ljust(40))
+
+    # pylint: disable=no-value-for-parameter
+
+    @roles_routes.route('/roles', methods=['GET'])
+    async def list_roles_request():
+        return await handler_list.list_roles()
+
+    @roles_routes.route('/roles', methods=['POST'])
+    async def create_role_request():
+        return await handler_create.create_role()
+
+    @roles_routes.route('/roles/<int:role_id>', methods=['GET'])
+    async def get_role_request(role_id: int):
+        return await handler_get.get_role(role_id)
+
+    @roles_routes.route('/roles/<int:role_id>', methods=['PATCH'])
+    async def modify_role_request(role_id: int):
+        return await handler_modify.modify_role(role_id=role_id)
+
+    @roles_routes.route('/roles/<int:role_id>', methods=['DELETE'])
+    async def delete_role_request(role_id: int):
+        return await handler_delete.delete_role(role_id)
+
+    return roles_routes

--- a/items/services/items_identity/routes/roles/create_role_handler.py
+++ b/items/services/items_identity/routes/roles/create_role_handler.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.routes.roles.schemas import (
+    SCHEMA_CREATE_ROLE_REQUEST)
+from items.services.items_identity.services.role_management_service import (
+    RoleManagementService)
+from items.shared.service_state import ServiceState
+
+
+class CreateRoleHandler(BaseApiRoute):
+    """Handles POST /roles — create a new role."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        repo = RoleRepository(self._logger, configuration)
+        self._service = RoleManagementService(
+            self._logger, self._service_state, repo)
+
+    @validate_json(SCHEMA_CREATE_ROLE_REQUEST)
+    async def create_role(self, request_msg: ApiResponse) -> Response:
+        """Create a new role.
+
+        Args:
+            request_msg: Validated request containing ``name`` and
+                optionally ``permissions`` (defaults to an empty grid - a
+                role granting nothing yet).
+
+        Returns:
+            201 with ``{"id": <new_role_id>}`` on success.
+            400 if the supplied grid violates Add/Modify-implies-Read, or
+            repeats the same area more than once.
+            409 if the role name is already in use.
+            503 if the service is unavailable.
+        """
+        body = request_msg.body
+        result = await self._service.create_role(
+            name=body["name"],
+            permissions=body.get("permissions", []))
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if result.invalid:
+            return Response(
+                json.dumps({"error": "Invalid permission grid - "
+                           "Add/Modify requires Read, and each area may "
+                           "appear at most once"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        if result.conflict:
+            return Response(
+                json.dumps({"error": "Role name already in use"}),
+                status=HTTPStatus.CONFLICT,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"id": result.role_id}),
+            status=HTTPStatus.CREATED,
+            content_type="application/json")

--- a/items/services/items_identity/routes/roles/delete_role_handler.py
+++ b/items/services/items_identity/routes/roles/delete_role_handler.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.role_management_service import (
+    RoleManagementService)
+from items.shared.service_state import ServiceState
+
+
+class DeleteRoleHandler(BaseApiRoute):
+    """Handles DELETE /roles/<role_id> — delete a role."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        repo = RoleRepository(self._logger, configuration)
+        self._service = RoleManagementService(
+            self._logger, self._service_state, repo)
+
+    async def delete_role(self, role_id: int) -> Response:
+        """Delete a role.
+
+        Any project membership holding this role has its role assignment
+        cleared, not deleted - the membership itself remains (§4.3 of
+        user_roles_design.md).
+
+        Args:
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 on success.
+            404 if no role exists with that id.
+            503 if the service is unavailable.
+        """
+        result = await self._service.delete_role(role_id)
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "Role not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/roles/get_role_handler.py
+++ b/items/services/items_identity/routes/roles/get_role_handler.py
@@ -1,0 +1,72 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.role_management_service import (
+    RoleManagementService)
+from items.shared.service_state import ServiceState
+
+
+class GetRoleHandler(BaseApiRoute):
+    """Handles GET /roles/<role_id> — return a single role's full grid."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        repo = RoleRepository(self._logger, configuration)
+        self._service = RoleManagementService(
+            self._logger, self._service_state, repo)
+
+    async def get_role(self, role_id: int) -> Response:
+        """Return a single role, including its full permission grid.
+
+        Args:
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 with ``{"id", "name", "permissions"}`` on success.
+            404 if no role exists with that id.
+            503 if the service is unavailable.
+        """
+        result = await self._service.get_role(role_id)
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "Role not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps(result.role),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/roles/list_roles_handler.py
+++ b/items/services/items_identity/routes/roles/list_roles_handler.py
@@ -1,0 +1,64 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.role_management_service import (
+    RoleManagementService)
+from items.shared.service_state import ServiceState
+
+
+class ListRolesHandler(BaseApiRoute):
+    """Handles GET /roles — return all roles (name only, not their grids)."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        repo = RoleRepository(self._logger, configuration)
+        self._service = RoleManagementService(
+            self._logger, self._service_state, repo)
+
+    async def list_roles(self) -> Response:
+        """Return all roles as a JSON array.
+
+        Returns:
+            200 with ``{"roles": [...]}`` on success. Each entry is
+            ``{"id": ..., "name": ...}`` - use ``GET /roles/<id>`` for a
+            role's full permission grid.
+            503 if the service is unavailable.
+        """
+        result = await self._service.get_all_roles()
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"roles": result.roles}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/roles/modify_role_handler.py
+++ b/items/services/items_identity/routes/roles/modify_role_handler.py
@@ -1,0 +1,104 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.routes.roles.schemas import (
+    SCHEMA_MODIFY_ROLE_REQUEST)
+from items.services.items_identity.services.role_management_service import (
+    RoleManagementService)
+from items.shared.service_state import ServiceState
+
+
+class ModifyRoleHandler(BaseApiRoute):
+    """Handles PATCH /roles/<role_id> — update a role's name and/or grid."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        repo = RoleRepository(self._logger, configuration)
+        self._service = RoleManagementService(
+            self._logger, self._service_state, repo)
+
+    @validate_json(SCHEMA_MODIFY_ROLE_REQUEST)
+    async def modify_role(self, request_msg: ApiResponse,
+                          role_id: int) -> Response:
+        """Update a role's name and/or replace its permission grid.
+
+        Args:
+            request_msg: Validated request. All fields are optional:
+                ``name``, ``permissions``. Omitted fields retain their
+                current values. ``permissions``, when present, *replaces*
+                the entire grid - see ``RoleRepository`` for why there is
+                no partial update.
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 on success.
+            400 if the supplied grid violates Add/Modify-implies-Read, or
+            repeats the same area more than once.
+            404 if no role exists with that id.
+            409 if renaming to a name already in use by another role.
+            503 if the service is unavailable.
+        """
+        body = request_msg.body
+        result = await self._service.update_role(
+            role_id=role_id,
+            name=body.get("name"),
+            permissions=body.get("permissions"))
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if result.invalid:
+            return Response(
+                json.dumps({"error": "Invalid permission grid - "
+                           "Add/Modify requires Read, and each area may "
+                           "appear at most once"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "Role not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        if result.conflict:
+            return Response(
+                json.dumps({"error": "Role name already in use"}),
+                status=HTTPStatus.CONFLICT,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/roles/schemas.py
+++ b/items/services/items_identity/routes/roles/schemas.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from items.shared.permission_area import PermissionArea
+
+_AREA_VALUES: list[str] = [area.value for area in PermissionArea]
+
+_PERMISSION_ITEM_SCHEMA: dict = {
+    "type": "object",
+    "additionalProperties": False,
+
+    "properties":
+    {
+        "area":
+        {
+            "type": "string",
+            "enum": _AREA_VALUES
+        },
+        "can_read":
+        {
+            "type": "boolean"
+        },
+        "can_add_modify":
+        {
+            "type": "boolean"
+        },
+        "can_delete":
+        {
+            "type": "boolean"
+        }
+    },
+    "required": ["area", "can_read", "can_add_modify", "can_delete"]
+}
+
+SCHEMA_CREATE_ROLE_REQUEST: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+    "type": "object",
+    "additionalProperties": False,
+
+    "properties":
+    {
+        "name":
+        {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+        },
+        "permissions":
+        {
+            "type": "array",
+            "items": _PERMISSION_ITEM_SCHEMA
+        }
+    },
+    "required": ["name"]
+}
+
+SCHEMA_MODIFY_ROLE_REQUEST: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+    "type": "object",
+    "additionalProperties": False,
+    "minProperties": 1,
+
+    "properties":
+    {
+        "name":
+        {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 100
+        },
+        "permissions":
+        {
+            "type": "array",
+            "items": _PERMISSION_ITEM_SCHEMA
+        }
+    },
+    "required": []
+}

--- a/items/services/items_identity/services/role_management_service.py
+++ b/items/services/items_identity/services/role_management_service.py
@@ -1,0 +1,352 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from dataclasses import dataclass, field
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.shared.service_state import ServiceState
+
+
+def _permission_row_to_dict(row: tuple) -> dict:
+    """Convert a ``role_permissions`` row tuple to a permission dict.
+
+    Args:
+        row: ``(area, can_read, can_add_modify, can_delete)``
+
+    Returns:
+        A dict with the same fields, the three flags converted to bool.
+    """
+    area, can_read, can_add_modify, can_delete = row
+    return {
+        "area": area,
+        "can_read": bool(can_read),
+        "can_add_modify": bool(can_add_modify),
+        "can_delete": bool(can_delete),
+    }
+
+
+def _permissions_to_rows(permissions: list[dict]) -> list[tuple]:
+    """Convert permission dicts (as received from a request body) to the
+    ``(area, can_read, can_add_modify, can_delete)`` tuple shape the
+    repository expects.
+
+    Args:
+        permissions: List of permission dicts, each with ``area``,
+            ``can_read``, ``can_add_modify``, ``can_delete``.
+
+    Returns:
+        The equivalent list of tuples.
+    """
+    return [(p["area"], p["can_read"], p["can_add_modify"], p["can_delete"])
+            for p in permissions]
+
+
+def _permissions_are_valid(permissions: list[dict]) -> bool:
+    """Validate a permission grid against invariants the JSON schema can't
+    express on its own.
+
+    Args:
+        permissions: List of permission dicts to validate.
+
+    Returns:
+        False if any entry grants Add/Modify without Read (§4.1 of
+        user_roles_design.md), or if the same area appears more than once
+        (would otherwise violate the ``(role_id, area)`` primary key at
+        the database layer with a raw, unhelpful error). True otherwise.
+    """
+    seen_areas = set()
+    for entry in permissions:
+        if entry["can_add_modify"] and not entry["can_read"]:
+            return False
+        if entry["area"] in seen_areas:
+            return False
+        seen_areas.add(entry["area"])
+    return True
+
+
+@dataclass
+class RoleListResult:
+    """Outcome of a list-all-roles request.
+
+    Attributes:
+        available: False when the service is unavailable.
+        roles:     List of ``{"id": ..., "name": ...}`` dicts.
+    """
+    available: bool = True
+    roles: list = field(default_factory=list)
+
+
+@dataclass
+class RoleLookupResult:
+    """Outcome of a single-role lookup.
+
+    Attributes:
+        available: False when the service is unavailable.
+        found:     False when no role exists with the requested id.
+        role:      ``{"id", "name", "permissions"}`` dict on success -
+                   ``permissions`` is the full per-area grid.
+    """
+    available: bool = True
+    found: bool = True
+    role: Optional[dict] = field(default=None)
+
+
+@dataclass
+class RoleCreateResult:
+    """Outcome of a create-role request.
+
+    Attributes:
+        available: False when the service is unavailable.
+        conflict:  True when the role name is already in use.
+        invalid:   True when the supplied grid violates the
+                   Add/Modify-implies-Read invariant, or repeats an area.
+        role_id:   The newly created role's id on success.
+    """
+    available: bool = True
+    conflict: bool = False
+    invalid: bool = False
+    role_id: Optional[int] = field(default=None)
+
+
+@dataclass
+class RoleUpdateResult:
+    """Outcome of an update-role request.
+
+    Attributes:
+        available: False when the service is unavailable.
+        found:     False when no role exists with the requested id.
+        conflict:  True when renaming to a name already in use.
+        invalid:   True when the supplied grid violates the
+                   Add/Modify-implies-Read invariant, or repeats an area.
+        success:   True when the update was applied.
+    """
+    available: bool = True
+    found: bool = True
+    conflict: bool = False
+    invalid: bool = False
+    success: bool = False
+
+
+@dataclass
+class RoleDeleteResult:
+    """Outcome of a delete-role request.
+
+    Attributes:
+        available: False when the service is unavailable.
+        found:     False when no role exists with the requested id.
+        success:   True when the role was deleted.
+    """
+    available: bool = True
+    found: bool = True
+    success: bool = False
+
+
+class RoleManagementService:
+    """Create, modify, and delete named roles and their permission grids.
+
+    A role is a name plus a per-area Read/Add-Modify/Delete grid
+    (§4/§7 of user_roles_design.md). Assigning a role to a project
+    membership is a separate concern, handled elsewhere - this service
+    only manages role *definitions*.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 state: ServiceState,
+                 role_repository: RoleRepository) -> None:
+        """Initialise the role management service.
+
+        Args:
+            logger:          Parent logger.
+            state:           Shared service state.
+            role_repository: Repository providing role data access.
+        """
+        self._logger = logger.getChild(__name__)
+        self._state: ServiceState = state
+        self._repo: RoleRepository = role_repository
+
+    async def get_all_roles(self) -> RoleListResult:
+        """Return all roles (name only - not their grids).
+
+        Returns:
+            A :class:`RoleListResult`. Database failures are reported as
+            unavailable.
+        """
+        if not self._state.is_available():
+            return RoleListResult(available=False)
+
+        try:
+            rows = await self._repo.get_all_roles()
+        except SqliteInterfaceException as ex:
+            self._logger.exception("Database failure listing roles: %s", ex)
+            self._state.set_service_degraded("Role list database unavailable")
+            return RoleListResult(available=False)
+
+        return RoleListResult(
+            roles=[{"id": role_id, "name": name} for role_id, name in rows])
+
+    async def get_role(self, role_id: int) -> RoleLookupResult:
+        """Return a single role, including its full permission grid.
+
+        Args:
+            role_id: The role's id.
+
+        Returns:
+            A :class:`RoleLookupResult`.
+        """
+        if not self._state.is_available():
+            return RoleLookupResult(available=False)
+
+        try:
+            row = await self._repo.get_role_by_id(role_id)
+            if row is None:
+                return RoleLookupResult(found=False)
+
+            permission_rows = await self._repo.get_role_permissions(role_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure fetching role %d: %s", role_id, ex)
+            self._state.set_service_degraded("Role lookup database unavailable")
+            return RoleLookupResult(available=False)
+
+        found_id, name = row
+        return RoleLookupResult(role={
+            "id": found_id,
+            "name": name,
+            "permissions": [_permission_row_to_dict(r)
+                           for r in permission_rows],
+        })
+
+    async def create_role(self, name: str,
+                          permissions: list[dict]) -> RoleCreateResult:
+        """Create a new role with the supplied permission grid.
+
+        Args:
+            name: The role's name (must be unique).
+            permissions: The role's initial grid - a list of permission
+                dicts. May be empty (a role granting nothing yet).
+
+        Returns:
+            A :class:`RoleCreateResult`. ``conflict`` is True if the name
+            is already in use. ``invalid`` is True if the grid violates
+            Add/Modify-implies-Read or repeats an area.
+        """
+        if not self._state.is_available():
+            return RoleCreateResult(available=False)
+
+        if not _permissions_are_valid(permissions):
+            return RoleCreateResult(invalid=True)
+
+        try:
+            if await self._repo.role_name_exists(name):
+                return RoleCreateResult(conflict=True)
+
+            role_id = await self._repo.create_role(
+                name, _permissions_to_rows(permissions))
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure creating role %s: %s", name, ex)
+            self._state.set_service_degraded(
+                "Role creation database unavailable")
+            return RoleCreateResult(available=False)
+
+        return RoleCreateResult(role_id=role_id)
+
+    async def update_role(self,
+                          role_id: int,
+                          name: Optional[str] = None,
+                          permissions: Optional[list[dict]] = None
+                          ) -> RoleUpdateResult:
+        """Update a role's name and/or replace its permission grid.
+
+        Patch-style: only the fields supplied are changed. ``permissions``,
+        when supplied, *replaces* the entire grid - see
+        :class:`RoleRepository`'s docstring for why there is no partial
+        update.
+
+        Args:
+            role_id: The role's id.
+            name: New name, or ``None`` to leave unchanged.
+            permissions: New complete grid, or ``None`` to leave the
+                existing grid unchanged.
+
+        Returns:
+            A :class:`RoleUpdateResult`.
+        """
+        if not self._state.is_available():
+            return RoleUpdateResult(available=False)
+
+        if permissions is not None and not _permissions_are_valid(permissions):
+            return RoleUpdateResult(invalid=True)
+
+        try:
+            row = await self._repo.get_role_by_id(role_id)
+            if row is None:
+                return RoleUpdateResult(found=False)
+
+            if name is not None and await self._repo.role_name_exists(name):
+                _, current_name = row
+                if name != current_name:
+                    return RoleUpdateResult(conflict=True)
+
+            permission_rows = (
+                _permissions_to_rows(permissions)
+                if permissions is not None else None)
+            await self._repo.update_role(role_id, name, permission_rows)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure updating role %d: %s", role_id, ex)
+            self._state.set_service_degraded(
+                "Role update database unavailable")
+            return RoleUpdateResult(available=False)
+
+        return RoleUpdateResult(success=True)
+
+    async def delete_role(self, role_id: int) -> RoleDeleteResult:
+        """Delete a role.
+
+        Any project membership holding this role has its role assignment
+        cleared (not deleted) - see :meth:`RoleRepository.delete_role`.
+
+        Args:
+            role_id: The role's id.
+
+        Returns:
+            A :class:`RoleDeleteResult`.
+        """
+        if not self._state.is_available():
+            return RoleDeleteResult(available=False)
+
+        try:
+            row = await self._repo.get_role_by_id(role_id)
+            if row is None:
+                return RoleDeleteResult(found=False)
+
+            await self._repo.delete_role(role_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure deleting role %d: %s", role_id, ex)
+            self._state.set_service_degraded(
+                "Role deletion database unavailable")
+            return RoleDeleteResult(available=False)
+
+        return RoleDeleteResult(success=True)

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 4"
+PRE_RELEASE = "Alpha Build 5"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/items/shared/permission_area.py
+++ b/items/shared/permission_area.py
@@ -1,0 +1,39 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from enum import Enum
+
+
+class PermissionArea(Enum):
+    """The fixed set of areas a role's grid can grant access to.
+
+    Matches §4 of user_roles_design.md. Only ``TEST_CASES`` has backing
+    tables today (§11 of the same document) - the rest exist in the grid
+    so it looks complete now rather than growing columns later, but
+    granting them currently has no enforceable effect anywhere.
+
+    Values match the ``area`` column in ``role_permissions`` (a text key,
+    not a fixed schema column - see §7.1's "areas are rows, not columns"
+    rationale for why the table itself doesn't constrain this list; this
+    enum is where that constraint actually lives, at the application
+    layer).
+    """
+
+    TEST_CASES = "test_cases"
+    MILESTONES = "milestones"
+    TEST_RUNS = "test_runs"
+    TEST_PLANS = "test_plans"
+    TEST_REPORTS = "test_reports"
+    TEST_RESULTS = "test_results"

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -1,6 +1,6 @@
 {
   "info": {
-    "_postman_id": "9c53508b-17ba-44e7-bad7-12a1337904b4",
+    "_postman_id": "62cabf3b-20e5-4466-95cb-32be1b26c5c6",
     "name": "ITEMS",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "10935426"
@@ -963,6 +963,117 @@
                     "users",
                     "{{USER_UUID}}",
                     "password"
+                  ]
+                }
+              },
+              "response": []
+            }
+          ]
+        },
+        {
+          "name": "Roles",
+          "item": [
+            {
+              "name": "List Roles",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/roles",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "roles"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Get Role",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/roles/{{ROLE_ID}}",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "roles",
+                    "{{ROLE_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Create Role",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Tester\",\n    \"permissions\": [\n        {\n            \"area\": \"test_cases\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        },\n        {\n            \"area\": \"milestones\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        },\n        {\n            \"area\": \"test_runs\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        },\n        {\n            \"area\": \"test_plans\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        },\n        {\n            \"area\": \"test_reports\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        },\n        {\n            \"area\": \"test_results\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/roles",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "roles"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Update Role",
+              "request": {
+                "method": "PATCH",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"name\": \"Senior Tester\",\n    \"permissions\": [\n        {\n            \"area\": \"test_cases\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        }\n    ]\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/roles/{{ROLE_ID}}",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "roles",
+                    "{{ROLE_ID}}"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Delete Role",
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/roles/{{ROLE_ID}}",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "roles",
+                    "{{ROLE_ID}}"
                   ]
                 }
               },

--- a/unit_tests/items_identity/main.py
+++ b/unit_tests/items_identity/main.py
@@ -3,12 +3,14 @@ from test_service import TestService
 from test_threadsafe_configuration import TestIdentityConfiguration
 from test_da_user_data_access_layer import TestUserRepository
 from test_da_invite_data_access_layer import TestInviteRepository
+from test_da_role_data_access_layer import TestRoleRepository
 from test_apis_authentication_api import TestAuthenticatePasswordHandler
 from test_apis_health_api import TestHealthHandler
 from test_services_authentication_service import TestAuthenticationService
 from test_services_user_profile_service import TestUserProfileService
 from test_services_user_management_service import TestUserManagementService
 from test_services_invite_management_service import TestInviteManagementService
+from test_services_role_management_service import TestRoleManagementService
 from test_apis_user_profile_api import TestGetUserProfileHandler
 from test_apis_user_management import (
     TestListUsersHandler,
@@ -17,6 +19,13 @@ from test_apis_user_management import (
     TestModifyUserHandler,
     TestResetPasswordHandler,
     TestChangePasswordHandler,
+)
+from test_apis_role_management import (
+    TestListRolesHandler,
+    TestGetRoleHandler,
+    TestCreateRoleHandler,
+    TestModifyRoleHandler,
+    TestDeleteRoleHandler,
 )
 from test_apis_invite_management import (
     TestGetInvitesHandler,
@@ -29,8 +38,8 @@ from test_invite_token_lookup import (
     TestGetInviteByTokenHandler,
 )
 from test_create_routes import (TestCreateAuthRoutes, TestCreateSystemRoutes,
-                                TestCreateInviteRoutes, TestCreateUsersRoutes,
-                                TestCreateRoutes)
+                                TestCreateInviteRoutes, TestCreateRolesRoutes,
+                                TestCreateUsersRoutes, TestCreateRoutes)
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/items_identity/test_apis_role_management.py
+++ b/unit_tests/items_identity/test_apis_role_management.py
@@ -1,0 +1,325 @@
+"""
+Handler-level tests for the role management API endpoints:
+  GET    /roles           - ListRolesHandler
+  GET    /roles/<role_id>  - GetRoleHandler
+  POST   /roles           - CreateRoleHandler
+  PATCH  /roles/<role_id>  - ModifyRoleHandler
+  DELETE /roles/<role_id>  - DeleteRoleHandler
+"""
+import unittest
+import json
+import logging
+from http import HTTPStatus
+from unittest.mock import patch, MagicMock, AsyncMock
+from quart import Response
+from routes.roles.list_roles_handler import ListRolesHandler
+from routes.roles.get_role_handler import GetRoleHandler
+from routes.roles.create_role_handler import CreateRoleHandler
+from routes.roles.modify_role_handler import ModifyRoleHandler
+from routes.roles.delete_role_handler import DeleteRoleHandler
+from services.role_management_service import (
+    RoleListResult,
+    RoleLookupResult,
+    RoleCreateResult,
+    RoleUpdateResult,
+    RoleDeleteResult,
+)
+
+_ROLE_DICT = {"id": 1, "name": "Tester"}
+_ROLE_WITH_GRID = {
+    "id": 1,
+    "name": "Tester",
+    "permissions": [
+        {"area": "test_cases", "can_read": True, "can_add_modify": True,
+         "can_delete": False},
+    ],
+}
+
+
+def _undecorated(method):
+    """Return the original function if it's wrapped by a decorator."""
+    return getattr(method, "__wrapped__", method)
+
+
+def _make_handler_setup(handler_cls):
+    """Return an asyncSetUp that wires up a handler with mocked service."""
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_logger.getChild.return_value = MagicMock(spec=logging.Logger)
+        self.mock_state = MagicMock()
+        self.mock_config = MagicMock()
+
+        module_name = handler_cls.__module__.split('.')[-1]
+        repo_patch = patch(
+            f"routes.roles.{module_name}.RoleRepository", autospec=True)
+        svc_patch = patch(
+            f"routes.roles.{module_name}.RoleManagementService", autospec=True)
+        self.addCleanup(repo_patch.stop)
+        self.addCleanup(svc_patch.stop)
+        repo_patch.start()
+        self.mock_svc_cls = svc_patch.start()
+
+        self.mock_svc = MagicMock()
+        self.mock_svc_cls.return_value = self.mock_svc
+
+        self.handler = handler_cls(
+            self.mock_logger, self.mock_state, self.mock_config)
+
+    return asyncSetUp
+
+
+# ---------------------------------------------------------------------------
+# ListRolesHandler
+# ---------------------------------------------------------------------------
+
+class TestListRolesHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(ListRolesHandler)
+
+    async def _call(self, result: RoleListResult) -> Response:
+        self.mock_svc.get_all_roles = AsyncMock(return_value=result)
+        return await self.handler.list_roles()
+
+    async def test_success_returns_200_with_roles(self):
+        resp = await self._call(RoleListResult(roles=[_ROLE_DICT]))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["roles"], [_ROLE_DICT])
+
+    async def test_empty_list_returns_200(self):
+        resp = await self._call(RoleListResult(roles=[]))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["roles"], [])
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(RoleListResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_response_is_json(self):
+        resp = await self._call(RoleListResult(roles=[]))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# GetRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestGetRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(GetRoleHandler)
+
+    async def _call(self, result: RoleLookupResult, role_id: int = 1) -> Response:
+        self.mock_svc.get_role = AsyncMock(return_value=result)
+        return await self.handler.get_role(role_id)
+
+    async def test_success_returns_200_with_role(self):
+        resp = await self._call(RoleLookupResult(role=_ROLE_WITH_GRID))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body, _ROLE_WITH_GRID)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(RoleLookupResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(RoleLookupResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_unavailable_takes_precedence_over_not_found(self):
+        resp = await self._call(RoleLookupResult(available=False, found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_role_id_passed_to_service(self):
+        self.mock_svc.get_role = AsyncMock(
+            return_value=RoleLookupResult(role=_ROLE_WITH_GRID))
+        await self.handler.get_role(42)
+        self.mock_svc.get_role.assert_awaited_once_with(42)
+
+    async def test_response_is_json(self):
+        resp = await self._call(RoleLookupResult(role=_ROLE_WITH_GRID))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# CreateRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestCreateRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(CreateRoleHandler)
+
+    def _request(self, **overrides):
+        body = {"name": "Tester"}
+        body.update(overrides)
+        mock_req = MagicMock()
+        mock_req.body = body
+        return mock_req
+
+    async def _call(self, result: RoleCreateResult, **body_overrides) -> Response:
+        self.mock_svc.create_role = AsyncMock(return_value=result)
+        target = _undecorated(self.handler.create_role)
+        return await target(self.handler, self._request(**body_overrides))
+
+    async def test_success_returns_201_with_id(self):
+        resp = await self._call(RoleCreateResult(role_id=7))
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["id"], 7)
+
+    async def test_conflict_returns_409(self):
+        resp = await self._call(RoleCreateResult(conflict=True))
+        self.assertEqual(resp.status_code, HTTPStatus.CONFLICT)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_invalid_returns_400(self):
+        resp = await self._call(RoleCreateResult(invalid=True))
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(RoleCreateResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_permissions_defaults_to_empty_list_when_absent(self):
+        await self._call(RoleCreateResult(role_id=1))
+        kwargs = self.mock_svc.create_role.call_args[1]
+        self.assertEqual(kwargs["permissions"], [])
+
+    async def test_permissions_passed_when_provided(self):
+        perms = [{"area": "test_cases", "can_read": True,
+                  "can_add_modify": False, "can_delete": False}]
+        await self._call(RoleCreateResult(role_id=1), permissions=perms)
+        kwargs = self.mock_svc.create_role.call_args[1]
+        self.assertEqual(kwargs["permissions"], perms)
+
+    async def test_response_is_json(self):
+        resp = await self._call(RoleCreateResult(role_id=1))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# ModifyRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestModifyRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(ModifyRoleHandler)
+
+    def _request(self, **overrides):
+        mock_req = MagicMock()
+        mock_req.body = dict(overrides)
+        return mock_req
+
+    async def _call(self, result: RoleUpdateResult, role_id: int = 1,
+                    **body_overrides) -> Response:
+        self.mock_svc.update_role = AsyncMock(return_value=result)
+        target = _undecorated(self.handler.modify_role)
+        return await target(self.handler, self._request(**body_overrides),
+                            role_id=role_id)
+
+    async def test_success_returns_200(self):
+        resp = await self._call(RoleUpdateResult(success=True), name="New")
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(RoleUpdateResult(found=False), name="New")
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_conflict_returns_409(self):
+        resp = await self._call(RoleUpdateResult(conflict=True), name="Taken")
+        self.assertEqual(resp.status_code, HTTPStatus.CONFLICT)
+
+    async def test_invalid_returns_400(self):
+        resp = await self._call(RoleUpdateResult(invalid=True), permissions=[])
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(RoleUpdateResult(available=False), name="New")
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_invalid_takes_precedence_over_not_found(self):
+        resp = await self._call(
+            RoleUpdateResult(invalid=True, found=False), permissions=[])
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+
+    async def test_not_found_takes_precedence_over_conflict(self):
+        resp = await self._call(
+            RoleUpdateResult(found=False, conflict=True), name="New")
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_role_id_and_name_passed_to_service(self):
+        self.mock_svc.update_role = AsyncMock(
+            return_value=RoleUpdateResult(success=True))
+        target = _undecorated(self.handler.modify_role)
+        await target(self.handler, self._request(name="New"), role_id=9)
+        self.mock_svc.update_role.assert_awaited_once_with(
+            role_id=9, name="New", permissions=None)
+
+    async def test_name_defaults_to_none_when_absent(self):
+        await self._call(RoleUpdateResult(success=True), permissions=[])
+        kwargs = self.mock_svc.update_role.call_args[1]
+        self.assertIsNone(kwargs["name"])
+
+    async def test_permissions_defaults_to_none_when_absent(self):
+        await self._call(RoleUpdateResult(success=True), name="New")
+        kwargs = self.mock_svc.update_role.call_args[1]
+        self.assertIsNone(kwargs["permissions"])
+
+    async def test_response_is_json(self):
+        resp = await self._call(RoleUpdateResult(success=True), name="New")
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# DeleteRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestDeleteRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(DeleteRoleHandler)
+
+    async def _call(self, result: RoleDeleteResult, role_id: int = 1) -> Response:
+        self.mock_svc.delete_role = AsyncMock(return_value=result)
+        return await self.handler.delete_role(role_id)
+
+    async def test_success_returns_200(self):
+        resp = await self._call(RoleDeleteResult(success=True))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(RoleDeleteResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(RoleDeleteResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_unavailable_takes_precedence_over_not_found(self):
+        resp = await self._call(RoleDeleteResult(available=False, found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_role_id_passed_to_service(self):
+        self.mock_svc.delete_role = AsyncMock(
+            return_value=RoleDeleteResult(success=True))
+        await self.handler.delete_role(13)
+        self.mock_svc.delete_role.assert_awaited_once_with(13)
+
+    async def test_response_is_json(self):
+        resp = await self._call(RoleDeleteResult(success=True))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_identity/test_create_routes.py
+++ b/unit_tests/items_identity/test_create_routes.py
@@ -7,6 +7,7 @@ from quart import Response
 from routes import create_routes
 from routes.auth import create_auth_routes
 from routes.invites import create_invite_routes
+from routes.roles import create_roles_routes
 from routes.system import create_system_routes
 from routes.users import create_users_routes
 
@@ -332,6 +333,162 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
         mock_handler.change_password.assert_called_once()
 
 
+class TestCreateRolesRoutes(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_state = MagicMock()
+        self.mock_config = MagicMock()
+
+    def _ok_response(self, body=None, status=200):
+        return Response(
+            json.dumps(body or {"status": "ok"}),
+            status=status,
+            content_type="application/json")
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_returns_blueprint_with_correct_name(self, *_mocks):
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        self.assertIsInstance(bp, quart.Blueprint)
+        self.assertEqual(bp.name, "roles_routes")
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_initialises_all_handlers_with_correct_args(
+            self, mock_list, mock_get, mock_create, mock_modify, mock_delete):
+        create_roles_routes(self.mock_logger, self.mock_state, self.mock_config)
+        for mock_cls in (mock_list, mock_get, mock_create, mock_modify,
+                         mock_delete):
+            mock_cls.assert_called_once_with(
+                self.mock_logger, self.mock_state, self.mock_config)
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_logs_route_registration(self, *_mocks):
+        create_roles_routes(self.mock_logger, self.mock_state, self.mock_config)
+        self.mock_logger.debug.assert_called()
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_route_handler_calls_list_roles(
+            self, mock_list_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.list_roles = AsyncMock(
+            return_value=self._ok_response({"roles": []}))
+        mock_list_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.get("/roles")
+
+        mock_handler.list_roles.assert_called_once()
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_route_handler_calls_get_role(
+            self, _list, mock_get_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.get_role = AsyncMock(
+            return_value=self._ok_response({"id": 1, "name": "Tester"}))
+        mock_get_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.get("/roles/1")
+
+        mock_handler.get_role.assert_called_once()
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_route_handler_calls_create_role(
+            self, _list, _get, mock_create_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.create_role = AsyncMock(
+            return_value=self._ok_response({"id": 1}, status=201))
+        mock_create_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.post("/roles", json={"name": "Tester"})
+
+        mock_handler.create_role.assert_called_once()
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_route_handler_calls_modify_role(
+            self, _list, _get, _create, mock_modify_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.modify_role = AsyncMock(
+            return_value=self._ok_response())
+        mock_modify_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.patch("/roles/1", json={"name": "New Name"})
+
+        mock_handler.modify_role.assert_called_once()
+
+    @patch("routes.roles.DeleteRoleHandler")
+    @patch("routes.roles.ModifyRoleHandler")
+    @patch("routes.roles.CreateRoleHandler")
+    @patch("routes.roles.GetRoleHandler")
+    @patch("routes.roles.ListRolesHandler")
+    async def test_route_handler_calls_delete_role(
+            self, _list, _get, _create, _modify, mock_delete_cls):
+        mock_handler = MagicMock()
+        mock_handler.delete_role = AsyncMock(
+            return_value=self._ok_response())
+        mock_delete_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_roles_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.delete("/roles/1")
+
+        mock_handler.delete_role.assert_called_once()
+
+
 class TestCreateInviteRoutes(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.mock_logger = MagicMock(spec=logging.Logger)
@@ -488,13 +645,15 @@ class TestCreateRoutes(unittest.IsolatedAsyncioTestCase):
 
     @patch("routes.create_users_routes")
     @patch("routes.create_system_routes")
+    @patch("routes.create_roles_routes")
     @patch("routes.create_invite_routes")
     @patch("routes.create_auth_routes")
     async def test_returns_blueprint_with_correct_name(self, mock_auth,
-                                                       mock_invite, mock_sys,
-                                                       mock_users):
+                                                       mock_invite, mock_roles,
+                                                       mock_sys, mock_users):
         mock_auth.return_value = quart.Blueprint("mock_auth", __name__)
         mock_invite.return_value = quart.Blueprint("mock_invite", __name__)
+        mock_roles.return_value = quart.Blueprint("mock_roles", __name__)
         mock_sys.return_value = quart.Blueprint("mock_sys", __name__)
         mock_users.return_value = quart.Blueprint("mock_users", __name__)
         bp = create_routes(self.mock_logger, self.mock_state, self.mock_config)
@@ -503,18 +662,23 @@ class TestCreateRoutes(unittest.IsolatedAsyncioTestCase):
 
     @patch("routes.create_users_routes")
     @patch("routes.create_system_routes")
+    @patch("routes.create_roles_routes")
     @patch("routes.create_invite_routes")
     @patch("routes.create_auth_routes")
     async def test_registers_all_sub_blueprints(self, mock_auth, mock_invite,
-                                                mock_sys, mock_users):
+                                                mock_roles, mock_sys,
+                                                mock_users):
         mock_auth.return_value = quart.Blueprint("mock_auth", __name__)
         mock_invite.return_value = quart.Blueprint("mock_invite", __name__)
+        mock_roles.return_value = quart.Blueprint("mock_roles", __name__)
         mock_sys.return_value = quart.Blueprint("mock_sys", __name__)
         mock_users.return_value = quart.Blueprint("mock_users", __name__)
         create_routes(self.mock_logger, self.mock_state, self.mock_config)
         mock_auth.assert_called_once_with(
             self.mock_logger, self.mock_state, self.mock_config)
         mock_invite.assert_called_once_with(self.mock_logger, self.mock_config)
+        mock_roles.assert_called_once_with(
+            self.mock_logger, self.mock_state, self.mock_config)
         mock_sys.assert_called_once_with(self.mock_logger, self.mock_state)
         mock_users.assert_called_once_with(
             self.mock_logger, self.mock_state, self.mock_config)

--- a/unit_tests/items_identity/test_da_role_data_access_layer.py
+++ b/unit_tests/items_identity/test_da_role_data_access_layer.py
@@ -1,0 +1,183 @@
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch
+import logging
+from data_access.role_repository import RoleRepository
+
+
+class TestRoleRepository(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.logger = logging.getLogger("test")
+        self.mock_config = MagicMock()
+        self.mock_config.backend_db_filename = "test.db"
+
+        self.mock_db = MagicMock()
+        self.mock_db.run_query = AsyncMock()
+        self.mock_db.insert_query = AsyncMock()
+        self.mock_db.delete_query = AsyncMock()
+        self.mock_db.bulk_insert_query = AsyncMock()
+
+        patcher = patch("data_access.role_repository.SqliteInterface",
+                        return_value=self.mock_db)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        self.repo = RoleRepository(self.logger, self.mock_config)
+
+    # -------------------------------------------------------
+    # get_all_roles
+    # -------------------------------------------------------
+
+    async def test_get_all_roles_returns_empty_list_when_none(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_all_roles()
+        self.assertEqual(result, [])
+
+    async def test_get_all_roles_returns_rows(self):
+        expected = [(1, "Tester"), (2, "Lead")]
+        self.mock_db.run_query.return_value = expected
+        result = await self.repo.get_all_roles()
+        self.assertEqual(result, expected)
+
+    async def test_get_all_roles_passes_correct_query(self):
+        self.mock_db.run_query.return_value = []
+        await self.repo.get_all_roles()
+        self.mock_db.run_query.assert_called_once_with(
+            RoleRepository.GET_ALL_ROLES_QUERY, ())
+
+    # -------------------------------------------------------
+    # get_role_by_id
+    # -------------------------------------------------------
+
+    async def test_get_role_by_id_returns_none_when_not_found(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_role_by_id(999)
+        self.assertIsNone(result)
+
+    async def test_get_role_by_id_returns_row(self):
+        self.mock_db.run_query.return_value = (1, "Tester")
+        result = await self.repo.get_role_by_id(1)
+        self.assertEqual(result, (1, "Tester"))
+
+    async def test_get_role_by_id_passes_correct_query(self):
+        self.mock_db.run_query.return_value = None
+        await self.repo.get_role_by_id(5)
+        self.mock_db.run_query.assert_called_once_with(
+            RoleRepository.GET_ROLE_BY_ID_QUERY, (5,), fetch_one=True)
+
+    # -------------------------------------------------------
+    # role_name_exists
+    # -------------------------------------------------------
+
+    async def test_role_name_exists_returns_false_when_not_found(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.role_name_exists("Tester")
+        self.assertFalse(result)
+
+    async def test_role_name_exists_returns_true_when_found(self):
+        self.mock_db.run_query.return_value = (1,)
+        result = await self.repo.role_name_exists("Tester")
+        self.assertTrue(result)
+
+    # -------------------------------------------------------
+    # get_role_permissions
+    # -------------------------------------------------------
+
+    async def test_get_role_permissions_returns_empty_list_when_none(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_role_permissions(1)
+        self.assertEqual(result, [])
+
+    async def test_get_role_permissions_returns_rows(self):
+        expected = [("test_cases", 1, 1, 0)]
+        self.mock_db.run_query.return_value = expected
+        result = await self.repo.get_role_permissions(1)
+        self.assertEqual(result, expected)
+
+    async def test_get_role_permissions_passes_correct_query(self):
+        self.mock_db.run_query.return_value = []
+        await self.repo.get_role_permissions(7)
+        self.mock_db.run_query.assert_called_once_with(
+            RoleRepository.GET_ROLE_PERMISSIONS_QUERY, (7,))
+
+    # -------------------------------------------------------
+    # create_role
+    # -------------------------------------------------------
+
+    async def test_create_role_inserts_role_and_returns_id(self):
+        self.mock_db.insert_query.return_value = 42
+        role_id = await self.repo.create_role("Tester", [])
+        self.assertEqual(role_id, 42)
+        self.mock_db.insert_query.assert_awaited_once_with(
+            RoleRepository.INSERT_ROLE_QUERY, ("Tester",))
+
+    async def test_create_role_with_permissions_inserts_grid(self):
+        self.mock_db.insert_query.return_value = 1
+        permissions = [("test_cases", True, True, False)]
+        await self.repo.create_role("Tester", permissions)
+        self.mock_db.bulk_insert_query.assert_awaited_once_with(
+            RoleRepository.INSERT_ROLE_PERMISSION_QUERY,
+            [(1, "test_cases", True, True, False)])
+
+    async def test_create_role_with_empty_permissions_does_not_bulk_insert(self):
+        self.mock_db.insert_query.return_value = 1
+        await self.repo.create_role("Tester", [])
+        self.mock_db.bulk_insert_query.assert_not_called()
+
+    async def test_create_role_always_clears_existing_permissions_first(self):
+        """New role, so nothing to clear - but the replace-then-insert
+        sequence must still run delete first, insert second, every time."""
+        self.mock_db.insert_query.return_value = 1
+        await self.repo.create_role("Tester", [("test_cases", 1, 0, 0)])
+        self.mock_db.delete_query.assert_awaited_once_with(
+            RoleRepository.DELETE_ROLE_PERMISSIONS_QUERY, (1,))
+
+    # -------------------------------------------------------
+    # update_role
+    # -------------------------------------------------------
+
+    async def test_update_role_name_only_updates_name(self):
+        await self.repo.update_role(1, "New Name", None)
+        self.mock_db.run_query.assert_awaited_once_with(
+            RoleRepository.UPDATE_ROLE_NAME_QUERY, ("New Name", 1),
+            commit=True)
+        self.mock_db.delete_query.assert_not_called()
+
+    async def test_update_role_name_none_does_not_update_name(self):
+        await self.repo.update_role(1, None, None)
+        self.mock_db.run_query.assert_not_called()
+
+    async def test_update_role_permissions_replaces_grid(self):
+        permissions = [("test_cases", True, False, False)]
+        await self.repo.update_role(1, None, permissions)
+        self.mock_db.delete_query.assert_awaited_once_with(
+            RoleRepository.DELETE_ROLE_PERMISSIONS_QUERY, (1,))
+        self.mock_db.bulk_insert_query.assert_awaited_once_with(
+            RoleRepository.INSERT_ROLE_PERMISSION_QUERY,
+            [(1, "test_cases", True, False, False)])
+
+    async def test_update_role_permissions_none_leaves_grid_untouched(self):
+        await self.repo.update_role(1, "New Name", None)
+        self.mock_db.delete_query.assert_not_called()
+        self.mock_db.bulk_insert_query.assert_not_called()
+
+    async def test_update_role_empty_permissions_list_clears_grid(self):
+        """An explicit empty list (not None) means "this role now grants
+        nothing" - distinct from omitting permissions entirely."""
+        await self.repo.update_role(1, None, [])
+        self.mock_db.delete_query.assert_awaited_once_with(
+            RoleRepository.DELETE_ROLE_PERMISSIONS_QUERY, (1,))
+        self.mock_db.bulk_insert_query.assert_not_called()
+
+    # -------------------------------------------------------
+    # delete_role
+    # -------------------------------------------------------
+
+    async def test_delete_role_passes_correct_query(self):
+        await self.repo.delete_role(3)
+        self.mock_db.delete_query.assert_awaited_once_with(
+            RoleRepository.DELETE_ROLE_QUERY, (3,))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_identity/test_services_role_management_service.py
+++ b/unit_tests/items_identity/test_services_role_management_service.py
@@ -1,0 +1,253 @@
+import unittest
+import logging
+from unittest.mock import MagicMock, AsyncMock
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from services.role_management_service import (
+    RoleManagementService,
+    RoleListResult,
+    RoleLookupResult,
+    RoleCreateResult,
+    RoleUpdateResult,
+    RoleDeleteResult,
+)
+
+_VALID_PERMISSIONS = [
+    {"area": "test_cases", "can_read": True, "can_add_modify": True,
+     "can_delete": False},
+]
+_VALID_PERMISSION_ROWS = [("test_cases", True, True, False)]
+
+_INVALID_PERMISSIONS_NO_READ = [
+    {"area": "test_cases", "can_read": False, "can_add_modify": True,
+     "can_delete": False},
+]
+
+_DUPLICATE_AREA_PERMISSIONS = [
+    {"area": "test_cases", "can_read": True, "can_add_modify": False,
+     "can_delete": False},
+    {"area": "test_cases", "can_read": True, "can_add_modify": False,
+     "can_delete": False},
+]
+
+
+class TestRoleManagementService(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_logger.getChild.return_value = MagicMock(spec=logging.Logger)
+
+        self.mock_state = MagicMock()
+        self.mock_state.is_available.return_value = True
+
+        self.mock_repo = MagicMock()
+        self.mock_repo.get_all_roles = AsyncMock()
+        self.mock_repo.get_role_by_id = AsyncMock()
+        self.mock_repo.get_role_permissions = AsyncMock()
+        self.mock_repo.role_name_exists = AsyncMock(return_value=False)
+        self.mock_repo.create_role = AsyncMock()
+        self.mock_repo.update_role = AsyncMock()
+        self.mock_repo.delete_role = AsyncMock()
+
+        self.svc = RoleManagementService(
+            self.mock_logger, self.mock_state, self.mock_repo)
+
+    # -------------------------------------------------------
+    # get_all_roles
+    # -------------------------------------------------------
+
+    async def test_get_all_roles_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.get_all_roles()
+        self.assertFalse(result.available)
+
+    async def test_get_all_roles_returns_empty_list(self):
+        self.mock_repo.get_all_roles.return_value = []
+        result = await self.svc.get_all_roles()
+        self.assertEqual(result.roles, [])
+
+    async def test_get_all_roles_returns_id_name_dicts(self):
+        self.mock_repo.get_all_roles.return_value = [(1, "Tester"), (2, "Lead")]
+        result = await self.svc.get_all_roles()
+        self.assertEqual(result.roles,
+                         [{"id": 1, "name": "Tester"}, {"id": 2, "name": "Lead"}])
+
+    async def test_get_all_roles_unavailable_on_db_exception(self):
+        self.mock_repo.get_all_roles.side_effect = SqliteInterfaceException("err")
+        result = await self.svc.get_all_roles()
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # get_role
+    # -------------------------------------------------------
+
+    async def test_get_role_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.get_role(1)
+        self.assertFalse(result.available)
+
+    async def test_get_role_not_found(self):
+        self.mock_repo.get_role_by_id.return_value = None
+        result = await self.svc.get_role(999)
+        self.assertFalse(result.found)
+
+    async def test_get_role_success_includes_permissions(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        self.mock_repo.get_role_permissions.return_value = _VALID_PERMISSION_ROWS
+        result = await self.svc.get_role(1)
+        self.assertTrue(result.found)
+        self.assertEqual(result.role["id"], 1)
+        self.assertEqual(result.role["name"], "Tester")
+        self.assertEqual(result.role["permissions"], _VALID_PERMISSIONS)
+
+    async def test_get_role_success_with_no_permissions_rows(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        self.mock_repo.get_role_permissions.return_value = []
+        result = await self.svc.get_role(1)
+        self.assertEqual(result.role["permissions"], [])
+
+    async def test_get_role_unavailable_on_db_exception(self):
+        self.mock_repo.get_role_by_id.side_effect = SqliteInterfaceException("err")
+        result = await self.svc.get_role(1)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # create_role
+    # -------------------------------------------------------
+
+    async def test_create_role_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.create_role("Tester", [])
+        self.assertFalse(result.available)
+
+    async def test_create_role_success(self):
+        self.mock_repo.create_role.return_value = 5
+        result = await self.svc.create_role("Tester", _VALID_PERMISSIONS)
+        self.assertTrue(result.available)
+        self.assertFalse(result.conflict)
+        self.assertFalse(result.invalid)
+        self.assertEqual(result.role_id, 5)
+        self.mock_repo.create_role.assert_awaited_once_with(
+            "Tester", _VALID_PERMISSION_ROWS)
+
+    async def test_create_role_conflict_when_name_exists(self):
+        self.mock_repo.role_name_exists.return_value = True
+        result = await self.svc.create_role("Tester", [])
+        self.assertTrue(result.conflict)
+        self.mock_repo.create_role.assert_not_called()
+
+    async def test_create_role_invalid_when_add_modify_without_read(self):
+        result = await self.svc.create_role(
+            "Tester", _INVALID_PERMISSIONS_NO_READ)
+        self.assertTrue(result.invalid)
+        self.mock_repo.role_name_exists.assert_not_called()
+        self.mock_repo.create_role.assert_not_called()
+
+    async def test_create_role_invalid_when_area_repeated(self):
+        result = await self.svc.create_role(
+            "Tester", _DUPLICATE_AREA_PERMISSIONS)
+        self.assertTrue(result.invalid)
+        self.mock_repo.create_role.assert_not_called()
+
+    async def test_create_role_empty_permissions_is_valid(self):
+        self.mock_repo.create_role.return_value = 1
+        result = await self.svc.create_role("Tester", [])
+        self.assertFalse(result.invalid)
+        self.assertEqual(result.role_id, 1)
+
+    async def test_create_role_unavailable_on_db_exception(self):
+        self.mock_repo.create_role.side_effect = SqliteInterfaceException("err")
+        result = await self.svc.create_role("Tester", [])
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # update_role
+    # -------------------------------------------------------
+
+    async def test_update_role_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.update_role(1)
+        self.assertFalse(result.available)
+
+    async def test_update_role_invalid_permissions_skips_lookup(self):
+        result = await self.svc.update_role(
+            1, permissions=_INVALID_PERMISSIONS_NO_READ)
+        self.assertTrue(result.invalid)
+        self.mock_repo.get_role_by_id.assert_not_called()
+
+    async def test_update_role_not_found(self):
+        self.mock_repo.get_role_by_id.return_value = None
+        result = await self.svc.update_role(999, name="New")
+        self.assertFalse(result.found)
+
+    async def test_update_role_success_name_only(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Old Name")
+        result = await self.svc.update_role(1, name="New Name")
+        self.assertTrue(result.success)
+        self.mock_repo.update_role.assert_awaited_once_with(1, "New Name", None)
+
+    async def test_update_role_success_permissions_only(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        result = await self.svc.update_role(1, permissions=_VALID_PERMISSIONS)
+        self.assertTrue(result.success)
+        self.mock_repo.update_role.assert_awaited_once_with(
+            1, None, _VALID_PERMISSION_ROWS)
+
+    async def test_update_role_renaming_to_own_current_name_is_not_a_conflict(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        self.mock_repo.role_name_exists.return_value = True
+        result = await self.svc.update_role(1, name="Tester")
+        self.assertFalse(result.conflict)
+        self.assertTrue(result.success)
+
+    async def test_update_role_renaming_to_another_roles_name_is_conflict(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        self.mock_repo.role_name_exists.return_value = True
+        result = await self.svc.update_role(1, name="Lead")
+        self.assertTrue(result.conflict)
+        self.mock_repo.update_role.assert_not_called()
+
+    async def test_update_role_no_name_change_does_not_check_uniqueness(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        result = await self.svc.update_role(1, permissions=[])
+        self.assertTrue(result.success)
+        self.mock_repo.role_name_exists.assert_not_called()
+
+    async def test_update_role_unavailable_on_db_exception(self):
+        self.mock_repo.get_role_by_id.side_effect = SqliteInterfaceException("err")
+        result = await self.svc.update_role(1, name="New")
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # delete_role
+    # -------------------------------------------------------
+
+    async def test_delete_role_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.delete_role(1)
+        self.assertFalse(result.available)
+
+    async def test_delete_role_not_found(self):
+        self.mock_repo.get_role_by_id.return_value = None
+        result = await self.svc.delete_role(999)
+        self.assertFalse(result.found)
+        self.mock_repo.delete_role.assert_not_called()
+
+    async def test_delete_role_success(self):
+        self.mock_repo.get_role_by_id.return_value = (1, "Tester")
+        result = await self.svc.delete_role(1)
+        self.assertTrue(result.success)
+        self.mock_repo.delete_role.assert_awaited_once_with(1)
+
+    async def test_delete_role_unavailable_on_db_exception(self):
+        self.mock_repo.get_role_by_id.side_effect = SqliteInterfaceException("err")
+        result = await self.svc.delete_role(1)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Identity: role CRUD

**Branch:** `identity_roles_crud` → `main`
**Theme:** Roles & permissions (post-0.3.0) — first application-code piece,
built on the schema from `identity_roles_db_update`

## Summary

Role *definitions* only - create/list/get/modify/delete a named role and
its per-area permission grid. Deliberately does not touch project
membership (assigning a role to a `project_members` row) - that's the
next branch, per the split agreed earlier (roles first, since nothing
depends on it; membership second, since it needs roles to exist to be
useful).

Mirrors the existing `UserRepository`/`UserManagementService`/
`routes/users/*` conventions throughout - same `ServiceState.is_available()`
checks, same dataclass-result shape per operation, same
`SqliteInterfaceException` handling, same `@validate_json` + handler
structure. Nothing architecturally new, just the same pattern applied to
a new domain.

## New shared constant

`items/shared/permission_area.py` - `PermissionArea` enum, the fixed list
of six grid areas (Test Cases, Milestones, Test Runs, Test Plans, Test
Reports, Test Results) from §4 of `user_roles_design.md`. Lives in
`items/shared` rather than inside Identity because CMS/Gateway/Portal will
all eventually need the same vocabulary (CMS decides which areas are
real, Portal renders the grid, Gateway will check against it) - parking it
centrally now avoids moving or duplicating it later. Confirmed the
CHECK constraint on `role_permissions` doesn't (deliberately) constrain
`area` to this list at the database level - see §7.1's "areas are rows,
not columns" - so this enum is where that constraint actually lives, at
the application layer.

## Identity

- **`data_access/role_repository.py`** (new) - `RoleRepository`. A role's
  grid is always replaced as a whole (delete existing `role_permissions`
  rows for the role, insert the new set) rather than upserted per area -
  matches how a checkbox-grid form naturally submits, and avoids needing
  separate insert/update/delete logic per area.
- **`services/role_management_service.py`** (new) - `RoleManagementService`
  plus five result dataclasses (`RoleListResult`, `RoleLookupResult`,
  `RoleCreateResult`, `RoleUpdateResult`, `RoleDeleteResult`). Validates
  two invariants the JSON schema can't express on its own before writing
  anything: Add/Modify-implies-Read (§4.1), and no area repeated twice in
  the same grid (would otherwise hit the `(role_id, area)` primary key as
  a raw, unhelpful database error). Name uniqueness checked explicitly
  (pre-check, not caught via `UNIQUE` constraint exception) for a clean
  409 rather than a raw SQL error, matching `email_exists` in
  `UserManagementService`.
- **`routes/roles/`** (new) - five handlers (`ListRolesHandler`,
  `GetRoleHandler`, `CreateRoleHandler`, `ModifyRoleHandler`,
  `DeleteRoleHandler`) plus `schemas.py`. `GET /roles` returns name only;
  `GET /roles/<id>` returns the full grid - same asymmetry as
  `list_users`/`get_user`.
- **`routes/__init__.py`** - wired `create_roles_routes` in alongside the
  existing blueprints.
- Deleting a role clears (`SET NULL`) any `project_members.role_id`
  pointing at it rather than leaving a dangling reference - the schema
  from the previous branch already handles this at the database level, no
  application code needed to enforce it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [x] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

New: `test_da_role_data_access_layer.py`, `test_services_role_management_service.py`,
`test_apis_role_management.py`, plus `TestCreateRolesRoutes` added to
`test_create_routes.py` and `TestCreateRoutes` updated to include the new
blueprint. All mirror the exact structure of the equivalent `users` test
files (including the `_undecorated`/`_make_handler_setup` helpers, copied
rather than reinvented).

**369 tests, OK (up from 277). 100% coverage maintained** across
`items_identity` (1331/1331 statements) and `items/shared`. Pylint:
10.00/10 on both.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
