### PR TITLE
[Identity] Changes to support project membership

### DIFF
--- a/items/services/items_identity/data_access/project_member_repository.py
+++ b/items/services/items_identity/data_access/project_member_repository.py
@@ -1,0 +1,184 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterface
+from items.services.items_identity.identity_configuration import \
+    IdentityConfiguration
+
+
+class ProjectMemberRepository:
+    """
+    Provides persistence operations for project membership - which users
+    are on which projects, and what role (if any) they hold there.
+
+    v1 is users-only (§7.2 of user_roles_design.md): every row this
+    repository writes has ``principal_type = 'user'``, hardcoded rather
+    than accepted as a parameter. The schema already supports
+    ``principal_type = 'group'`` for when groups arrive, but nothing in
+    this v1 API surface needs to expose that yet.
+
+    All methods identify a user by their internal integer id, not their
+    UUID - callers resolve the UUID first (see ``UserRepository``), same
+    division of responsibility as ``user_auth_details``.
+    """
+
+    GET_MEMBERSHIPS_FOR_USER_QUERY: str = (
+        "SELECT pm.id, pm.project_id, pm.role_id, r.name "
+        "FROM project_members pm "
+        "LEFT JOIN roles r ON pm.role_id = r.id "
+        "WHERE pm.principal_type = 'user' AND pm.principal_id = ? "
+        "ORDER BY pm.project_id")
+
+    GET_MEMBERSHIP_QUERY: str = (
+        "SELECT pm.id, pm.role_id, r.name "
+        "FROM project_members pm "
+        "LEFT JOIN roles r ON pm.role_id = r.id "
+        "WHERE pm.principal_type = 'user' AND pm.principal_id = ? "
+        "AND pm.project_id = ?")
+
+    INSERT_MEMBERSHIP_QUERY: str = (
+        "INSERT INTO project_members "
+        "(principal_type, principal_id, project_id, role_id) "
+        "VALUES ('user', ?, ?, ?)")
+
+    UPDATE_MEMBERSHIP_ROLE_QUERY: str = (
+        "UPDATE project_members SET role_id = ? "
+        "WHERE principal_type = 'user' AND principal_id = ? "
+        "AND project_id = ?")
+
+    DELETE_MEMBERSHIP_QUERY: str = (
+        "DELETE FROM project_members "
+        "WHERE principal_type = 'user' AND principal_id = ? "
+        "AND project_id = ?")
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 config: IdentityConfiguration) -> None:
+        """Initialise a ProjectMemberRepository instance.
+
+        Args:
+            logger: Parent logger used for repository and database logging.
+            config: Identity service configuration containing database
+                connection settings.
+        """
+        self._logger: logging.Logger = logger.getChild(__name__)
+        self._config: IdentityConfiguration = config
+
+        self._db: SqliteInterface = SqliteInterface(
+            self._logger,
+            self._config.backend_db_filename)
+
+    async def get_memberships_for_user(self, user_id: int) -> list:
+        """Retrieve every project membership held by a user.
+
+        Args:
+            user_id: The user's internal primary key.
+
+        Returns:
+            A list of ``(id, project_id, role_id, role_name)`` tuples,
+            ordered by ``project_id``. ``role_id``/``role_name`` are both
+            ``None`` for a membership with no role assigned. Empty list if
+            the user has no memberships.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        rows = await self._db.run_query(self.GET_MEMBERSHIPS_FOR_USER_QUERY,
+                                        (user_id,))
+        return rows if rows else []
+
+    async def get_membership(
+            self, user_id: int,
+            project_id: int) -> Optional[tuple[int, Optional[int],
+                                               Optional[str]]]:
+        """Retrieve a single membership for a (user, project) pair.
+
+        Args:
+            user_id: The user's internal primary key.
+            project_id: The project's id (CMS-side, no FK - see class
+                docstring on `ProjectMemberRepository`).
+
+        Returns:
+            A ``(membership_id, role_id, role_name)`` tuple if the user is
+            a member of the project, otherwise ``None``. ``role_id``/
+            ``role_name`` are ``None`` if the membership has no role
+            assigned.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        return await self._db.run_query(self.GET_MEMBERSHIP_QUERY,
+                                        (user_id, project_id),
+                                        fetch_one=True)
+
+    async def create_membership(self,
+                                user_id: int,
+                                project_id: int,
+                                role_id: Optional[int]) -> int:
+        """Insert a new project membership.
+
+        Args:
+            user_id: The user's internal primary key.
+            project_id: The project's id.
+            role_id: The role to assign, or ``None`` for "member, no role
+                assigned yet" (§4.3 of user_roles_design.md - a valid
+                state, not a placeholder).
+
+        Returns:
+            The internal ``id`` of the newly inserted membership row.
+
+        Raises:
+            SqliteInterfaceException: If the insert fails - including a
+                uniqueness violation if this (user, project) pair already
+                has a membership row. Callers should check
+                :meth:`get_membership` first for a clean conflict response
+                rather than relying on this exception.
+        """
+        return await self._db.insert_query(
+            self.INSERT_MEMBERSHIP_QUERY, (user_id, project_id, role_id))
+
+    async def update_membership_role(self,
+                                     user_id: int,
+                                     project_id: int,
+                                     role_id: Optional[int]) -> None:
+        """Change the role assigned to an existing membership.
+
+        Args:
+            user_id: The user's internal primary key.
+            project_id: The project's id.
+            role_id: The new role, or ``None`` to clear back to "member,
+                no role assigned".
+
+        Raises:
+            SqliteInterfaceException: If the update fails.
+        """
+        await self._db.run_query(self.UPDATE_MEMBERSHIP_ROLE_QUERY,
+                                 (role_id, user_id, project_id),
+                                 commit=True)
+
+    async def delete_membership(self, user_id: int, project_id: int) -> None:
+        """Remove a project membership entirely.
+
+        Args:
+            user_id: The user's internal primary key.
+            project_id: The project's id.
+
+        Raises:
+            SqliteInterfaceException: If the delete fails.
+        """
+        await self._db.delete_query(self.DELETE_MEMBERSHIP_QUERY,
+                                    (user_id, project_id))

--- a/items/services/items_identity/routes/users/__init__.py
+++ b/items/services/items_identity/routes/users/__init__.py
@@ -25,6 +25,10 @@ from .create_user_handler import CreateUserHandler
 from .modify_user_handler import ModifyUserHandler
 from .reset_password_handler import ResetPasswordHandler
 from .change_password_handler import ChangePasswordHandler
