### PR TITLE
[Gateway] Proxy routes for user roles to identity

### DIFF
--- a/items/services/items_gateway/routes/web/__init__.py
+++ b/items/services/items_gateway/routes/web/__init__.py
@@ -20,6 +20,8 @@ from items.services.items_gateway.routes.web.invites import (
     create_invite_routes)
 from items.services.items_gateway.routes.web.projects import (
     create_projects_routes)
+from items.services.items_gateway.routes.web.roles import (
+    create_roles_routes)
 from items.services.items_gateway.routes.web.sessions import (
     create_sessions_routes)
 from items.services.items_gateway.routes.web.testcase_custom_fields import (
@@ -57,6 +59,9 @@ def create_web_routes(injections: RouteInjections) -> quart.Blueprint:
         injections.configuration,
         injections.rest_client,
         injections.sessions))
+
+    # Register role routes.
+    routes_bp.register_blueprint(create_roles_routes(injections))
 
     # Register sessions routes.
     routes_bp.register_blueprint(create_sessions_routes(injections.logger,

--- a/items/services/items_gateway/routes/web/roles/__init__.py
+++ b/items/services/items_gateway/routes/web/roles/__init__.py
@@ -1,0 +1,107 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from quart import Blueprint
+from items.services.items_gateway.auth_decorators import require_administrator
+from items.services.items_gateway.route_injections import RouteInjections
+from items.services.items_gateway.routes.web.roles.list_roles_handler import (
+    ListRolesHandler)
+from items.services.items_gateway.routes.web.roles.get_role_handler import (
+    GetRoleHandler)
+from items.services.items_gateway.routes.web.roles.create_role_handler import (
+    CreateRoleHandler)
+from items.services.items_gateway.routes.web.roles.modify_role_handler import (
+    ModifyRoleHandler)
+from items.services.items_gateway.routes.web.roles.delete_role_handler import (
+    DeleteRoleHandler)
+
+
+def create_roles_routes(injections: RouteInjections) -> Blueprint:
+    """Create the Blueprint containing role management web routes.
+
+    All routes are admin-only, enforced here via ``@require_administrator``
+    rather than trusted to the caller - role definitions gate what every
+    project member can do, so managing them is administrator-only, same as
+    users, invites, and testcase custom fields.
+
+    Registered routes:
+        GET    /roles              List all roles (name only).
+        POST   /roles              Create a new role.
+        GET    /roles/<role_id>    Get a single role's full grid.
+        PATCH  /roles/<role_id>    Update a role's name and/or grid.
+        DELETE /roles/<role_id>    Delete a role.
+
+    Args:
+        injections: Shared application dependencies.
+
+    Returns:
+        A configured Quart Blueprint.
+    """
+    routes = Blueprint('roles_routes', __name__)
+
+    handler_list = ListRolesHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_get = GetRoleHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_create = CreateRoleHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_modify = ModifyRoleHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_delete = DeleteRoleHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+
+    injections.logger.debug(" Roles WEB routes:")
+
+    injections.logger.debug("=> %s GET  /web/roles",
+                            "List roles".ljust(40))
+
+    @routes.route('/roles', methods=['GET'])
+    @require_administrator(injections.sessions)
+    async def list_roles_request():
+        return await handler_list.list_roles()
+
+    injections.logger.debug("=> %s POST /web/roles",
+                            "Create role".ljust(40))
+
+    @routes.route('/roles', methods=['POST'])
+    @require_administrator(injections.sessions)
+    async def create_role_request():
+        return await handler_create.create_role()
+
+    injections.logger.debug("=> %s GET  /web/roles/<int:role_id>",
+                            "Get role".ljust(40))
+
+    @routes.route('/roles/<int:role_id>', methods=['GET'])
+    @require_administrator(injections.sessions)
+    async def get_role_request(role_id: int):
+        return await handler_get.get_role(role_id)
+
+    injections.logger.debug("=> %s PATCH /web/roles/<int:role_id>",
+                            "Modify role".ljust(40))
+
+    @routes.route('/roles/<int:role_id>', methods=['PATCH'])
+    @require_administrator(injections.sessions)
+    async def modify_role_request(role_id: int):
+        return await handler_modify.modify_role(role_id)
+
+    injections.logger.debug("=> %s DELETE /web/roles/<int:role_id>",
+                            "Delete role".ljust(40))
+
+    @routes.route('/roles/<int:role_id>', methods=['DELETE'])
+    @require_administrator(injections.sessions)
+    async def delete_role_request(role_id: int):
+        return await handler_delete.delete_role(role_id)
+
+    return routes

--- a/items/services/items_gateway/routes/web/roles/create_role_handler.py
+++ b/items/services/items_gateway/routes/web/roles/create_role_handler.py
@@ -1,0 +1,73 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class CreateRoleHandler(BaseApiRoute):
+    """Handles POST /roles — create a new role.
+
+    Proxies the request body to the identity service and propagates the
+    response. Schema validation is performed by the identity service;
+    invalid payloads will receive a 400 response propagated from there.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def create_role(self) -> Response:
+        """Create a new role.
+
+        Returns:
+            201 with ``{"id": <new_role_id>}`` on success.
+            400 if the request body is missing or not valid JSON, or the
+            supplied permission grid is invalid.
+            409 if the role name is already in use.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = f"{self._configuration.apis_identity_svc}roles"
+        response: ApiResponse = await self._rest_client.post(url,
+                                                              json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/roles/delete_role_handler.py
+++ b/items/services/items_gateway/routes/web/roles/delete_role_handler.py
@@ -1,0 +1,66 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class DeleteRoleHandler(BaseApiRoute):
+    """Handles DELETE /roles/<role_id> — delete a role.
+
+    Proxies the request to the identity service and propagates the response.
+    Any project membership holding this role has its role assignment
+    cleared, not deleted - identity's concern, not the gateway's.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def delete_role(self, role_id: int) -> Response:
+        """Delete a role.
+
+        Args:
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 on success.
+            404 if no role exists with that id.
+            500 if the identity service is unreachable.
+        """
+        url: str = f"{self._configuration.apis_identity_svc}roles/{role_id}"
+        response: ApiResponse = await self._rest_client.delete(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/roles/get_role_handler.py
+++ b/items/services/items_gateway/routes/web/roles/get_role_handler.py
@@ -1,0 +1,64 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class GetRoleHandler(BaseApiRoute):
+    """Handles GET /roles/<role_id> — get a single role's full grid.
+
+    Proxies the request to the identity service and propagates the response.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def get_role(self, role_id: int) -> Response:
+        """Return a single role, including its full permission grid.
+
+        Args:
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 with the role details on success.
+            404 if no role exists with that id.
+            500 if the identity service is unreachable.
+        """
+        url: str = f"{self._configuration.apis_identity_svc}roles/{role_id}"
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/roles/list_roles_handler.py
+++ b/items/services/items_gateway/routes/web/roles/list_roles_handler.py
@@ -1,0 +1,60 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class ListRolesHandler(BaseApiRoute):
+    """Handles GET /roles — list all roles.
+
+    Proxies the request to the identity service and propagates the response.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def list_roles(self) -> Response:
+        """Return all roles from the identity service.
+
+        Returns:
+            200 with the role list on success.
+            500 if the identity service is unreachable.
+        """
+        url: str = f"{self._configuration.apis_identity_svc}roles"
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/roles/modify_role_handler.py
+++ b/items/services/items_gateway/routes/web/roles/modify_role_handler.py
@@ -1,0 +1,77 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class ModifyRoleHandler(BaseApiRoute):
+    """Handles PATCH /roles/<role_id> — update a role's name and/or grid.
+
+    Patch-style: only fields present in the body are updated; ``permissions``,
+    when present, replaces the role's entire grid (identity's own rule, not
+    re-enforced here). Proxies to the identity service.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def modify_role(self, role_id: int) -> Response:
+        """Update a role's name and/or replace its permission grid.
+
+        Args:
+            role_id: The role's id (from the URL).
+
+        Returns:
+            200 on success.
+            400 if the request body is missing or not valid JSON, or the
+            supplied permission grid is invalid.
+            404 if no role exists with that id.
+            409 if renaming to a name already in use by another role.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = f"{self._configuration.apis_identity_svc}roles/{role_id}"
+        response: ApiResponse = await self._rest_client.patch(url,
+                                                               json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/users/__init__.py
+++ b/items/services/items_gateway/routes/web/users/__init__.py
@@ -26,6 +26,14 @@ from items.services.items_gateway.routes.web.users.modify_user_handler import (
     ModifyUserHandler)
 from items.services.items_gateway.routes.web.users.reset_password_handler import (
     ResetPasswordHandler)
+from items.services.items_gateway.routes.web.users.list_user_projects_handler import (
+    ListUserProjectsHandler)
+from items.services.items_gateway.routes.web.users.add_user_project_handler import (
+    AddUserProjectHandler)
+from items.services.items_gateway.routes.web.users.modify_user_project_handler import (
+    ModifyUserProjectHandler)
+from items.services.items_gateway.routes.web.users.remove_user_project_handler import (
+    RemoveUserProjectHandler)
 
 
 def create_users_routes(injections: RouteInjections) -> Blueprint:
@@ -40,6 +48,12 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
         GET  /users/<user_id>    Get a single user account.
         PATCH /users/<user_id>   Update a user's profile fields (patch-style).
         POST /users/<user_id>/password   Reset a user's password (admin).
+        GET  /users/<user_id>/projects   List the user's project memberships.
+        POST /users/<user_id>/projects   Add the user to a project.
+        PATCH /users/<user_id>/projects/<project_id>   Change the user's
+            role on a project.
+        DELETE /users/<user_id>/projects/<project_id>   Remove the user's
+            membership of a project.
 
     Note:
         ``POST /users/me/password`` (change own password) is not registered
@@ -53,6 +67,7 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
     Returns:
         A configured Quart Blueprint.
     """
+    # pylint: disable=too-many-locals
     routes = Blueprint('users_routes', __name__)
 
     handler_list = ListUsersHandler(
@@ -66,6 +81,14 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
     handler_reset_password = ResetPasswordHandler(
         injections.logger, injections.configuration, injections.rest_client,
         injections.email_service)
+    handler_list_projects = ListUserProjectsHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_add_project = AddUserProjectHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_modify_project = ModifyUserProjectHandler(
+        injections.logger, injections.configuration, injections.rest_client)
+    handler_remove_project = RemoveUserProjectHandler(
+        injections.logger, injections.configuration, injections.rest_client)
 
     injections.logger.debug(" Users WEB routes:")
 
@@ -108,5 +131,43 @@ def create_users_routes(injections: RouteInjections) -> Blueprint:
     @require_administrator(injections.sessions)
     async def reset_password_request(user_id: str):
         return await handler_reset_password.reset_password(user_id)
+
+    injections.logger.debug("=> %s GET  /web/users/<string:user_id>/projects",
+                            "List project memberships".ljust(40))
+
+    @routes.route('/users/<string:user_id>/projects', methods=['GET'])
+    @require_administrator(injections.sessions)
+    async def list_user_projects_request(user_id: str):
+        return await handler_list_projects.list_user_projects(user_id)
+
+    injections.logger.debug("=> %s POST /web/users/<string:user_id>/projects",
+                            "Add project membership".ljust(40))
+
+    @routes.route('/users/<string:user_id>/projects', methods=['POST'])
+    @require_administrator(injections.sessions)
+    async def add_user_project_request(user_id: str):
+        return await handler_add_project.add_user_project(user_id)
+
+    injections.logger.debug(
+        "=> %s PATCH /web/users/<string:user_id>/projects/<int:project_id>",
+        "Change membership role".ljust(40))
+
+    @routes.route('/users/<string:user_id>/projects/<int:project_id>',
+                  methods=['PATCH'])
+    @require_administrator(injections.sessions)
+    async def modify_user_project_request(user_id: str, project_id: int):
+        return await handler_modify_project.modify_user_project(
+            user_id, project_id)
+
+    injections.logger.debug(
+        "=> %s DELETE /web/users/<string:user_id>/projects/<int:project_id>",
+        "Remove project membership".ljust(40))
+
+    @routes.route('/users/<string:user_id>/projects/<int:project_id>',
+                  methods=['DELETE'])
+    @require_administrator(injections.sessions)
+    async def remove_user_project_request(user_id: str, project_id: int):
+        return await handler_remove_project.remove_user_project(
+            user_id, project_id)
 
     return routes

--- a/items/services/items_gateway/routes/web/users/add_user_project_handler.py
+++ b/items/services/items_gateway/routes/web/users/add_user_project_handler.py
@@ -1,0 +1,138 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class AddUserProjectHandler(BaseApiRoute):
+    """Handles POST /users/<user_id>/projects — add a user to a project.
+
+    Unlike every other handler in this domain, this one talks to *both*
+    backend services for a single request: identity can't validate
+    ``project_id`` itself (no foreign key is possible across the database
+    boundary - see §7 of user_roles_design.md), so the gateway confirms the
+    project actually exists in CMS before proxying the membership creation
+    to identity. Without this, a typo'd ``project_id`` would silently
+    succeed and sit as a dangling, inert reference - a confusing failure
+    mode with no error anywhere pointing at why (see the discussion
+    recorded when this branch was scoped).
+
+    This check only runs on creation. It's deliberately not repeated
+    elsewhere in this domain - membership creation is a rare, deliberate
+    admin action, so the extra CMS round trip is cheap in aggregate; it
+    would not be worth adding to a request that runs on every page load
+    (that reasoning is exactly why the testcase routes avoid an equivalent
+    extra hop - see routes/web/testcases/get_testcase_handler.py).
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def add_user_project(self, user_id: str) -> Response:
+        """Add a user to a project, optionally assigning a role.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+
+        Returns:
+            201 on success.
+            400 if the request body is missing or not valid JSON, or a
+            supplied ``role_id`` doesn't exist.
+            404 if no user exists with that UUID, or ``project_id`` doesn't
+            match a real CMS project.
+            409 if the user is already a member of this project.
+            500 if either backend service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        project_id = body.get("project_id")
+        if isinstance(project_id, int):
+            cms_error = await self._check_project_exists(project_id)
+            if cms_error is not None:
+                return cms_error
+
+        url: str = (f"{self._configuration.apis_identity_svc}"
+                    f"users/{user_id}/projects")
+        response: ApiResponse = await self._rest_client.post(url,
+                                                              json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")
+
+    async def _check_project_exists(self, project_id: int) -> Response | None:
+        """Confirm a project exists in CMS before creating a membership.
+
+        Args:
+            project_id: The project id to check.
+
+        Returns:
+            ``None`` if the project exists and the caller should proceed.
+            Otherwise, the ``Response`` to return immediately - a 404 if
+            CMS reports the project doesn't exist, or a 500 if CMS is
+            unreachable or returns something unexpected.
+        """
+        url: str = f"{self._configuration.apis_cms_svc}projects/{project_id}"
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to CMS service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "CMS service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        if response.status_code == HTTPStatus.NOT_FOUND:
+            return Response(
+                json.dumps({"error": "Project not found"}),
+                status=HTTPStatus.NOT_FOUND,
+                content_type="application/json")
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.error(
+                "CMS service returned unexpected status %s checking "
+                "project %d", response.status_code, project_id)
+            return Response(
+                json.dumps({"error": "Internal error!"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return None

--- a/items/services/items_gateway/routes/web/users/list_user_projects_handler.py
+++ b/items/services/items_gateway/routes/web/users/list_user_projects_handler.py
@@ -1,0 +1,65 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class ListUserProjectsHandler(BaseApiRoute):
+    """Handles GET /users/<user_id>/projects — list a user's memberships.
+
+    Proxies the request to the identity service and propagates the response.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def list_user_projects(self, user_id: str) -> Response:
+        """Return every project membership held by a user.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+
+        Returns:
+            200 with the membership list on success.
+            404 if no user exists with that UUID.
+            500 if the identity service is unreachable.
+        """
+        url: str = (f"{self._configuration.apis_identity_svc}"
+                    f"users/{user_id}/projects")
+        response: ApiResponse = await self._rest_client.get(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/users/modify_user_project_handler.py
+++ b/items/services/items_gateway/routes/web/users/modify_user_project_handler.py
@@ -1,0 +1,82 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import request, Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class ModifyUserProjectHandler(BaseApiRoute):
+    """Handles PATCH /users/<user_id>/projects/<project_id> — set role.
+
+    No CMS existence check here, unlike ``AddUserProjectHandler`` - the
+    project referenced by the URL is already an existing membership (it
+    was validated against CMS when the membership was created), and this
+    endpoint only ever changes the *role* on it, never the project.
+    Proxies to the identity service.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def modify_user_project(self, user_id: str,
+                                  project_id: int) -> Response:
+        """Change (or clear) the role on an existing membership.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+            project_id: The project's id (from the URL).
+
+        Returns:
+            200 on success.
+            400 if the request body is missing or not valid JSON, or a
+            supplied ``role_id`` doesn't exist.
+            404 if no user exists with that UUID, or the user is not a
+            member of this project.
+            500 if the identity service is unreachable.
+        """
+        body = await request.get_json(force=True, silent=True)
+        if body is None:
+            return Response(
+                json.dumps({"error": "Invalid JSON body"}),
+                status=HTTPStatus.BAD_REQUEST,
+                content_type="application/json")
+
+        url: str = (f"{self._configuration.apis_identity_svc}"
+                    f"users/{user_id}/projects/{project_id}")
+        response: ApiResponse = await self._rest_client.patch(url,
+                                                               json_data=body)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/services/items_gateway/routes/web/users/remove_user_project_handler.py
+++ b/items/services/items_gateway/routes/web/users/remove_user_project_handler.py
@@ -1,0 +1,68 @@
+"""
+Copyright 2025-2026 Integrated Test Management Suite Development Team
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from http import HTTPStatus
+import json
+import logging
+from quart import Response
+from weaver_framework.microservice.api_response import ApiResponse
+from weaver_framework.microservice.base_api_route import BaseApiRoute
+from weaver_framework.microservice.rest_client import RestClient
+from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+
+
+class RemoveUserProjectHandler(BaseApiRoute):
+    """Handles DELETE /users/<user_id>/projects/<project_id> — remove.
+
+    Proxies the request to the identity service and propagates the response.
+    """
+
+    def __init__(self,
+                 logger: logging.Logger,
+                 configuration: GatewayConfiguration,
+                 rest_client: RestClient) -> None:
+        self._logger = logger.getChild(type(self).__name__)
+        self._configuration = configuration
+        self._rest_client = rest_client
+
+    async def remove_user_project(self, user_id: str,
+                                  project_id: int) -> Response:
+        """Remove a user's membership of a project entirely.
+
+        Args:
+            user_id: The user's UUID (from the URL).
+            project_id: The project's id (from the URL).
+
+        Returns:
+            200 on success.
+            404 if no user exists with that UUID, or the user is not a
+            member of this project.
+            500 if the identity service is unreachable.
+        """
+        url: str = (f"{self._configuration.apis_identity_svc}"
+                    f"users/{user_id}/projects/{project_id}")
+        response: ApiResponse = await self._rest_client.delete(url)
+
+        if response.exception_msg is not None:
+            self._logger.error("Connection to identity service failed: %s",
+                               response.exception_msg)
+            return Response(
+                json.dumps({"error": "Identity service unavailable"}),
+                status=HTTPStatus.INTERNAL_SERVER_ERROR,
+                content_type="application/json")
+
+        return Response(json.dumps(response.body),
+                        status=response.status_code,
+                        content_type="application/json")

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 6"
+PRE_RELEASE = "Alpha Build 7"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -2268,6 +2268,321 @@
                     }
                   },
                   "response": []
+                },
+                {
+                  "name": "List User Projects",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/users/{{USER_UUID}}/projects",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "users",
+                        "{{USER_UUID}}",
+                        "projects"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Add User Project",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"project_id\": 1,\n    \"role_id\": {{ROLE_ID}}\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/users/{{USER_UUID}}/projects",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "users",
+                        "{{USER_UUID}}",
+                        "projects"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Change User Project Role",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"role_id\": {{ROLE_ID}}\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/users/{{USER_UUID}}/projects/1",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "users",
+                        "{{USER_UUID}}",
+                        "projects",
+                        "1"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Remove User Project",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/users/{{USER_UUID}}/projects/1",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "users",
+                        "{{USER_UUID}}",
+                        "projects",
+                        "1"
+                      ]
+                    }
+                  },
+                  "response": []
+                }
+              ]
+            },
+            {
+              "name": "Roles",
+              "item": [
+                {
+                  "name": "List Roles",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/roles",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "roles"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Get Role",
+                  "request": {
+                    "method": "GET",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/roles/{{ROLE_ID}}",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "roles",
+                        "{{ROLE_ID}}"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Create Role",
+                  "request": {
+                    "method": "POST",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"name\": \"Tester\",\n    \"permissions\": [\n        {\n            \"area\": \"test_cases\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": false\n        }\n    ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/roles",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "roles"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Update Role",
+                  "request": {
+                    "method": "PATCH",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "body": {
+                      "mode": "raw",
+                      "raw": "{\n    \"name\": \"Senior Tester\",\n    \"permissions\": [\n        {\n            \"area\": \"test_cases\",\n            \"can_read\": true,\n            \"can_add_modify\": true,\n            \"can_delete\": true\n        }\n    ]\n}",
+                      "options": {
+                        "raw": {
+                          "language": "json"
+                        }
+                      }
+                    },
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/roles/{{ROLE_ID}}",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "roles",
+                        "{{ROLE_ID}}"
+                      ]
+                    }
+                  },
+                  "response": []
+                },
+                {
+                  "name": "Delete Role",
+                  "request": {
+                    "method": "DELETE",
+                    "header": [
+                      {
+                        "key": "X-Items-User",
+                        "value": "{{ITEMS_USER}}",
+                        "type": "text"
+                      },
+                      {
+                        "key": "X-Items-Token",
+                        "value": "{{ITEMS_TOKEN}}",
+                        "type": "text"
+                      }
+                    ],
+                    "url": {
+                      "raw": "{{GATEWAY_SVC_URL}}/web/roles/{{ROLE_ID}}",
+                      "host": [
+                        "{{GATEWAY_SVC_URL}}"
+                      ],
+                      "path": [
+                        "web",
+                        "roles",
+                        "{{ROLE_ID}}"
+                      ]
+                    }
+                  },
+                  "response": []
                 }
               ]
             }

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -49,6 +49,19 @@ from test_users_handlers import (
     TestResetPasswordHandler,
     TestResetPasswordHandlerEmail,
 )
+from test_roles_handlers import (
+    TestListRolesHandler,
+    TestGetRoleHandler,
+    TestCreateRoleHandler,
+    TestModifyRoleHandler,
+    TestDeleteRoleHandler,
+)
+from test_user_project_handlers import (
+    TestListUserProjectsHandler,
+    TestAddUserProjectHandler,
+    TestModifyUserProjectHandler,
+    TestRemoveUserProjectHandler,
+)
 from test_invite_emails import (
     TestCreateInviteSendsEmail,
     TestResendInviteSendsEmail,

--- a/unit_tests/items_gateway/test_admin_route_enforcement.py
+++ b/unit_tests/items_gateway/test_admin_route_enforcement.py
@@ -68,6 +68,15 @@ _ADMIN_ONLY_ROUTES = [
     ("PATCH", "/web/testcase_custom_fields/1", {"direction": "up"}),
     ("POST", "/web/testcase_custom_fields/", _VALID_FIELD_BODY),
     ("DELETE", "/web/testcase_custom_fields/1", None),
+    ("GET", "/web/roles", None),
+    ("POST", "/web/roles", {"name": "Tester"}),
+    ("GET", "/web/roles/1", None),
+    ("PATCH", "/web/roles/1", {"name": "New Name"}),
+    ("DELETE", "/web/roles/1", None),
+    ("GET", "/web/users/1/projects", None),
+    ("POST", "/web/users/1/projects", {"project_id": 5}),
+    ("PATCH", "/web/users/1/projects/5", {"role_id": 2}),
+    ("DELETE", "/web/users/1/projects/5", None),
 ]
 
 # (method, path, json_body) - routes that need a valid session but not

--- a/unit_tests/items_gateway/test_roles_handlers.py
+++ b/unit_tests/items_gateway/test_roles_handlers.py
@@ -1,0 +1,334 @@
+"""
+Unit tests for gateway role management route handlers:
+  GET    /roles              - ListRolesHandler
+  GET    /roles/<id>         - GetRoleHandler
+  POST   /roles              - CreateRoleHandler
+  PATCH  /roles/<id>         - ModifyRoleHandler
+  DELETE /roles/<id>         - DeleteRoleHandler
+"""
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.roles.list_roles_handler import (
+    ListRolesHandler)
+from items.services.items_gateway.routes.web.roles.get_role_handler import (
+    GetRoleHandler)
+from items.services.items_gateway.routes.web.roles.create_role_handler import (
+    CreateRoleHandler)
+from items.services.items_gateway.routes.web.roles.modify_role_handler import (
+    ModifyRoleHandler)
+from items.services.items_gateway.routes.web.roles.delete_role_handler import (
+    DeleteRoleHandler)
+
+_LOGGER = MagicMock()
+_ROLE = {
+    "id": 1,
+    "name": "Tester",
+    "permissions": [
+        {"area": "test_cases", "can_read": True, "can_add_modify": True,
+         "can_delete": False},
+    ],
+}
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_identity_svc = "http://identity/"
+    return cfg
+
+
+def _ok(body):
+    return ApiResponse(status_code=200, body=body)
+
+
+def _err(body, status=500):
+    return ApiResponse(status_code=status, body=body)
+
+
+def _conn_err():
+    r = ApiResponse(status_code=0, body=None)
+    r.exception_msg = "connection refused"
+    return r
+
+
+# ---------------------------------------------------------------------------
+# ListRolesHandler
+# ---------------------------------------------------------------------------
+
+class TestListRolesHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = ListRolesHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/roles", methods=["GET"])
+        async def route():
+            return await handler.list_roles()
+
+        self.client = app.test_client()
+
+    async def _get(self):
+        async with self.client as c:
+            return await c.get("/roles")
+
+    async def test_success_returns_200_with_body(self):
+        self.mock_rc.get.return_value = _ok({"roles": [_ROLE]})
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["roles"], [_ROLE])
+
+    async def test_identity_url_is_correct(self):
+        self.mock_rc.get.return_value = _ok({"roles": []})
+        await self._get()
+        self.mock_rc.get.assert_called_once_with("http://identity/roles")
+
+    async def test_identity_error_is_propagated(self):
+        self.mock_rc.get.return_value = _err({"error": "unavailable"}, 503)
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 503)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.get.return_value = _conn_err()
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.get.return_value = _ok({"roles": []})
+        resp = await self._get()
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# GetRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestGetRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = GetRoleHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/roles/<int:role_id>", methods=["GET"])
+        async def route(role_id: int):
+            return await handler.get_role(role_id)
+
+        self.client = app.test_client()
+
+    async def _get(self, role_id=1):
+        async with self.client as c:
+            return await c.get(f"/roles/{role_id}")
+
+    async def test_success_returns_200_with_role(self):
+        self.mock_rc.get.return_value = _ok(_ROLE)
+        resp = await self._get(1)
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body, _ROLE)
+
+    async def test_role_id_included_in_url(self):
+        self.mock_rc.get.return_value = _ok(_ROLE)
+        await self._get(7)
+        self.mock_rc.get.assert_called_once_with("http://identity/roles/7")
+
+    async def test_identity_404_is_propagated(self):
+        self.mock_rc.get.return_value = _err({"error": "Role not found"}, 404)
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.get.return_value = _conn_err()
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.get.return_value = _ok(_ROLE)
+        resp = await self._get()
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# CreateRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestCreateRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = CreateRoleHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/roles", methods=["POST"])
+        async def route():
+            return await handler.create_role()
+
+        self.client = app.test_client()
+
+    async def _post(self, body):
+        async with self.client as c:
+            return await c.post("/roles", json=body)
+
+    async def test_success_returns_201_with_id(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"id": 1})
+        resp = await self._post({"name": "Tester"})
+        self.assertEqual(resp.status_code, 201)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["id"], 1)
+
+    async def test_body_forwarded_to_identity(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"id": 1})
+        role_body = {"name": "Tester", "permissions": [
+            {"area": "test_cases", "can_read": True,
+             "can_add_modify": False, "can_delete": False}]}
+        await self._post(role_body)
+        self.mock_rc.post.assert_called_once_with(
+            "http://identity/roles", json_data=role_body)
+
+    async def test_identity_conflict_is_propagated(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=409, body={"error": "Role name already in use"})
+        resp = await self._post({"name": "Tester"})
+        self.assertEqual(resp.status_code, 409)
+
+    async def test_identity_invalid_grid_is_propagated(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=400, body={"error": "Invalid permission grid"})
+        resp = await self._post({"name": "Tester"})
+        self.assertEqual(resp.status_code, 400)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.post.return_value = _conn_err()
+        resp = await self._post({"name": "Tester"})
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_invalid_json_body_returns_400_without_calling_identity(self):
+        async with self.client as c:
+            resp = await c.post("/roles", data="not json",
+                                headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_response_is_json(self):
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"id": 1})
+        resp = await self._post({"name": "Tester"})
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# ModifyRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestModifyRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = ModifyRoleHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/roles/<int:role_id>", methods=["PATCH"])
+        async def route(role_id: int):
+            return await handler.modify_role(role_id)
+
+        self.client = app.test_client()
+
+    async def _patch(self, body, role_id=1):
+        async with self.client as c:
+            return await c.patch(f"/roles/{role_id}", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        resp = await self._patch({"name": "New Name"})
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_role_id_included_in_url(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        await self._patch({"name": "New Name"}, role_id=9)
+        self.mock_rc.patch.assert_called_once_with(
+            "http://identity/roles/9", json_data={"name": "New Name"})
+
+    async def test_identity_404_is_propagated(self):
+        self.mock_rc.patch.return_value = _err({"error": "Role not found"}, 404)
+        resp = await self._patch({"name": "New Name"})
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_identity_conflict_is_propagated(self):
+        self.mock_rc.patch.return_value = _err(
+            {"error": "Role name already in use"}, 409)
+        resp = await self._patch({"name": "Taken"})
+        self.assertEqual(resp.status_code, 409)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.patch.return_value = _conn_err()
+        resp = await self._patch({"name": "New Name"})
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_invalid_json_body_returns_400_without_calling_identity(self):
+        async with self.client as c:
+            resp = await c.patch("/roles/1", data="not json",
+                                 headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.patch.assert_not_called()
+
+    async def test_response_is_json(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        resp = await self._patch({"name": "New Name"})
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# DeleteRoleHandler
+# ---------------------------------------------------------------------------
+
+class TestDeleteRoleHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = DeleteRoleHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/roles/<int:role_id>", methods=["DELETE"])
+        async def route(role_id: int):
+            return await handler.delete_role(role_id)
+
+        self.client = app.test_client()
+
+    async def _delete(self, role_id=1):
+        async with self.client as c:
+            return await c.delete(f"/roles/{role_id}")
+
+    async def test_success_returns_200(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_role_id_included_in_url(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        await self._delete(role_id=13)
+        self.mock_rc.delete.assert_called_once_with(
+            "http://identity/roles/13")
+
+    async def test_identity_404_is_propagated(self):
+        self.mock_rc.delete.return_value = _err({"error": "Role not found"}, 404)
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.delete.return_value = _conn_err()
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        resp = await self._delete()
+        self.assertEqual(resp.content_type, "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unit_tests/items_gateway/test_route_factories.py
+++ b/unit_tests/items_gateway/test_route_factories.py
@@ -251,6 +251,64 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
                                     headers=_AUTH_HEADERS)
         self.assertNotEqual(response.status_code, 405)
 
+    async def test_list_user_projects_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/web/users/1/projects",
+                                   headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_add_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/web/users/1/projects",
+                                    json={"project_id": 5},
+                                    headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_modify_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.patch("/web/users/1/projects/5",
+                                     json={"role_id": 2},
+                                     headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_remove_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.delete("/web/users/1/projects/5",
+                                      headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    # ------------------------------------------------------------------
+    # Roles routes (routes/web/roles/__init__.py)
+    # ------------------------------------------------------------------
+
+    async def test_list_roles_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/web/roles", headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_create_role_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/web/roles", json={"name": "Tester"},
+                                    headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_get_role_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.get("/web/roles/1", headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_modify_role_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.patch("/web/roles/1",
+                                     json={"name": "New Name"},
+                                     headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_delete_role_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.delete("/web/roles/1", headers=_AUTH_HEADERS)
+        self.assertNotEqual(response.status_code, 405)
+
     # ------------------------------------------------------------------
     # Invites routes (routes/web/invites/__init__.py)
     # ------------------------------------------------------------------

--- a/unit_tests/items_gateway/test_user_project_handlers.py
+++ b/unit_tests/items_gateway/test_user_project_handlers.py
@@ -1,0 +1,344 @@
+"""
+Unit tests for gateway project-membership route handlers:
+  GET    /users/<uuid>/projects              - ListUserProjectsHandler
+  POST   /users/<uuid>/projects              - AddUserProjectHandler
+  PATCH  /users/<uuid>/projects/<project_id> - ModifyUserProjectHandler
+  DELETE /users/<uuid>/projects/<project_id> - RemoveUserProjectHandler
+"""
+import json
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+from quart import Quart
+from weaver_framework.microservice.api_response import ApiResponse
+from items.services.items_gateway.routes.web.users.list_user_projects_handler import (
+    ListUserProjectsHandler)
+from items.services.items_gateway.routes.web.users.add_user_project_handler import (
+    AddUserProjectHandler)
+from items.services.items_gateway.routes.web.users.modify_user_project_handler import (
+    ModifyUserProjectHandler)
+from items.services.items_gateway.routes.web.users.remove_user_project_handler import (
+    RemoveUserProjectHandler)
+
+_LOGGER = MagicMock()
+_UUID = "550e8400-e29b-41d4-a716-446655440000"
+_MEMBERSHIP = {"project_id": 5, "role_id": 2, "role_name": "Tester"}
+
+
+def _config():
+    cfg = MagicMock()
+    cfg.apis_identity_svc = "http://identity/"
+    cfg.apis_cms_svc = "http://cms/"
+    return cfg
+
+
+def _ok(body):
+    return ApiResponse(status_code=200, body=body)
+
+
+def _err(body, status=500):
+    return ApiResponse(status_code=status, body=body)
+
+
+def _conn_err():
+    r = ApiResponse(status_code=0, body=None)
+    r.exception_msg = "connection refused"
+    return r
+
+
+# ---------------------------------------------------------------------------
+# ListUserProjectsHandler
+# ---------------------------------------------------------------------------
+
+class TestListUserProjectsHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = ListUserProjectsHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/users/<string:user_id>/projects", methods=["GET"])
+        async def route(user_id: str):
+            return await handler.list_user_projects(user_id)
+
+        self.client = app.test_client()
+
+    async def _get(self, user_id=_UUID):
+        async with self.client as c:
+            return await c.get(f"/users/{user_id}/projects")
+
+    async def test_success_returns_200_with_memberships(self):
+        self.mock_rc.get.return_value = _ok({"memberships": [_MEMBERSHIP]})
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 200)
+        body = json.loads(await resp.get_data())
+        self.assertEqual(body["memberships"], [_MEMBERSHIP])
+
+    async def test_identity_url_is_correct(self):
+        self.mock_rc.get.return_value = _ok({"memberships": []})
+        await self._get()
+        self.mock_rc.get.assert_called_once_with(
+            f"http://identity/users/{_UUID}/projects")
+
+    async def test_identity_404_is_propagated(self):
+        self.mock_rc.get.return_value = _err({"error": "User not found"}, 404)
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.get.return_value = _conn_err()
+        resp = await self._get()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.get.return_value = _ok({"memberships": []})
+        resp = await self._get()
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# AddUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestAddUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = AddUserProjectHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/users/<string:user_id>/projects", methods=["POST"])
+        async def route(user_id: str):
+            return await handler.add_user_project(user_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, body, user_id=_UUID):
+        async with self.client as c:
+            return await c.post(f"/users/{user_id}/projects", json=body)
+
+    async def test_success_returns_201(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"status": "ok"})
+        resp = await self._post({"project_id": 5, "role_id": 2})
+        self.assertEqual(resp.status_code, 201)
+
+    async def test_cms_checked_before_identity_when_project_id_present(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"status": "ok"})
+        await self._post({"project_id": 5})
+        self.mock_rc.get.assert_called_once_with("http://cms/projects/5")
+        self.mock_rc.post.assert_called_once()
+
+    async def test_cms_project_not_found_returns_404_without_calling_identity(self):
+        self.mock_rc.get.return_value = _err({"error": "not found"}, 404)
+        resp = await self._post({"project_id": 999999})
+        self.assertEqual(resp.status_code, 404)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_cms_connection_error_returns_500_without_calling_identity(self):
+        self.mock_rc.get.return_value = _conn_err()
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.status_code, 500)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_cms_unexpected_status_returns_500_without_calling_identity(self):
+        self.mock_rc.get.return_value = _err({"error": "boom"}, 503)
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.status_code, 500)
+        self.mock_rc.post.assert_not_called()
+
+    async def test_missing_project_id_skips_cms_check(self):
+        """Identity's own schema validation rejects a missing project_id -
+        the gateway has nothing to check against CMS without one."""
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=400, body={"error": "project_id required"})
+        resp = await self._post({"role_id": 2})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.get.assert_not_called()
+
+    async def test_non_integer_project_id_skips_cms_check(self):
+        """Malformed project_id is identity's schema validation's job, not
+        the gateway's - the gateway just can't check it against CMS."""
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=400, body={"error": "project_id must be an integer"})
+        resp = await self._post({"project_id": "not-a-number"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.get.assert_not_called()
+
+    async def test_identity_user_not_found_is_propagated(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = _err({"error": "User not found"}, 404)
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_identity_conflict_is_propagated(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = _err(
+            {"error": "User is already a member of this project"}, 409)
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.status_code, 409)
+
+    async def test_identity_connection_error_returns_500(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = _conn_err()
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_invalid_json_body_returns_400_without_calling_anything(self):
+        async with self.client as c:
+            resp = await c.post(f"/users/{_UUID}/projects", data="not json",
+                                headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.get.assert_not_called()
+        self.mock_rc.post.assert_not_called()
+
+    async def test_body_forwarded_to_identity_unchanged(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"status": "ok"})
+        body = {"project_id": 5, "role_id": 2}
+        await self._post(body)
+        self.mock_rc.post.assert_called_once_with(
+            f"http://identity/users/{_UUID}/projects", json_data=body)
+
+    async def test_response_is_json(self):
+        self.mock_rc.get.return_value = _ok({"id": 5, "name": "Alpha"})
+        self.mock_rc.post.return_value = ApiResponse(
+            status_code=201, body={"status": "ok"})
+        resp = await self._post({"project_id": 5})
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# ModifyUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestModifyUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = ModifyUserProjectHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/users/<string:user_id>/projects/<int:project_id>",
+                  methods=["PATCH"])
+        async def route(user_id: str, project_id: int):
+            return await handler.modify_user_project(user_id, project_id)
+
+        self.client = app.test_client()
+
+    async def _patch(self, body, user_id=_UUID, project_id=5):
+        async with self.client as c:
+            return await c.patch(
+                f"/users/{user_id}/projects/{project_id}", json=body)
+
+    async def test_success_returns_200(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        resp = await self._patch({"role_id": 3})
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_does_not_call_cms(self):
+        """No project-existence check here - only AddUserProjectHandler
+        does that, on creation."""
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        await self._patch({"role_id": 3})
+        self.mock_rc.get.assert_not_called()
+
+    async def test_url_includes_user_and_project_id(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        await self._patch({"role_id": 3}, user_id=_UUID, project_id=9)
+        self.mock_rc.patch.assert_called_once_with(
+            f"http://identity/users/{_UUID}/projects/9",
+            json_data={"role_id": 3})
+
+    async def test_role_id_null_is_forwarded_to_clear_role(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        await self._patch({"role_id": None})
+        self.mock_rc.patch.assert_called_once_with(
+            f"http://identity/users/{_UUID}/projects/5",
+            json_data={"role_id": None})
+
+    async def test_identity_role_not_found_is_propagated(self):
+        self.mock_rc.patch.return_value = _err(
+            {"error": "No role exists with that id"}, 400)
+        resp = await self._patch({"role_id": 999})
+        self.assertEqual(resp.status_code, 400)
+
+    async def test_identity_membership_not_found_is_propagated(self):
+        self.mock_rc.patch.return_value = _err(
+            {"error": "User is not a member of this project"}, 404)
+        resp = await self._patch({"role_id": 3})
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.patch.return_value = _conn_err()
+        resp = await self._patch({"role_id": 3})
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_invalid_json_body_returns_400_without_calling_identity(self):
+        async with self.client as c:
+            resp = await c.patch(f"/users/{_UUID}/projects/5", data="not json",
+                                 headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.status_code, 400)
+        self.mock_rc.patch.assert_not_called()
+
+    async def test_response_is_json(self):
+        self.mock_rc.patch.return_value = _ok({"status": "ok"})
+        resp = await self._patch({"role_id": 3})
+        self.assertEqual(resp.content_type, "application/json")
+
+
+# ---------------------------------------------------------------------------
+# RemoveUserProjectHandler
+# ---------------------------------------------------------------------------
+
+class TestRemoveUserProjectHandler(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.mock_rc = AsyncMock()
+        handler = RemoveUserProjectHandler(_LOGGER, _config(), self.mock_rc)
+        app = Quart(__name__)
+
+        @app.route("/users/<string:user_id>/projects/<int:project_id>",
+                  methods=["DELETE"])
+        async def route(user_id: str, project_id: int):
+            return await handler.remove_user_project(user_id, project_id)
+
+        self.client = app.test_client()
+
+    async def _delete(self, user_id=_UUID, project_id=5):
+        async with self.client as c:
+            return await c.delete(f"/users/{user_id}/projects/{project_id}")
+
+    async def test_success_returns_200(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_url_includes_user_and_project_id(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        await self._delete(user_id=_UUID, project_id=9)
+        self.mock_rc.delete.assert_called_once_with(
+            f"http://identity/users/{_UUID}/projects/9")
+
+    async def test_identity_404_is_propagated(self):
+        self.mock_rc.delete.return_value = _err(
+            {"error": "User is not a member of this project"}, 404)
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_connection_error_returns_500(self):
+        self.mock_rc.delete.return_value = _conn_err()
+        resp = await self._delete()
+        self.assertEqual(resp.status_code, 500)
+
+    async def test_response_is_json(self):
+        self.mock_rc.delete.return_value = _ok({"status": "ok"})
+        resp = await self._delete()
+        self.assertEqual(resp.content_type, "application/json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Gateway: roles and project membership proxy routes

**Branch:** `gateway_roles_and_membership` → `main`
**Theme:** Roles & permissions (post-0.3.0) — fourth application-code
piece, exposing the Identity-side work (`identity_roles_db_update` →
`identity_roles_crud` → `identity_project_membership`) through the Gateway

## Summary

Combined branch rather than split - unlike earlier splits in this theme
(schema/CRUD/membership on the Identity side), there was no compelling
reason to separate roles-proxy from membership-proxy here: both are pure
additions with nothing currently calling either route, so no deployment-
ordering hazard forces an order, and the design was already fully settled
by the Identity work. The only new pattern either introduces is the CMS
existence check on membership creation, which stayed easy to review even
combined.

All 14 new routes are admin-only, enforced via the existing
`@require_administrator` decorator - confirmed by cross-checking decorator
count against route count (14 routes, 14 decorators, no gaps), same check
used when the enforcement mechanism itself was first built.

## Gateway: roles proxy

New `routes/web/roles/` blueprint, five handlers
(`ListRolesHandler`/`GetRoleHandler`/`CreateRoleHandler`/
`ModifyRoleHandler`/`DeleteRoleHandler`), registered in
`routes/web/__init__.py`. Pure pass-throughs to identity, matching the
existing `users`/`invites` proxy style exactly - no business logic, no
schema re-validation (identity already does that), just forward the
request and propagate the response.

## Gateway: project membership proxy

Four new handlers nested in the existing `routes/web/users/` blueprint
(matching the URL shape - `/web/users/<id>/projects...` - and the
existing `POST /web/users/<id>/password` precedent for nesting under
`users` rather than a new top-level folder).

`AddUserProjectHandler` is the one genuinely new thing in this theme so
far: **the first Gateway handler that talks to both CMS and Identity for
a single request.** Before proxying a membership creation to identity, it
calls CMS to confirm `project_id` actually exists - 404s cleanly if not,
without ever reaching identity. This was discussed and settled before
writing any code:

- Identity can't validate `project_id` itself (no FK possible across the
  database boundary, §7 of `user_roles_design.md`), so without this check
  a typo'd `project_id` would silently succeed and sit as an inert,
  unexplained dangling reference.
- The extra CMS round trip is only paid on membership *creation* - a rare,
  deliberate admin action, not a hot path. That's the opposite situation
  from the testcase-route work, which specifically avoided an equivalent
  extra hop because that one would have hit every single request.
- The check is deliberately narrow: `ModifyUserProjectHandler` (changing
  a role) and `RemoveUserProjectHandler` (removing a membership) don't
  repeat it - the project referenced by the URL is already an existing,
  previously-validated membership; only the role changes on those paths,
  never the project.
- `project_id` is only checked when present and an integer - a missing or
  malformed value is left for identity's own schema validation to reject,
  rather than the gateway trying to pre-validate input shape that isn't
  its job.

## Postman

15 new requests: `Identity Service > Roles` and 4 membership requests
already existed from the Identity theme's earlier branches - this branch
adds the Gateway equivalents under `Gateway Service > Web > Roles` (5) and
extends `Gateway Service > Web > Users` (4 more), all with the
`X-Items-User`/`X-Items-Token` headers already wired up from the
enforcement branch's login-capture script. Added as a targeted text edit,
not a full re-serialise - third time this convention's been followed in
this theme, no repeat of the earlier reformatting mishaps.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing
New: `test_roles_handlers.py`, `test_user_project_handlers.py`. Both
`test_route_factories.py` (reachability) and
`test_admin_route_enforcement.py` (401/403/pass-through correctness for
all 14 new routes) extended. One pylint fix needed:
`create_users_routes` crossed the too-many-locals threshold (20 vs 15)
after adding four more handler instantiations - added
`# pylint: disable=too-many-locals`, matching the same disable already
present on `create_invite_routes` for the same reason.

**388 tests, OK (up from 315 pre-this-theme's gateway work). 100%
coverage maintained** (1923/1923 statements). Pylint: 10.00/10.

## Deliberately out of scope

- **No Portal UI** - the "Access"/"Projects" tabs on Add/Modify User stay
  placeholders.
- **No enforcement of membership on read routes** - `GET /web/projects`,
  `GET /web/projects/<id>`, `GET /web/<project_id>/testcases`,
  `GET /web/testcases/<id>` are all still `@require_session`-only. That's
  the final piece of this theme, with the original acceptance test still
  the target: assigned to projects 1/3/5, project 2 returns nothing.
- **No cleanup-on-project-purge** - if a project is later deleted from
  CMS, nothing removes the now-dangling `project_members` rows pointing
  at it in identity. Already a known, tracked gap (§10.4 of
  `user_roles_design.md`), unrelated to this branch, not touched here.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