+from .list_user_projects_handler import ListUserProjectsHandler
+from .add_user_project_handler import AddUserProjectHandler
+from .modify_user_project_handler import ModifyUserProjectHandler
+from .remove_user_project_handler import RemoveUserProjectHandler
 
 
 def create_users_routes(logger: logging.Logger,
@@ -43,6 +47,14 @@ def create_users_routes(logger: logging.Logger,
     * ``PATCH /users/<user_id>``       - Update a user's profile fields (UUID).
     * ``POST /users/<user_id>/password`` - Admin password reset (UUID).
     * ``POST /users/me/password``      - Self-service password change.
+    * ``GET  /users/<user_id>/projects`` - List the user's project
+      memberships (UUID).
+    * ``POST /users/<user_id>/projects`` - Add the user to a project
+      (UUID).
+    * ``PATCH /users/<user_id>/projects/<project_id>`` - Change the
+      user's role on a project (UUID).
+    * ``DELETE /users/<user_id>/projects/<project_id>`` - Remove the
+      user's membership of a project (UUID).
 
     Args:
         logger:
@@ -68,6 +80,10 @@ def create_users_routes(logger: logging.Logger,
     handler_modify = ModifyUserHandler(logger, service_state, config)
     handler_reset_password = ResetPasswordHandler(logger, service_state, config)
     handler_change_password = ChangePasswordHandler(logger, service_state, config)
+    handler_list_projects = ListUserProjectsHandler(logger, service_state, config)
+    handler_add_project = AddUserProjectHandler(logger, service_state, config)
+    handler_modify_project = ModifyUserProjectHandler(logger, service_state, config)
+    handler_remove_project = RemoveUserProjectHandler(logger, service_state, config)
 
     logger.debug("Registering Users API routes:")
 
@@ -85,6 +101,14 @@ def create_users_routes(logger: logging.Logger,
                  'Reset password'.ljust(40))
     logger.debug("=> %s POST /users/me/password",
                  'Change own password'.ljust(40))
+    logger.debug("=> %s GET  /users/<user_id>/projects",
+                 'List project memberships'.ljust(40))
+    logger.debug("=> %s POST /users/<user_id>/projects",
+                 'Add project membership'.ljust(40))
+    logger.debug("=> %s PATCH /users/<user_id>/projects/<project_id>",
+                 'Change membership role'.ljust(40))
+    logger.debug("=> %s DELETE /users/<user_id>/projects/<project_id>",
+                 'Remove project membership'.ljust(40))
 
     # pylint: disable=no-value-for-parameter
 
@@ -115,5 +139,27 @@ def create_users_routes(logger: logging.Logger,
     @users_routes.route('/users/me/password', methods=['POST'])
     async def change_password_request():
         return await handler_change_password.change_password()
+
+    @users_routes.route('/users/<string:user_id>/projects', methods=['GET'])
+    async def list_user_projects_request(user_id: str):
+        return await handler_list_projects.list_user_projects(user_id)
+
+    @users_routes.route('/users/<string:user_id>/projects', methods=['POST'])
+    async def add_user_project_request(user_id: str):
+        return await handler_add_project.add_user_project(user_id=user_id)
+
+    @users_routes.route(
+        '/users/<string:user_id>/projects/<int:project_id>',
+        methods=['PATCH'])
+    async def modify_user_project_request(user_id: str, project_id: int):
+        return await handler_modify_project.modify_user_project(
+            user_id=user_id, project_id=project_id)
+
+    @users_routes.route(
+        '/users/<string:user_id>/projects/<int:project_id>',
+        methods=['DELETE'])
+    async def remove_user_project_request(user_id: str, project_id: int):
+        return await handler_remove_project.remove_user_project(
+            user_id=user_id, project_id=project_id)
 
     return users_routes

--- a/items/services/items_identity/routes/users/add_user_project_handler.py
+++ b/items/services/items_identity/routes/users/add_user_project_handler.py
@@ -1,0 +1,107 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from items.services.items_identity.data_access.project_member_repository import (
+    ProjectMemberRepository)
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.routes.users.schemas import (
+    SCHEMA_ADD_USER_PROJECT_REQUEST)
+from items.services.items_identity.services.project_membership_service import (
+    ProjectMembershipService)
+from items.shared.service_state import ServiceState
+
+
+class AddUserProjectHandler(BaseApiRoute):
+    """Handles POST /users/<user_id>/projects — add the user to a project."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        member_repo = ProjectMemberRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        role_repo = RoleRepository(self._logger, configuration)
+        self._service = ProjectMembershipService(
+            self._logger, self._service_state,
+            member_repo, user_repo, role_repo)
+
+    @validate_json(SCHEMA_ADD_USER_PROJECT_REQUEST)
+    async def add_user_project(self, request_msg: ApiResponse,
+                               user_id: str) -> Response:
+        """Add a user to a project, optionally assigning a role.
+
+        Args:
+            request_msg: Validated request containing ``project_id`` and
+                optionally ``role_id`` (defaults to ``null`` - "member, no
+                role assigned yet", a valid state, not a placeholder).
+            user_id: The user's UUID (from the URL).
+
+        Returns:
+            201 on success.
+            400 if ``role_id`` is supplied but no such role exists.
+            404 if no user exists with that UUID.
+            409 if the user is already a member of this project.
+            503 if the service is unavailable.
+        """
+        body = request_msg.body
+        result = await self._service.add_membership(
+            user_uuid=user_id,
+            project_id=body["project_id"],
+            role_id=body.get("role_id"))
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "User not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        if result.role_not_found:
+            return Response(
+                json.dumps({"error": "No role exists with that id"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        if result.conflict:
+            return Response(
+                json.dumps(
+                    {"error": "User is already a member of this project"}),
+                status=HTTPStatus.CONFLICT,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=HTTPStatus.CREATED,
+            content_type="application/json")

--- a/items/services/items_identity/routes/users/list_user_projects_handler.py
+++ b/items/services/items_identity/routes/users/list_user_projects_handler.py
@@ -1,0 +1,81 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.project_member_repository import (
+    ProjectMemberRepository)
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.project_membership_service import (
+    ProjectMembershipService)
+from items.shared.service_state import ServiceState
+
+
+class ListUserProjectsHandler(BaseApiRoute):
+    """Handles GET /users/<user_id>/projects — list a user's memberships."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        member_repo = ProjectMemberRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        role_repo = RoleRepository(self._logger, configuration)
+        self._service = ProjectMembershipService(
+            self._logger, self._service_state,
+            member_repo, user_repo, role_repo)
+
+    async def list_user_projects(self, user_id: str) -> Response:
+        """Return every project membership held by a user.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+
+        Returns:
+            200 with ``{"memberships": [...]}`` on success. Each entry is
+            ``{"project_id", "role_id", "role_name"}`` - the latter two are
+            ``null`` when the membership has no role assigned.
+            404 if no user exists with that UUID.
+            503 if the service is unavailable.
+        """
+        result = await self._service.get_memberships(user_id)
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "User not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"memberships": result.memberships}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/users/modify_user_project_handler.py
+++ b/items/services/items_identity/routes/users/modify_user_project_handler.py
@@ -1,0 +1,107 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.microservice_decorators import validate_json
+from items.services.items_identity.data_access.project_member_repository import (
+    ProjectMemberRepository)
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.routes.users.schemas import (
+    SCHEMA_MODIFY_USER_PROJECT_REQUEST)
+from items.services.items_identity.services.project_membership_service import (
+    ProjectMembershipService)
+from items.shared.service_state import ServiceState
+
+
+class ModifyUserProjectHandler(BaseApiRoute):
+    """Handles PATCH /users/<user_id>/projects/<project_id> — change role."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        member_repo = ProjectMemberRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        role_repo = RoleRepository(self._logger, configuration)
+        self._service = ProjectMembershipService(
+            self._logger, self._service_state,
+            member_repo, user_repo, role_repo)
+
+    @validate_json(SCHEMA_MODIFY_USER_PROJECT_REQUEST)
+    async def modify_user_project(self, request_msg: ApiResponse,
+                                  user_id: str, project_id: int) -> Response:
+        """Change (or clear) the role on an existing membership.
+
+        Args:
+            request_msg: Validated request containing ``role_id`` - an
+                integer to assign a role, or ``null`` to clear back to
+                "member, no role assigned".
+            user_id: The user's UUID (from the URL).
+            project_id: The project's id (from the URL).
+
+        Returns:
+            200 on success.
+            400 if a supplied ``role_id`` doesn't exist.
+            404 if no user exists with that UUID, or the user is not a
+            member of this project.
+            503 if the service is unavailable.
+        """
+        result = await self._service.update_membership_role(
+            user_uuid=user_id,
+            project_id=project_id,
+            role_id=request_msg.body["role_id"])
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "User not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        if result.role_not_found:
+            return Response(
+                json.dumps({"error": "No role exists with that id"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        if result.membership_not_found:
+            return Response(
+                json.dumps(
+                    {"error": "User is not a member of this project"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/users/remove_user_project_handler.py
+++ b/items/services/items_identity/routes/users/remove_user_project_handler.py
@@ -1,0 +1,90 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from items.services.items_identity.data_access.project_member_repository import (
+    ProjectMemberRepository)
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.services.items_identity.identity_configuration import (
+    IdentityConfiguration)
+from items.services.items_identity.services.project_membership_service import (
+    ProjectMembershipService)
+from items.shared.service_state import ServiceState
+
+
+class RemoveUserProjectHandler(BaseApiRoute):
+    """Handles DELETE /users/<user_id>/projects/<project_id> — remove."""
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 service_state: ServiceState,
+                 configuration: IdentityConfiguration) -> None:
+        self._logger = logger.getChild(__name__)
+        self._service_state: ServiceState = service_state
+
+        member_repo = ProjectMemberRepository(self._logger, configuration)
+        user_repo = UserRepository(self._logger, configuration)
+        role_repo = RoleRepository(self._logger, configuration)
+        self._service = ProjectMembershipService(
+            self._logger, self._service_state,
+            member_repo, user_repo, role_repo)
+
+    async def remove_user_project(self, user_id: str,
+                                  project_id: int) -> Response:
+        """Remove a user's membership of a project entirely.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+            project_id: The project's id (from the URL).
+
+        Returns:
+            200 on success.
+            404 if no user exists with that UUID, or the user is not a
+            member of this project.
+            503 if the service is unavailable.
+        """
+        result = await self._service.remove_membership(
+            user_uuid=user_id, project_id=project_id)
+
+        if not result.available:
+            return Response(
+                json.dumps({"error": "Service unavailable"}),
+                status=HTTPStatus.SERVICE_UNAVAILABLE,
+                content_type="application/json")
+
+        if not result.found:
+            return Response(
+                json.dumps({"error": "User not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        if result.membership_not_found:
+            return Response(
+                json.dumps(
+                    {"error": "User is not a member of this project"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        return Response(
+            json.dumps({"status": "ok"}),
+            status=HTTPStatus.OK,
+            content_type="application/json")

--- a/items/services/items_identity/routes/users/schemas.py
+++ b/items/services/items_identity/routes/users/schemas.py
@@ -126,6 +126,48 @@ SCHEMA_RESET_PASSWORD_REQUEST: dict = {
     "required": ["new_password"]
 }
 
+SCHEMA_ADD_USER_PROJECT_REQUEST: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+    "type": "object",
+    "additionalProperties": False,
+
+    "properties":
+    {
+        "project_id":
+        {
+            "type": "integer"
+        },
+        "role_id":
+        {
+            # Omitting role_id entirely also means "no role yet" - this
+            # lets a caller be explicit about it instead if they prefer.
+            "type": ["integer", "null"]
+        }
+    },
+    "required": ["project_id"]
+}
+
+SCHEMA_MODIFY_USER_PROJECT_REQUEST: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+
+    "type": "object",
+    "additionalProperties": False,
+
+    "properties":
+    {
+        "role_id":
+        {
+            # null clears the role back to "member, no role assigned"
+            # (§4.3 of user_roles_design.md) rather than being omittable -
+            # this endpoint's only job is changing the role, so leaving
+            # role_id out of the body would be ambiguous about intent.
+            "type": ["integer", "null"]
+        }
+    },
+    "required": ["role_id"]
+}
+
 SCHEMA_CHANGE_PASSWORD_REQUEST: dict = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
 

--- a/items/services/items_identity/services/project_membership_service.py
+++ b/items/services/items_identity/services/project_membership_service.py
@@ -1,0 +1,333 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from dataclasses import dataclass, field
+import logging
+from typing import Optional
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from items.services.items_identity.data_access.project_member_repository import (
+    ProjectMemberRepository)
+from items.services.items_identity.data_access.role_repository import (
+    RoleRepository)
+from items.services.items_identity.data_access.user_repository import (
+    UserRepository)
+from items.shared.service_state import ServiceState
+
+
+def _membership_row_to_dict(row: tuple) -> dict:
+    """Convert a membership row tuple to a dict.
+
+    Args:
+        row: ``(id, project_id, role_id, role_name)``
+
+    Returns:
+        A dict with ``project_id``, ``role_id``, ``role_name``. The latter
+        two are ``None`` when no role is assigned - callers presenting
+        this to a user (e.g. the web portal) map that to a display label
+        such as "Unassigned" themselves; this service returns the raw,
+        undecorated data.
+    """
+    _, project_id, role_id, role_name = row
+    return {
+        "project_id": project_id,
+        "role_id": role_id,
+        "role_name": role_name,
+    }
+
+
+@dataclass
+class MembershipListResult:
+    """Outcome of a list-a-user's-memberships request.
+
+    Attributes:
+        available:    False when the service is unavailable.
+        found:        False when no user exists with the requested UUID.
+        memberships:  List of ``{"project_id", "role_id", "role_name"}``
+                      dicts on success.
+    """
+    available: bool = True
+    found: bool = True
+    memberships: list = field(default_factory=list)
+
+
+@dataclass
+class MembershipCreateResult:
+    """Outcome of an add-project-membership request.
+
+    Attributes:
+        available:      False when the service is unavailable.
+        found:          False when no user exists with the requested UUID.
+        role_not_found: True when a supplied ``role_id`` doesn't exist.
+        conflict:       True when the user is already a member of this
+                        project.
+        success:        True when the membership was created.
+    """
+    available: bool = True
+    found: bool = True
+    role_not_found: bool = False
+    conflict: bool = False
+    success: bool = False
+
+
+@dataclass
+class MembershipUpdateResult:
+    """Outcome of a change-membership-role request.
+
+    Attributes:
+        available:           False when the service is unavailable.
+        found:                False when no user exists with the requested
+                              UUID.
+        membership_not_found: True when the user is not a member of this
+                              project.
+        role_not_found:       True when a supplied ``role_id`` doesn't
+                              exist.
+        success:              True when the role was updated.
+    """
+    available: bool = True
+    found: bool = True
+    membership_not_found: bool = False
+    role_not_found: bool = False
+    success: bool = False
+
+
+@dataclass
+class MembershipDeleteResult:
+    """Outcome of a remove-project-membership request.
+
+    Attributes:
+        available:            False when the service is unavailable.
+        found:                False when no user exists with the requested
+                              UUID.
+        membership_not_found: True when the user is not a member of this
+                              project.
+        success:              True when the membership was removed.
+    """
+    available: bool = True
+    found: bool = True
+    membership_not_found: bool = False
+    success: bool = False
+
+
+class ProjectMembershipService:
+    """Manage which projects a user belongs to, and their role on each.
+
+    Distinct from :class:`RoleManagementService`, which manages role
+    *definitions* - this service only manages the assignment of an
+    existing role to a (user, project) membership.
+
+    All public-facing methods identify users by UUID, resolved to the
+    internal integer id before touching :class:`ProjectMemberRepository` -
+    same convention as :class:`UserManagementService`.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 state: ServiceState,
+                 member_repository: ProjectMemberRepository,
+                 user_repository: UserRepository,
+                 role_repository: RoleRepository) -> None:
+        """Initialise the project membership service.
+
+        Args:
+            logger:            Parent logger.
+            state:              Shared service state.
+            member_repository: Repository providing membership data access.
+            user_repository:   Repository used to resolve a UUID to the
+                               user's internal id.
+            role_repository:   Repository used to validate a supplied
+                               ``role_id`` actually exists before writing
+                               it - without this check an invalid
+                               ``role_id`` would surface as a raw foreign
+                               key failure instead of a clean error.
+        """
+        self._logger = logger.getChild(__name__)
+        self._state: ServiceState = state
+        self._repo: ProjectMemberRepository = member_repository
+        self._user_repo: UserRepository = user_repository
+        self._role_repo: RoleRepository = role_repository
+
+    async def _resolve_user_id(self, user_uuid: str) -> Optional[int]:
+        """Resolve a user's UUID to their internal id.
+
+        Args:
+            user_uuid: The user's public UUID string.
+
+        Returns:
+            The internal id if found, otherwise ``None``.
+
+        Raises:
+            SqliteInterfaceException: If the database query fails.
+        """
+        row = await self._user_repo.get_user_by_uuid(user_uuid)
+        return row[0] if row else None
+
+    async def get_memberships(self, user_uuid: str) -> MembershipListResult:
+        """Return every project membership held by a user.
+
+        Args:
+            user_uuid: The user's public UUID string.
+
+        Returns:
+            A :class:`MembershipListResult`.
+        """
+        if not self._state.is_available():
+            return MembershipListResult(available=False)
+
+        try:
+            user_id = await self._resolve_user_id(user_uuid)
+            if user_id is None:
+                return MembershipListResult(found=False)
+
+            rows = await self._repo.get_memberships_for_user(user_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure listing memberships for user %s: %s",
+                user_uuid, ex)
+            self._state.set_service_degraded(
+                "Membership list database unavailable")
+            return MembershipListResult(available=False)
+
+        return MembershipListResult(
+            memberships=[_membership_row_to_dict(r) for r in rows])
+
+    async def add_membership(self,
+                             user_uuid: str,
+                             project_id: int,
+                             role_id: Optional[int] = None
+                             ) -> MembershipCreateResult:
+        """Add a user to a project, optionally assigning a role.
+
+        Args:
+            user_uuid:  The user's public UUID string.
+            project_id: The project's id.
+            role_id:    The role to assign, or ``None`` for "member, no
+                       role assigned yet" (a valid state - see §4.3 of
+                       user_roles_design.md).
+
+        Returns:
+            A :class:`MembershipCreateResult`. ``conflict`` is True if the
+            user is already a member of this project. ``role_not_found``
+            is True if a supplied ``role_id`` doesn't exist.
+        """
+        if not self._state.is_available():
+            return MembershipCreateResult(available=False)
+
+        try:
+            user_id = await self._resolve_user_id(user_uuid)
+            if user_id is None:
+                return MembershipCreateResult(found=False)
+
+            if role_id is not None:
+                if await self._role_repo.get_role_by_id(role_id) is None:
+                    return MembershipCreateResult(role_not_found=True)
+
+            if await self._repo.get_membership(user_id, project_id) is not None:
+                return MembershipCreateResult(conflict=True)
+
+            await self._repo.create_membership(user_id, project_id, role_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure adding user %s to project %d: %s",
+                user_uuid, project_id, ex)
+            self._state.set_service_degraded(
+                "Membership creation database unavailable")
+            return MembershipCreateResult(available=False)
+
+        return MembershipCreateResult(success=True)
+
+    async def update_membership_role(self,
+                                     user_uuid: str,
+                                     project_id: int,
+                                     role_id: Optional[int]
+                                     ) -> MembershipUpdateResult:
+        """Change (or clear) the role on an existing membership.
+
+        Args:
+            user_uuid:  The user's public UUID string.
+            project_id: The project's id.
+            role_id:    The new role, or ``None`` to clear back to
+                       "member, no role assigned".
+
+        Returns:
+            A :class:`MembershipUpdateResult`. ``membership_not_found`` is
+            True if the user is not a member of this project.
+            ``role_not_found`` is True if a supplied ``role_id`` doesn't
+            exist.
+        """
+        if not self._state.is_available():
+            return MembershipUpdateResult(available=False)
+
+        try:
+            user_id = await self._resolve_user_id(user_uuid)
+            if user_id is None:
+                return MembershipUpdateResult(found=False)
+
+            if role_id is not None:
+                if await self._role_repo.get_role_by_id(role_id) is None:
+                    return MembershipUpdateResult(role_not_found=True)
+
+            if await self._repo.get_membership(user_id, project_id) is None:
+                return MembershipUpdateResult(membership_not_found=True)
+
+            await self._repo.update_membership_role(
+                user_id, project_id, role_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure updating membership role for user %s "
+                "on project %d: %s", user_uuid, project_id, ex)
+            self._state.set_service_degraded(
+                "Membership update database unavailable")
+            return MembershipUpdateResult(available=False)
+
+        return MembershipUpdateResult(success=True)
+
+    async def remove_membership(self,
+                                user_uuid: str,
+                                project_id: int) -> MembershipDeleteResult:
+        """Remove a user's membership of a project entirely.
+
+        Args:
+            user_uuid:  The user's public UUID string.
+            project_id: The project's id.
+
+        Returns:
+            A :class:`MembershipDeleteResult`. ``membership_not_found`` is
+            True if the user is not a member of this project.
+        """
+        if not self._state.is_available():
+            return MembershipDeleteResult(available=False)
+
+        try:
+            user_id = await self._resolve_user_id(user_uuid)
+            if user_id is None:
+                return MembershipDeleteResult(found=False)
+
+            if await self._repo.get_membership(user_id, project_id) is None:
+                return MembershipDeleteResult(membership_not_found=True)
+
+            await self._repo.delete_membership(user_id, project_id)
+
+        except SqliteInterfaceException as ex:
+            self._logger.exception(
+                "Database failure removing user %s from project %d: %s",
+                user_uuid, project_id, ex)
+            self._state.set_service_degraded(
+                "Membership deletion database unavailable")
+            return MembershipDeleteResult(available=False)
+
+        return MembershipDeleteResult(success=True)

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 5"
+PRE_RELEASE = "Alpha Build 6"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -967,6 +967,102 @@
                 }
               },
               "response": []
+            },
+            {
+              "name": "List User Projects",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/users/{{USER_UUID}}/projects",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "users",
+                    "{{USER_UUID}}",
+                    "projects"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Add User Project",
+              "request": {
+                "method": "POST",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"project_id\": 1,\n    \"role_id\": {{ROLE_ID}}\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/users/{{USER_UUID}}/projects",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "users",
+                    "{{USER_UUID}}",
+                    "projects"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Change User Project Role",
+              "request": {
+                "method": "PATCH",
+                "header": [],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n    \"role_id\": {{ROLE_ID}}\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/users/{{USER_UUID}}/projects/1",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "users",
+                    "{{USER_UUID}}",
+                    "projects",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
+            },
+            {
+              "name": "Remove User Project",
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{IDENTITY_SVC_URL}}/users/{{USER_UUID}}/projects/1",
+                  "host": [
+                    "{{IDENTITY_SVC_URL}}"
+                  ],
+                  "path": [
+                    "users",
+                    "{{USER_UUID}}",
+                    "projects",
+                    "1"
+                  ]
+                }
+              },
+              "response": []
             }
           ]
         },

--- a/unit_tests/items_identity/main.py
+++ b/unit_tests/items_identity/main.py
@@ -4,6 +4,7 @@ from test_threadsafe_configuration import TestIdentityConfiguration
 from test_da_user_data_access_layer import TestUserRepository
 from test_da_invite_data_access_layer import TestInviteRepository
 from test_da_role_data_access_layer import TestRoleRepository
+from test_da_project_member_data_access_layer import TestProjectMemberRepository
 from test_apis_authentication_api import TestAuthenticatePasswordHandler
 from test_apis_health_api import TestHealthHandler
 from test_services_authentication_service import TestAuthenticationService
@@ -11,6 +12,7 @@ from test_services_user_profile_service import TestUserProfileService
 from test_services_user_management_service import TestUserManagementService
 from test_services_invite_management_service import TestInviteManagementService
 from test_services_role_management_service import TestRoleManagementService
+from test_services_project_membership_service import TestProjectMembershipService
 from test_apis_user_profile_api import TestGetUserProfileHandler
 from test_apis_user_management import (
     TestListUsersHandler,
@@ -26,6 +28,12 @@ from test_apis_role_management import (
     TestCreateRoleHandler,
     TestModifyRoleHandler,
     TestDeleteRoleHandler,
+)
+from test_apis_user_project_management import (
+    TestListUserProjectsHandler,
+    TestAddUserProjectHandler,
+    TestModifyUserProjectHandler,
+    TestRemoveUserProjectHandler,
 )
 from test_apis_invite_management import (
     TestGetInvitesHandler,

--- a/unit_tests/items_identity/test_apis_user_project_management.py
+++ b/unit_tests/items_identity/test_apis_user_project_management.py
@@ -1,0 +1,308 @@
+"""
+Handler-level tests for the project membership API endpoints:
+  GET    /users/<uuid>/projects              - ListUserProjectsHandler
+  POST   /users/<uuid>/projects              - AddUserProjectHandler
+  PATCH  /users/<uuid>/projects/<project_id> - ModifyUserProjectHandler
+  DELETE /users/<uuid>/projects/<project_id> - RemoveUserProjectHandler
+"""
+import unittest
+import json
+import logging
+from http import HTTPStatus
+from unittest.mock import patch, MagicMock, AsyncMock
+from quart import Response
+from routes.users.list_user_projects_handler import ListUserProjectsHandler
+from routes.users.add_user_project_handler import AddUserProjectHandler
+from routes.users.modify_user_project_handler import ModifyUserProjectHandler
+from routes.users.remove_user_project_handler import RemoveUserProjectHandler
+from services.project_membership_service import (
+    MembershipListResult,
+    MembershipCreateResult,
+    MembershipUpdateResult,
+    MembershipDeleteResult,
+)
+
+_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+_MEMBERSHIP_DICT = {"project_id": 5, "role_id": 2, "role_name": "Tester"}
+
+
+def _undecorated(method):
+    """Return the original function if it's wrapped by a decorator."""
+    return getattr(method, "__wrapped__", method)
+
+
+def _make_handler_setup(handler_cls):
+    """Return an asyncSetUp that wires up a handler with mocked service."""
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_logger.getChild.return_value = MagicMock(spec=logging.Logger)
+        self.mock_state = MagicMock()
+        self.mock_config = MagicMock()
+
+        module_name = handler_cls.__module__.split('.')[-1]
+        member_repo_patch = patch(
+            f"routes.users.{module_name}.ProjectMemberRepository",
+            autospec=True)
+        user_repo_patch = patch(
+            f"routes.users.{module_name}.UserRepository", autospec=True)
+        role_repo_patch = patch(
+            f"routes.users.{module_name}.RoleRepository", autospec=True)
+        svc_patch = patch(
+            f"routes.users.{module_name}.ProjectMembershipService",
+            autospec=True)
+        for p in (member_repo_patch, user_repo_patch, role_repo_patch,
+                  svc_patch):
+            self.addCleanup(p.stop)
+        member_repo_patch.start()
+        user_repo_patch.start()
+        role_repo_patch.start()
+        self.mock_svc_cls = svc_patch.start()
+
+        self.mock_svc = MagicMock()
+        self.mock_svc_cls.return_value = self.mock_svc
+
+        self.handler = handler_cls(
+            self.mock_logger, self.mock_state, self.mock_config)
+
+    return asyncSetUp
+
+
+# ---------------------------------------------------------------------------
+# ListUserProjectsHandler
+# ---------------------------------------------------------------------------
+
+class TestListUserProjectsHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(ListUserProjectsHandler)
+
+    async def _call(self, result: MembershipListResult,
+                    user_id: str = _UUID) -> Response:
+        self.mock_svc.get_memberships = AsyncMock(return_value=result)
+        return await self.handler.list_user_projects(user_id)
+
+    async def test_success_returns_200_with_memberships(self):
+        resp = await self._call(
+            MembershipListResult(memberships=[_MEMBERSHIP_DICT]))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["memberships"], [_MEMBERSHIP_DICT])
+
+    async def test_empty_list_returns_200(self):
+        resp = await self._call(MembershipListResult(memberships=[]))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["memberships"], [])
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(MembershipListResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(MembershipListResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_user_id_passed_to_service(self):
+        self.mock_svc.get_memberships = AsyncMock(
+            return_value=MembershipListResult(memberships=[]))
+        await self.handler.list_user_projects(_UUID)
+        self.mock_svc.get_memberships.assert_awaited_once_with(_UUID)
+
+    async def test_response_is_json(self):
+        resp = await self._call(MembershipListResult(memberships=[]))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# AddUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestAddUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(AddUserProjectHandler)
+
+    def _request(self, **overrides):
+        body = {"project_id": 5}
+        body.update(overrides)
+        mock_req = MagicMock()
+        mock_req.body = body
+        return mock_req
+
+    async def _call(self, result: MembershipCreateResult,
+                    user_id: str = _UUID, **body_overrides) -> Response:
+        self.mock_svc.add_membership = AsyncMock(return_value=result)
+        target = _undecorated(self.handler.add_user_project)
+        return await target(self.handler, self._request(**body_overrides),
+                            user_id)
+
+    async def test_success_returns_201(self):
+        resp = await self._call(MembershipCreateResult(success=True))
+        self.assertEqual(resp.status_code, HTTPStatus.CREATED)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(MembershipCreateResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_role_not_found_returns_400(self):
+        resp = await self._call(MembershipCreateResult(role_not_found=True))
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_conflict_returns_409(self):
+        resp = await self._call(MembershipCreateResult(conflict=True))
+        self.assertEqual(resp.status_code, HTTPStatus.CONFLICT)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(MembershipCreateResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_role_id_defaults_to_none_when_absent(self):
+        await self._call(MembershipCreateResult(success=True))
+        kwargs = self.mock_svc.add_membership.call_args[1]
+        self.assertIsNone(kwargs["role_id"])
+
+    async def test_role_id_passed_when_provided(self):
+        await self._call(MembershipCreateResult(success=True), role_id=3)
+        kwargs = self.mock_svc.add_membership.call_args[1]
+        self.assertEqual(kwargs["role_id"], 3)
+
+    async def test_project_id_passed_to_service(self):
+        await self._call(MembershipCreateResult(success=True))
+        kwargs = self.mock_svc.add_membership.call_args[1]
+        self.assertEqual(kwargs["project_id"], 5)
+
+    async def test_user_id_passed_to_service(self):
+        await self._call(MembershipCreateResult(success=True), user_id=_UUID)
+        kwargs = self.mock_svc.add_membership.call_args[1]
+        self.assertEqual(kwargs["user_uuid"], _UUID)
+
+    async def test_response_is_json(self):
+        resp = await self._call(MembershipCreateResult(success=True))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# ModifyUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestModifyUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(ModifyUserProjectHandler)
+
+    def _request(self, role_id):
+        mock_req = MagicMock()
+        mock_req.body = {"role_id": role_id}
+        return mock_req
+
+    async def _call(self, result: MembershipUpdateResult, role_id=2,
+                    user_id: str = _UUID, project_id: int = 5) -> Response:
+        self.mock_svc.update_membership_role = AsyncMock(return_value=result)
+        target = _undecorated(self.handler.modify_user_project)
+        return await target(self.handler, self._request(role_id),
+                            user_id, project_id)
+
+    async def test_success_returns_200(self):
+        resp = await self._call(MembershipUpdateResult(success=True))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(MembershipUpdateResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+
+    async def test_role_not_found_returns_400(self):
+        resp = await self._call(MembershipUpdateResult(role_not_found=True))
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+
+    async def test_membership_not_found_returns_404(self):
+        resp = await self._call(
+            MembershipUpdateResult(membership_not_found=True))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(MembershipUpdateResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_role_not_found_takes_precedence_over_membership_not_found(self):
+        resp = await self._call(MembershipUpdateResult(
+            role_not_found=True, membership_not_found=True))
+        self.assertEqual(resp.status_code, HTTPStatus.BAD_REQUEST)
+
+    async def test_role_id_none_is_passed_through_to_clear_role(self):
+        await self._call(MembershipUpdateResult(success=True), role_id=None)
+        kwargs = self.mock_svc.update_membership_role.call_args[1]
+        self.assertIsNone(kwargs["role_id"])
+
+    async def test_user_id_and_project_id_passed_to_service(self):
+        await self._call(MembershipUpdateResult(success=True),
+                         user_id=_UUID, project_id=9)
+        kwargs = self.mock_svc.update_membership_role.call_args[1]
+        self.assertEqual(kwargs["user_uuid"], _UUID)
+        self.assertEqual(kwargs["project_id"], 9)
+
+    async def test_response_is_json(self):
+        resp = await self._call(MembershipUpdateResult(success=True))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# RemoveUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestRemoveUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    asyncSetUp = _make_handler_setup(RemoveUserProjectHandler)
+
+    async def _call(self, result: MembershipDeleteResult,
+                    user_id: str = _UUID, project_id: int = 5) -> Response:
+        self.mock_svc.remove_membership = AsyncMock(return_value=result)
+        return await self.handler.remove_user_project(user_id, project_id)
+
+    async def test_success_returns_200(self):
+        resp = await self._call(MembershipDeleteResult(success=True))
+        self.assertEqual(resp.status_code, HTTPStatus.OK)
+
+    async def test_not_found_returns_404(self):
+        resp = await self._call(MembershipDeleteResult(found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_membership_not_found_returns_404(self):
+        resp = await self._call(
+            MembershipDeleteResult(membership_not_found=True))
+        self.assertEqual(resp.status_code, HTTPStatus.NOT_FOUND)
+        body = json.loads(await resp.get_data())
+        self.assertIn("error", body)
+
+    async def test_unavailable_returns_503(self):
+        resp = await self._call(MembershipDeleteResult(available=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_unavailable_takes_precedence_over_not_found(self):
+        resp = await self._call(
+            MembershipDeleteResult(available=False, found=False))
+        self.assertEqual(resp.status_code, HTTPStatus.SERVICE_UNAVAILABLE)
+
+    async def test_user_id_and_project_id_passed_to_service(self):
+        self.mock_svc.remove_membership = AsyncMock(
+            return_value=MembershipDeleteResult(success=True))
+        await self.handler.remove_user_project(_UUID, 9)
+        self.mock_svc.remove_membership.assert_awaited_once_with(
+            user_uuid=_UUID, project_id=9)
+
+    async def test_response_is_json(self):
+        resp = await self._call(MembershipDeleteResult(success=True))
+        self.assertEqual(resp.content_type, "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_identity/test_create_routes.py
+++ b/unit_tests/items_identity/test_create_routes.py
@@ -98,19 +98,42 @@ class TestCreateSystemRoutes(unittest.IsolatedAsyncioTestCase):
         mock_handler.health.assert_called_once()
 
 
+_USERS_HANDLER_PATCHES = (
+    "routes.users.GetUserProfileHandler",
+    "routes.users.ListUsersHandler",
+    "routes.users.GetUserHandler",
+    "routes.users.CreateUserHandler",
+    "routes.users.ModifyUserHandler",
+    "routes.users.ResetPasswordHandler",
+    "routes.users.ChangePasswordHandler",
+    "routes.users.ListUserProjectsHandler",
+    "routes.users.AddUserProjectHandler",
+    "routes.users.ModifyUserProjectHandler",
+    "routes.users.RemoveUserProjectHandler",
+)
+
+
+def _patch_all_users_handlers(func):
+    """Apply every users-blueprint handler patch to a test method.
+
+    Args are supplied to the wrapped test innermost-decorator-first, i.e.
+    in the same order as ``_USERS_HANDLER_PATCHES`` reversed - the same
+    order used throughout this class already (profile, list, get, create,
+    modify, reset, change, list_projects, add_project, modify_project,
+    remove_project).
+    """
+    for target in _USERS_HANDLER_PATCHES:
+        func = patch(target)(func)
+    return func
+
+
 class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.mock_logger = MagicMock(spec=logging.Logger)
         self.mock_state = MagicMock()
         self.mock_config = MagicMock()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_returns_blueprint_with_correct_name(
             self, *_mocks):
         bp = create_users_routes(self.mock_logger, self.mock_state,
@@ -118,46 +141,31 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
         self.assertIsInstance(bp, quart.Blueprint)
         self.assertEqual(bp.name, "users_routes")
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_initialises_all_handlers_with_correct_args(
             self, mock_profile, mock_list, mock_get, mock_create,
-            mock_modify, mock_reset, mock_change):
+            mock_modify, mock_reset, mock_change, mock_list_projects,
+            mock_add_project, mock_modify_project, mock_remove_project):
         create_users_routes(self.mock_logger, self.mock_state, self.mock_config)
         for mock_cls in (mock_profile, mock_list, mock_get, mock_create,
-                         mock_modify, mock_reset, mock_change):
+                         mock_modify, mock_reset, mock_change,
+                         mock_list_projects, mock_add_project,
+                         mock_modify_project, mock_remove_project):
             mock_cls.assert_called_once_with(
                 self.mock_logger, self.mock_state, self.mock_config)
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_logs_route_registration(self, *_mocks):
         create_users_routes(self.mock_logger, self.mock_state, self.mock_config)
         self.mock_logger.debug.assert_called()
 
-    def _ok_response(self, body=None):
+    def _ok_response(self, body=None, status=200):
         return Response(
             json.dumps(body or {"status": "ok"}),
-            status=200,
+            status=status,
             content_type="application/json")
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_get_user_profile(
             self, mock_profile_cls, *_rest):
         mock_handler = MagicMock()
@@ -176,13 +184,7 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.get_user_profile.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_list_users(
             self, _profile, mock_list_cls, *_rest):
         mock_handler = MagicMock()
@@ -200,13 +202,7 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.list_users.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_create_user(
             self, _profile, _list, _get, mock_create_cls, *_rest):
         mock_handler = MagicMock()
@@ -228,13 +224,7 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.create_user.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_get_user(
             self, _profile, _list, mock_get_cls, *_rest):
         mock_handler = MagicMock()
@@ -252,13 +242,7 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.get_user.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_modify_user(
             self, _profile, _list, _get, _create, mock_modify_cls, *_rest):
         mock_handler = MagicMock()
@@ -279,16 +263,10 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.modify_user.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_reset_password(
             self, _profile, _list, _get, _create, _modify,
-            mock_reset_cls, _change):
+            mock_reset_cls, *_rest):
         mock_handler = MagicMock()
         mock_handler.reset_password = AsyncMock(
             return_value=self._ok_response())
@@ -305,16 +283,10 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
 
         mock_handler.reset_password.assert_called_once()
 
-    @patch("routes.users.ChangePasswordHandler")
-    @patch("routes.users.ResetPasswordHandler")
-    @patch("routes.users.ModifyUserHandler")
-    @patch("routes.users.CreateUserHandler")
-    @patch("routes.users.GetUserHandler")
-    @patch("routes.users.ListUsersHandler")
-    @patch("routes.users.GetUserProfileHandler")
+    @_patch_all_users_handlers
     async def test_route_handler_calls_change_password(
             self, _profile, _list, _get, _create, _modify,
-            _reset, mock_change_cls):
+            _reset, mock_change_cls, *_rest):
         mock_handler = MagicMock()
         mock_handler.change_password = AsyncMock(
             return_value=self._ok_response())
@@ -331,6 +303,84 @@ class TestCreateUsersRoutes(unittest.IsolatedAsyncioTestCase):
                 "new_password": "newpass123"})
 
         mock_handler.change_password.assert_called_once()
+
+    @_patch_all_users_handlers
+    async def test_route_handler_calls_list_user_projects(
+            self, _profile, _list, _get, _create, _modify, _reset,
+            _change, mock_list_projects_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.list_user_projects = AsyncMock(
+            return_value=self._ok_response({"memberships": []}))
+        mock_list_projects_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_users_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.get("/users/1/projects")
+
+        mock_handler.list_user_projects.assert_called_once()
+
+    @_patch_all_users_handlers
+    async def test_route_handler_calls_add_user_project(
+            self, _profile, _list, _get, _create, _modify, _reset,
+            _change, _list_projects, mock_add_project_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.add_user_project = AsyncMock(
+            return_value=self._ok_response(status=201))
+        mock_add_project_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_users_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.post("/users/1/projects", json={"project_id": 5})
+
+        mock_handler.add_user_project.assert_called_once()
+
+    @_patch_all_users_handlers
+    async def test_route_handler_calls_modify_user_project(
+            self, _profile, _list, _get, _create, _modify, _reset,
+            _change, _list_projects, _add_project,
+            mock_modify_project_cls, *_rest):
+        mock_handler = MagicMock()
+        mock_handler.modify_user_project = AsyncMock(
+            return_value=self._ok_response())
+        mock_modify_project_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_users_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.patch("/users/1/projects/5", json={"role_id": 2})
+
+        mock_handler.modify_user_project.assert_called_once()
+
+    @_patch_all_users_handlers
+    async def test_route_handler_calls_remove_user_project(
+            self, _profile, _list, _get, _create, _modify, _reset,
+            _change, _list_projects, _add_project, _modify_project,
+            mock_remove_project_cls):
+        mock_handler = MagicMock()
+        mock_handler.remove_user_project = AsyncMock(
+            return_value=self._ok_response())
+        mock_remove_project_cls.return_value = mock_handler
+
+        app = quart.Quart(__name__)
+        bp = create_users_routes(self.mock_logger, self.mock_state,
+                                 self.mock_config)
+        app.register_blueprint(bp)
+
+        async with app.test_client() as client:
+            await client.delete("/users/1/projects/5")
+
+        mock_handler.remove_user_project.assert_called_once()
 
 
 class TestCreateRolesRoutes(unittest.IsolatedAsyncioTestCase):

--- a/unit_tests/items_identity/test_da_project_member_data_access_layer.py
+++ b/unit_tests/items_identity/test_da_project_member_data_access_layer.py
@@ -1,0 +1,122 @@
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch
+import logging
+from data_access.project_member_repository import ProjectMemberRepository
+
+
+class TestProjectMemberRepository(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.logger = logging.getLogger("test")
+        self.mock_config = MagicMock()
+        self.mock_config.backend_db_filename = "test.db"
+
+        self.mock_db = MagicMock()
+        self.mock_db.run_query = AsyncMock()
+        self.mock_db.insert_query = AsyncMock()
+        self.mock_db.delete_query = AsyncMock()
+
+        patcher = patch(
+            "data_access.project_member_repository.SqliteInterface",
+            return_value=self.mock_db)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        self.repo = ProjectMemberRepository(self.logger, self.mock_config)
+
+    # -------------------------------------------------------
+    # get_memberships_for_user
+    # -------------------------------------------------------
+
+    async def test_get_memberships_for_user_returns_empty_list_when_none(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_memberships_for_user(1)
+        self.assertEqual(result, [])
+
+    async def test_get_memberships_for_user_returns_rows(self):
+        expected = [(1, 5, 2, "Tester"), (2, 7, None, None)]
+        self.mock_db.run_query.return_value = expected
+        result = await self.repo.get_memberships_for_user(1)
+        self.assertEqual(result, expected)
+
+    async def test_get_memberships_for_user_passes_correct_query(self):
+        self.mock_db.run_query.return_value = []
+        await self.repo.get_memberships_for_user(9)
+        self.mock_db.run_query.assert_called_once_with(
+            ProjectMemberRepository.GET_MEMBERSHIPS_FOR_USER_QUERY, (9,))
+
+    # -------------------------------------------------------
+    # get_membership
+    # -------------------------------------------------------
+
+    async def test_get_membership_returns_none_when_not_found(self):
+        self.mock_db.run_query.return_value = None
+        result = await self.repo.get_membership(1, 5)
+        self.assertIsNone(result)
+
+    async def test_get_membership_returns_row(self):
+        self.mock_db.run_query.return_value = (1, 2, "Tester")
+        result = await self.repo.get_membership(1, 5)
+        self.assertEqual(result, (1, 2, "Tester"))
+
+    async def test_get_membership_passes_correct_query(self):
+        self.mock_db.run_query.return_value = None
+        await self.repo.get_membership(1, 5)
+        self.mock_db.run_query.assert_called_once_with(
+            ProjectMemberRepository.GET_MEMBERSHIP_QUERY, (1, 5),
+            fetch_one=True)
+
+    # -------------------------------------------------------
+    # create_membership
+    # -------------------------------------------------------
+
+    async def test_create_membership_returns_new_id(self):
+        self.mock_db.insert_query.return_value = 42
+        result = await self.repo.create_membership(1, 5, 2)
+        self.assertEqual(result, 42)
+
+    async def test_create_membership_passes_correct_query(self):
+        self.mock_db.insert_query.return_value = 1
+        await self.repo.create_membership(1, 5, 2)
+        self.mock_db.insert_query.assert_awaited_once_with(
+            ProjectMemberRepository.INSERT_MEMBERSHIP_QUERY, (1, 5, 2))
+
+    async def test_create_membership_with_no_role(self):
+        self.mock_db.insert_query.return_value = 1
+        await self.repo.create_membership(1, 5, None)
+        self.mock_db.insert_query.assert_awaited_once_with(
+            ProjectMemberRepository.INSERT_MEMBERSHIP_QUERY, (1, 5, None))
+
+    async def test_membership_insert_always_uses_user_principal_type(self):
+        """v1 is users-only - the query hardcodes 'user', not a parameter."""
+        self.assertIn("'user'",
+                      ProjectMemberRepository.INSERT_MEMBERSHIP_QUERY)
+
+    # -------------------------------------------------------
+    # update_membership_role
+    # -------------------------------------------------------
+
+    async def test_update_membership_role_passes_correct_query(self):
+        await self.repo.update_membership_role(1, 5, 3)
+        self.mock_db.run_query.assert_awaited_once_with(
+            ProjectMemberRepository.UPDATE_MEMBERSHIP_ROLE_QUERY,
+            (3, 1, 5), commit=True)
+
+    async def test_update_membership_role_can_clear_to_none(self):
+        await self.repo.update_membership_role(1, 5, None)
+        self.mock_db.run_query.assert_awaited_once_with(
+            ProjectMemberRepository.UPDATE_MEMBERSHIP_ROLE_QUERY,
+            (None, 1, 5), commit=True)
+
+    # -------------------------------------------------------
+    # delete_membership
+    # -------------------------------------------------------
+
+    async def test_delete_membership_passes_correct_query(self):
+        await self.repo.delete_membership(1, 5)
+        self.mock_db.delete_query.assert_awaited_once_with(
+            ProjectMemberRepository.DELETE_MEMBERSHIP_QUERY, (1, 5))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_identity/test_services_project_membership_service.py
+++ b/unit_tests/items_identity/test_services_project_membership_service.py
@@ -1,0 +1,238 @@
+import unittest
+import logging
+from unittest.mock import MagicMock, AsyncMock
+from weaver_framework.database.sqlite_interface import SqliteInterfaceException
+from services.project_membership_service import (
+    ProjectMembershipService,
+    MembershipListResult,
+    MembershipCreateResult,
+    MembershipUpdateResult,
+    MembershipDeleteResult,
+)
+
+_UUID = "550e8400-e29b-41d4-a716-446655440000"
+
+# UserRepository.get_user_by_uuid row shape:
+# (id, uuid, email_address, full_name, display_name, account_status,
+#  logon_type, is_administrator)
+_USER_ROW = (1, _UUID, "a@b.com", "Full Name", "Display", 1, 0, 0)
+
+# ProjectMemberRepository row shapes:
+_MEMBERSHIP_ROW_WITH_ROLE = (10, 5, 2, "Tester")   # (id, project_id, role_id, role_name)
+_MEMBERSHIP_ROW_NO_ROLE = (11, 7, None, None)
+
+
+class TestProjectMembershipService(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_logger = MagicMock(spec=logging.Logger)
+        self.mock_logger.getChild.return_value = MagicMock(spec=logging.Logger)
+
+        self.mock_state = MagicMock()
+        self.mock_state.is_available.return_value = True
+
+        self.mock_member_repo = MagicMock()
+        self.mock_member_repo.get_memberships_for_user = AsyncMock()
+        self.mock_member_repo.get_membership = AsyncMock()
+        self.mock_member_repo.create_membership = AsyncMock()
+        self.mock_member_repo.update_membership_role = AsyncMock()
+        self.mock_member_repo.delete_membership = AsyncMock()
+
+        self.mock_user_repo = MagicMock()
+        self.mock_user_repo.get_user_by_uuid = AsyncMock(
+            return_value=_USER_ROW)
+
+        self.mock_role_repo = MagicMock()
+        self.mock_role_repo.get_role_by_id = AsyncMock(
+            return_value=(2, "Tester"))
+
+        self.svc = ProjectMembershipService(
+            self.mock_logger, self.mock_state,
+            self.mock_member_repo, self.mock_user_repo, self.mock_role_repo)
+
+    # -------------------------------------------------------
+    # get_memberships
+    # -------------------------------------------------------
+
+    async def test_get_memberships_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.get_memberships(_UUID)
+        self.assertFalse(result.available)
+
+    async def test_get_memberships_not_found_when_user_missing(self):
+        self.mock_user_repo.get_user_by_uuid.return_value = None
+        result = await self.svc.get_memberships(_UUID)
+        self.assertFalse(result.found)
+        self.mock_member_repo.get_memberships_for_user.assert_not_called()
+
+    async def test_get_memberships_returns_empty_list(self):
+        self.mock_member_repo.get_memberships_for_user.return_value = []
+        result = await self.svc.get_memberships(_UUID)
+        self.assertEqual(result.memberships, [])
+
+    async def test_get_memberships_returns_dicts_with_role(self):
+        self.mock_member_repo.get_memberships_for_user.return_value = [
+            _MEMBERSHIP_ROW_WITH_ROLE]
+        result = await self.svc.get_memberships(_UUID)
+        self.assertEqual(result.memberships,
+                         [{"project_id": 5, "role_id": 2, "role_name": "Tester"}])
+
+    async def test_get_memberships_returns_dicts_with_no_role(self):
+        self.mock_member_repo.get_memberships_for_user.return_value = [
+            _MEMBERSHIP_ROW_NO_ROLE]
+        result = await self.svc.get_memberships(_UUID)
+        self.assertEqual(result.memberships,
+                         [{"project_id": 7, "role_id": None, "role_name": None}])
+
+    async def test_get_memberships_uses_internal_id_not_uuid(self):
+        self.mock_member_repo.get_memberships_for_user.return_value = []
+        await self.svc.get_memberships(_UUID)
+        self.mock_member_repo.get_memberships_for_user.assert_awaited_once_with(
+            _USER_ROW[0])
+
+    async def test_get_memberships_unavailable_on_db_exception(self):
+        self.mock_member_repo.get_memberships_for_user.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.svc.get_memberships(_UUID)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # add_membership
+    # -------------------------------------------------------
+
+    async def test_add_membership_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.add_membership(_UUID, 5)
+        self.assertFalse(result.available)
+
+    async def test_add_membership_not_found_when_user_missing(self):
+        self.mock_user_repo.get_user_by_uuid.return_value = None
+        result = await self.svc.add_membership(_UUID, 5)
+        self.assertFalse(result.found)
+        self.mock_member_repo.create_membership.assert_not_called()
+
+    async def test_add_membership_success_with_role(self):
+        self.mock_member_repo.get_membership.return_value = None
+        result = await self.svc.add_membership(_UUID, 5, role_id=2)
+        self.assertTrue(result.success)
+        self.mock_member_repo.create_membership.assert_awaited_once_with(
+            _USER_ROW[0], 5, 2)
+
+    async def test_add_membership_success_without_role(self):
+        self.mock_member_repo.get_membership.return_value = None
+        result = await self.svc.add_membership(_UUID, 5)
+        self.assertTrue(result.success)
+        self.mock_role_repo.get_role_by_id.assert_not_called()
+        self.mock_member_repo.create_membership.assert_awaited_once_with(
+            _USER_ROW[0], 5, None)
+
+    async def test_add_membership_role_not_found(self):
+        self.mock_role_repo.get_role_by_id.return_value = None
+        result = await self.svc.add_membership(_UUID, 5, role_id=999)
+        self.assertTrue(result.role_not_found)
+        self.mock_member_repo.get_membership.assert_not_called()
+        self.mock_member_repo.create_membership.assert_not_called()
+
+    async def test_add_membership_conflict_when_already_a_member(self):
+        self.mock_member_repo.get_membership.return_value = (
+            _MEMBERSHIP_ROW_WITH_ROLE)
+        result = await self.svc.add_membership(_UUID, 5)
+        self.assertTrue(result.conflict)
+        self.mock_member_repo.create_membership.assert_not_called()
+
+    async def test_add_membership_unavailable_on_db_exception(self):
+        self.mock_member_repo.get_membership.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.svc.add_membership(_UUID, 5)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # update_membership_role
+    # -------------------------------------------------------
+
+    async def test_update_membership_role_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.update_membership_role(_UUID, 5, 2)
+        self.assertFalse(result.available)
+
+    async def test_update_membership_role_not_found_when_user_missing(self):
+        self.mock_user_repo.get_user_by_uuid.return_value = None
+        result = await self.svc.update_membership_role(_UUID, 5, 2)
+        self.assertFalse(result.found)
+
+    async def test_update_membership_role_role_not_found(self):
+        self.mock_role_repo.get_role_by_id.return_value = None
+        result = await self.svc.update_membership_role(_UUID, 5, 999)
+        self.assertTrue(result.role_not_found)
+        self.mock_member_repo.get_membership.assert_not_called()
+
+    async def test_update_membership_role_membership_not_found(self):
+        self.mock_member_repo.get_membership.return_value = None
+        result = await self.svc.update_membership_role(_UUID, 5, 2)
+        self.assertTrue(result.membership_not_found)
+        self.mock_member_repo.update_membership_role.assert_not_called()
+
+    async def test_update_membership_role_success(self):
+        self.mock_member_repo.get_membership.return_value = (
+            _MEMBERSHIP_ROW_WITH_ROLE)
+        result = await self.svc.update_membership_role(_UUID, 5, 3)
+        self.assertTrue(result.success)
+        self.mock_member_repo.update_membership_role.assert_awaited_once_with(
+            _USER_ROW[0], 5, 3)
+
+    async def test_update_membership_role_can_clear_to_none(self):
+        self.mock_member_repo.get_membership.return_value = (
+            _MEMBERSHIP_ROW_WITH_ROLE)
+        result = await self.svc.update_membership_role(_UUID, 5, None)
+        self.assertTrue(result.success)
+        self.mock_role_repo.get_role_by_id.assert_not_called()
+        self.mock_member_repo.update_membership_role.assert_awaited_once_with(
+            _USER_ROW[0], 5, None)
+
+    async def test_update_membership_role_unavailable_on_db_exception(self):
+        self.mock_member_repo.get_membership.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.svc.update_membership_role(_UUID, 5, 2)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+    # -------------------------------------------------------
+    # remove_membership
+    # -------------------------------------------------------
+
+    async def test_remove_membership_unavailable_when_state_unavailable(self):
+        self.mock_state.is_available.return_value = False
+        result = await self.svc.remove_membership(_UUID, 5)
+        self.assertFalse(result.available)
+
+    async def test_remove_membership_not_found_when_user_missing(self):
+        self.mock_user_repo.get_user_by_uuid.return_value = None
+        result = await self.svc.remove_membership(_UUID, 5)
+        self.assertFalse(result.found)
+
+    async def test_remove_membership_membership_not_found(self):
+        self.mock_member_repo.get_membership.return_value = None
+        result = await self.svc.remove_membership(_UUID, 5)
+        self.assertTrue(result.membership_not_found)
+        self.mock_member_repo.delete_membership.assert_not_called()
+
+    async def test_remove_membership_success(self):
+        self.mock_member_repo.get_membership.return_value = (
+            _MEMBERSHIP_ROW_WITH_ROLE)
+        result = await self.svc.remove_membership(_UUID, 5)
+        self.assertTrue(result.success)
+        self.mock_member_repo.delete_membership.assert_awaited_once_with(
+            _USER_ROW[0], 5)
+
+    async def test_remove_membership_unavailable_on_db_exception(self):
+        self.mock_member_repo.get_membership.side_effect = (
+            SqliteInterfaceException("err"))
+        result = await self.svc.remove_membership(_UUID, 5)
+        self.assertFalse(result.available)
+        self.mock_state.set_service_degraded.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Identity: project membership

**Branch:** `identity_project_membership` → `main`
**Theme:** Roles & permissions (post-0.3.0) — third application-code piece,
built on the schema from `identity_roles_db_update` and the role CRUD from
`identity_roles_crud`

## Summary

Assigning a user to a project, and optionally a role on that project.
Distinct from role *definitions* (`identity_roles_crud`) - this is only
the `project_members` side: who's on which project, and what role (if
any) they hold there.

Nests under `/users/<user_id>/`, matching the existing
`POST /users/<user_id>/password` precedent - lives in `routes/users/`
rather than a new top-level folder, since the URL shape already implies
that's where it belongs.

## API shape

- `GET    /users/<user_id>/projects` - list a user's memberships.
- `POST   /users/<user_id>/projects` - add the user to a project,
  `role_id` optional (omitted or `null` = "member, no role assigned yet" -
  a valid state per §4.3 of `user_roles_design.md`, not a placeholder).
- `PATCH  /users/<user_id>/projects/<project_id>` - change the role.
  `role_id` is *required* in the body here (unlike every other PATCH in
  this codebase, which is multi-field patch-style with everything
  optional) - this endpoint's only job is changing the role, and `null`
  is how you clear it back to "no role assigned", so leaving the field
  out would be ambiguous about intent rather than a no-op.
- `DELETE /users/<user_id>/projects/<project_id>` - remove the membership
  entirely.

`user_id` is the UUID, matching every other `/users/<user_id>` route -
resolved to the internal integer id via the existing `UserRepository`
before touching membership data, same division of responsibility already
used for `user_auth_details`.

## Identity

- **`data_access/project_member_repository.py`** (new) -
  `ProjectMemberRepository`. Every query hardcodes `principal_type =
  'user'` rather than accepting it as a parameter - v1 is users-only
  (§7.2), and the schema already supports `'group'` for later without
  this repository needing to expose that flexibility now. Membership
  reads `LEFT JOIN roles` so a listing includes the role's name directly,
  not just its id - avoids an N+1 lookup for whatever eventually renders
  this (the web portal's "Projects" tab, still a placeholder).
- **`services/project_membership_service.py`** (new) -
  `ProjectMembershipService`, four result dataclasses
  (`MembershipListResult`, `MembershipCreateResult`,
  `MembershipUpdateResult`, `MembershipDeleteResult`). Takes three
  repositories - the new one, plus `UserRepository` (UUID resolution) and
  `RoleRepository` (validates a supplied `role_id` actually exists before
  writing it). That validation matters: `project_members.role_id` is a
  real foreign key and `PRAGMA foreign_keys = ON` is set on every
  connection (confirmed by reading `weaver_framework`'s
  `SqliteInterface` directly), so an invalid `role_id` would otherwise
  surface as a raw constraint-failure 500 instead of a clean 400.
- **`routes/users/`** - four new handlers
  (`ListUserProjectsHandler`, `AddUserProjectHandler`,
  `ModifyUserProjectHandler`, `RemoveUserProjectHandler`) plus two new
  schemas in the existing `schemas.py`. Wired into the existing
  `create_users_routes` alongside everything else already there.

## Verified against a real database, not just mocks

Every repository/service test mocks the database layer, so built a
throwaway database with the updated `db_builder` and exercised the real
repository code directly against real SQLite:

- The `LEFT JOIN roles` query correctly returns the role name alongside a
  membership.
- A membership with no role shows `(id, None, None)`, exactly as designed.
- **Deleting a role while a membership points at it actually triggers
  `ON DELETE SET NULL`** - the membership survives, `role_id` clears to
  `NULL`. This is the one behaviour that's easy to get schematically
  right and still have wrong in practice (e.g. via `PRAGMA foreign_keys`
  not actually being on), so it was worth confirming for real rather than
  trusting the schema text.
- Clearing a role back to `None` and removing a membership entirely both
  behave as expected.

## Postman

Four new requests under `Identity Service / Users`: List User Projects,
Add User Project, Change User Project Role, Remove User Project. Added as
a targeted text edit (not a full re-serialise) - same lesson as the two
earlier Postman mishaps this theme, not repeated a third time.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

New: `test_da_project_member_data_access_layer.py`,
`test_services_project_membership_service.py`,
`test_apis_user_project_management.py`. `TestCreateUsersRoutes` in
`test_create_routes.py` needed every existing test's patch stack extended
to cover the four new handlers - refactored into a shared
`_patch_all_users_handlers` decorator instead of hand-editing eleven
`@patch` stacks across nine test methods. Caught and fixed one ordering
bug in that refactor before it shipped: `unittest.mock`'s decorator
stacking applies bottom-most-first, so the patch tuple had to list
handlers in the same order as the target functions' parameters, not
reversed - verified empirically against a real patchable target rather
than trusting my own reasoning about it.

**444 tests, OK (up from 369). 100% coverage maintained** across
`items_identity` (1615/1615 statements). Pylint: 10.00/10.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
