### PR TITLE
[Portal] User roles and membership

### DIFF
--- a/items/services/items_web_portal/page_handlers/admin/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/__init__.py
@@ -128,6 +128,32 @@ def create_admin_page_handlers(injections: PageHandlerInjections,
     async def admin_users_and_roles_uninvite_request():
         return await handler_users_and_roles.uninvite()
 
+    # Admin page | Add role: POST '/admin/users_roles/roles'
+    injections.logger.debug("=> %s POST /admin/users_roles/roles",
+                            "Admin add role".ljust(40))
+
+    @routes.route('/users_roles/roles', methods=['POST'])
+    async def admin_users_and_roles_role_add_request():
+        return await handler_users_and_roles.role_add()
+
+    # Admin page | Modify role: POST '/admin/users_roles/roles/<id>/modify'
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/roles/<id>/modify",
+        "Admin modify role".ljust(40))
+
+    @routes.route('/users_roles/roles/<int:role_id>/modify', methods=['POST'])
+    async def admin_users_and_roles_role_modify_request(role_id: int):
+        return await handler_users_and_roles.role_modify(role_id)
+
+    # Admin page | Delete role: POST '/admin/users_roles/roles/<id>/delete'
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/roles/<id>/delete",
+        "Admin delete role".ljust(40))
+
+    @routes.route('/users_roles/roles/<int:role_id>/delete', methods=['POST'])
+    async def admin_users_and_roles_role_delete_request(role_id: int):
+        return await handler_users_and_roles.role_delete(role_id)
+
     # Admin page | Manage Data (read): '/admin/users_roles'
     injections.logger.debug("=> %s GET /admin/manage_data",
                             "Admin manage data page (read)".ljust(40))

--- a/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/admin_users_and_roles_page_handler.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 from datetime import datetime, timezone
 from http import HTTPStatus
+import json
 import logging
 from typing import Optional
 from quart import request
@@ -27,6 +28,7 @@ from items.services.items_web_portal.metadata_settings import MetadataSettings
 import items.services.items_web_portal.page_locations as pages
 from items.services.items_web_portal.portal_page_handler import (
     PortalPageHandler)
+from items.shared.permission_area import PermissionArea
 
 
 class AdminUsersAndRolesPageHandler(PortalPageHandler):
@@ -89,8 +91,8 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "invite",
-                                              email_address)
+        return await self._render_after_write(
+            response, "invite", email=email_address)
 
     @require_administrator
     async def resend_invite(self):
@@ -107,8 +109,8 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "resend",
-                                              email_address)
+        return await self._render_after_write(
+            response, "resend", email=email_address)
 
     @require_administrator
     async def uninvite(self):
@@ -125,12 +127,107 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         response: ApiResponse = await self._rest_client.post(
             url, json_data={"email_address": email_address})
 
-        return await self._render_after_write(response, "uninvite",
-                                              email_address)
+        return await self._render_after_write(
+            response, "uninvite", email=email_address)
+
+    # ------------------------------------------------------------------
+    # Write: roles
+    # ------------------------------------------------------------------
+
+    @require_administrator
+    async def role_add(self):
+        """Create a new role from the submitted form.
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        name = form.get("name", "").strip()
+
+        if not name:
+            return await self._render(
+                error_msg_str="Role name is required.", active_tab="roles")
+
+        body = {"name": name,
+                "permissions": self._parse_permissions_from_form(form)}
+
+        url = f"{self._config.apis_gateway_svc}web/roles"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=body)
+
+        return await self._render_after_write(
+            response, "role_add", name=name)
+
+    @require_administrator
+    async def role_modify(self, role_id: int):
+        """Update an existing role's name and permission grid.
+
+        Args:
+            role_id: The role's primary key (from the URL).
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        name = form.get("name", "").strip()
+
+        if not name:
+            return await self._render(
+                error_msg_str="Role name is required.", active_tab="roles")
+
+        body = {"name": name,
+                "permissions": self._parse_permissions_from_form(form)}
+
+        url = f"{self._config.apis_gateway_svc}web/roles/{role_id}"
+        response: ApiResponse = await self._rest_client.patch(
+            url, json_data=body)
+
+        return await self._render_after_write(
+            response, "role_modify", name=name)
+
+    @require_administrator
+    async def role_delete(self, role_id: int):
+        """Delete a role.
+
+        Any project membership using this role has its role cleared to
+        "Unassigned" rather than being removed (enforced at the identity
+        service, see §4.3/§10.4 of user_roles_design.md) - deleting a role
+        never removes a user from a project.
+
+        Args:
+            role_id: The role's primary key (from the URL).
+
+        Returns:
+            The re-rendered users and roles page, showing an error banner
+            if the gateway/identity rejects the request.
+        """
+        form = await request.form
+        name = form.get("name", "").strip() or "Role"
+
+        url = f"{self._config.apis_gateway_svc}web/roles/{role_id}"
+        response: ApiResponse = await self._rest_client.delete(url)
+
+        return await self._render_after_write(
+            response, "role_delete", name=name)
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    # Human-readable labels for the fixed permission areas, in the order
+    # they should appear as grid rows. Only TEST_CASES has any enforceable
+    # effect today (see PermissionArea's docstring) - the rest are included
+    # so the grid looks complete rather than growing rows later.
+    _AREA_LABELS: dict = {
+        PermissionArea.TEST_CASES.value: "Test Cases",
+        PermissionArea.MILESTONES.value: "Milestones",
+        PermissionArea.TEST_RUNS.value: "Test Runs",
+        PermissionArea.TEST_PLANS.value: "Test Plans",
+        PermissionArea.TEST_REPORTS.value: "Test Reports",
+        PermissionArea.TEST_RESULTS.value: "Test Results",
+    }
 
     # Confirmation shown after each invite action succeeds. Without these the
     # page re-renders looking identical to having done nothing, so there is no
@@ -144,6 +241,9 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         "resend": ("Invitation resent to {email}. Any previous invitation "
                    "link is no longer valid."),
         "uninvite": "Invitation for {email} has been cancelled.",
+        "role_add": "Role '{name}' created.",
+        "role_modify": "Role '{name}' updated.",
+        "role_delete": "Role '{name}' deleted.",
     }
 
     # How long each confirmation stays on screen. Resend gets longer because
@@ -155,17 +255,26 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         "resend": 20_000,
     }
 
+    # Actions whose write happens from the Roles tab - re-rendering after
+    # one of these should land back on Roles rather than the default Users
+    # tab, otherwise every add/edit/delete bounces you away from where you
+    # were working.
+    _ROLE_ACTIONS: frozenset = frozenset(
+        {"role_add", "role_modify", "role_delete"})
+
     async def _render_after_write(self, response: ApiResponse,
                                   action: str,
-                                  email_address: str = ""):
+                                  **format_kwargs):
         """Re-render the page after a write, confirming it or showing an error.
 
         Args:
             response: The gateway response for the write operation.
             action: Short action name used in logging and to select the
-                confirmation message ("invite", "resend", "uninvite").
-            email_address: Address the action applied to, named in the
-                confirmation so it is clear which row was affected.
+                confirmation message ("invite", "resend", "uninvite",
+                "role_add", "role_modify", "role_delete").
+            **format_kwargs: Values substituted into the confirmation
+                message's placeholders (e.g. ``email="a@b.com"`` or
+                ``name="Tester"``).
 
         Returns:
             The re-rendered users and roles page.
@@ -177,18 +286,21 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
         if response.status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
             error_msg_str = self._extract_error(response)
             self._logger.warning(
-                "Invite %s failed (status %s): %s",
+                "%s failed (status %s): %s",
                 action, response.status_code, error_msg_str)
         else:
             template = self._SUCCESS_MESSAGES.get(action)
             if template:
-                success_msg_str = template.format(email=email_address)
+                success_msg_str = template.format(**format_kwargs)
                 success_dismiss_ms = self._SUCCESS_DISMISS_MS.get(
                     action, self._DEFAULT_DISMISS_MS)
 
+        active_tab = "roles" if action in self._ROLE_ACTIONS else "users"
+
         return await self._render(error_msg_str=error_msg_str,
                                   success_msg_str=success_msg_str,
-                                  success_dismiss_ms=success_dismiss_ms)
+                                  success_dismiss_ms=success_dismiss_ms,
+                                  active_tab=active_tab)
 
     @staticmethod
     def _extract_error(response: ApiResponse) -> str:
@@ -199,7 +311,8 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
 
     async def _render(self, error_msg_str: Optional[str] = None,
                       success_msg_str: Optional[str] = None,
-                      success_dismiss_ms: int = _DEFAULT_DISMISS_MS):
+                      success_dismiss_ms: int = _DEFAULT_DISMISS_MS,
+                      active_tab: str = "users"):
         """Fetch users and pending invites, then render the page.
 
         Args:
@@ -208,6 +321,9 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
                 page.
             success_dismiss_ms: How long the confirmation stays on screen
                 before dismissing itself.
+            active_tab: Which tab ("users" or "roles") should be shown as
+                active on render - so a role write lands back on Roles
+                rather than always resetting to the default Users tab.
 
         Returns:
             The rendered users and roles page response.
@@ -226,6 +342,7 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
                 "Could not load users — please try again.")
 
         invites = await self._fetch_pending_invites()
+        roles = await self._fetch_roles()
 
         return await self._render_page(
             pages.PAGE_INSTANCE_ADMIN_USERS_AND_ROLES,
@@ -234,6 +351,9 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
             active_admin_page="admin_page_users_roles",
             users=users,
             invites=invites,
+            roles=roles,
+            permission_areas=self._AREA_LABELS,
+            active_tab=active_tab,
             error_msg_str=error_msg_str,
             success_msg_str=success_msg_str,
             success_dismiss_ms=success_dismiss_ms)
@@ -287,3 +407,107 @@ class AdminUsersAndRolesPageHandler(PortalPageHandler):
             return ""
         return datetime.fromtimestamp(
             epoch_seconds, tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    async def _fetch_roles(self) -> list[dict]:
+        """Fetch every role together with its full permission grid.
+
+        The list endpoint (``GET /roles``) deliberately returns names only
+        - each role's grid is fetched individually via
+        ``_fetch_role_detail``. Mirrors ``_fetch_pending_invites``: a
+        failure fetching the list is non-fatal and simply renders the
+        table empty, and a failure fetching one role's grid still leaves
+        that role listed, just with an empty grid.
+
+        Returns:
+            A list of ``{"id", "name", "permissions_by_area",
+            "permissions_json"}`` dicts. ``permissions_by_area`` is keyed
+            by ``PermissionArea`` value for template lookups;
+            ``permissions_json`` is the same data JSON-encoded for the
+            edit button's ``data-permissions`` attribute (see
+            ``instance_admin_customisations.html``'s ``data-projects``
+            for the precedent this follows).
+        """
+        url = f"{self._config.apis_gateway_svc}web/roles"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch roles")
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch roles (status %s)", response.status_code)
+            return []
+
+        roles = []
+        for summary in response.body.get("roles", []):
+            role_id = summary.get("id")
+            detail = await self._fetch_role_detail(role_id)
+            permissions = detail.get("permissions", []) if detail else []
+            permissions_by_area = {p["area"]: p for p in permissions}
+            roles.append({
+                "id": role_id,
+                "name": summary.get("name", ""),
+                "permissions_by_area": permissions_by_area,
+                "permissions_json": json.dumps(permissions_by_area),
+            })
+        return roles
+
+    async def _fetch_role_detail(self, role_id) -> Optional[dict]:
+        """Fetch a single role's full permission grid.
+
+        Args:
+            role_id: The role's primary key.
+
+        Returns:
+            The role dict (``id``, ``name``, ``permissions``), or ``None``
+            on failure.
+        """
+        url = f"{self._config.apis_gateway_svc}web/roles/{role_id}"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch role %s", role_id)
+            return None
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch role %s (status %s)",
+                role_id, response.status_code)
+            return None
+
+        return response.body
+
+    @staticmethod
+    def _parse_permissions_from_form(form) -> list[dict]:
+        """Build a role's permission grid from the submitted checkbox form.
+
+        Checkbox fields are named ``perm_<area>_read``,
+        ``perm_<area>_add_modify`` and ``perm_<area>_delete``; a checkbox
+        is absent from the form entirely when unticked. An area with
+        nothing ticked is omitted rather than sent as an explicit
+        all-false row - the two are equivalent to the backend (an area
+        with no row has no access, see ``RoleRepository.get_role_permissions``),
+        so omitting keeps the payload to only what was actually granted.
+
+        Args:
+            form: The submitted form (werkzeug/quart MultiDict).
+
+        Returns:
+            A list of ``{"area", "can_read", "can_add_modify",
+            "can_delete"}`` dicts, one per area with at least one
+            permission ticked.
+        """
+        permissions: list[dict] = []
+        for area in PermissionArea:
+            can_read = form.get(f"perm_{area.value}_read") == "on"
+            can_add_modify = form.get(f"perm_{area.value}_add_modify") == "on"
+            can_delete = form.get(f"perm_{area.value}_delete") == "on"
+            if can_read or can_add_modify or can_delete:
+                permissions.append({
+                    "area": area.value,
+                    "can_read": can_read,
+                    "can_add_modify": can_add_modify,
+                    "can_delete": can_delete,
+                })
+        return permissions

--- a/items/services/items_web_portal/static/css/instance_admin_users_roles.css
+++ b/items/services/items_web_portal/static/css/instance_admin_users_roles.css
@@ -2,3 +2,63 @@ a.user-link:hover {
     color: #007bff !important;
     cursor: pointer !important;
 }
+
+/* Users & Roles - tabbed layout (mirrors instance_admin_customisations.css) */
+
+.users-roles-tabs {
+    border-bottom: 1px solid #cddceb;
+    overflow: hidden;
+    flex-wrap: nowrap;
+}
+
+.users-roles-tabs .nav-link {
+    color: #45525f;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 10px 16px;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.users-roles-tabs .nav-link:hover {
+    color: #2a72b5;
+    border-bottom-color: #cddceb;
+}
+
+.users-roles-tabs .nav-link.active {
+    color: #2a72b5;
+    font-weight: 600;
+    background-color: transparent;
+    border-bottom-color: #2a72b5;
+}
+
+.users-roles-tabs .nav-link i {
+    font-size: 1.05rem;
+    line-height: 1;
+}
+
+.users-roles-tab-content {
+    background-color: #ffffff;
+    border: 1px solid #cddceb;
+    border-top: none;
+    border-radius: 0 0 6px 6px;
+    padding: 24px;
+    min-height: 240px;
+}
+
+/*
+ * Collapse the tab labels to icons only once the full-label tab bar can no
+ * longer fit its container. The `icons-only` class is toggled by
+ * instance_admin_users_roles.js based on actual overflow, same mechanism as
+ * the Customisations page's tab bar.
+ */
+.users-roles-tabs.icons-only .nav-link .tab-label {
+    display: none;
+}
+
+.users-roles-tabs.icons-only .nav-link {
+    padding: 10px 14px;
+}

--- a/items/services/items_web_portal/static/scripts/instance_admin_users_roles.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_users_roles.js
@@ -1,13 +1,39 @@
 /*
- * Users & Roles page behaviour.
- *
- * Confirmation banners dismiss themselves after a delay set per message by
- * the server (data-auto-dismiss-ms). Errors deliberately carry no such
- * attribute and stay until the user closes them: a missed confirmation costs
- * nothing, whereas a missed error leaves someone believing an action
- * succeeded when it did not.
+ * Users & Roles page behaviour:
+ *   1. Responsive tab bar (collapse labels to icons when they would overflow).
+ *   2. Confirmation banner auto-dismiss.
+ *   3. Role add/edit modal population and the Add/Modify-implies-Read rule.
+ *   4. Role delete confirmation.
  */
 (function () {
+  /* ----------------------------------------------------------------
+   * Responsive tab bar
+   * ---------------------------------------------------------------- */
+  var tabBar = document.getElementById('usersRolesTabs');
+
+  function updateTabLabels() {
+    if (!tabBar) {
+      return;
+    }
+    // Measure in the labels-shown state so the decision is based on the space
+    // the labels actually need, not the collapsed width. Removing the class
+    // first forces a synchronous reflow before we read the dimensions.
+    tabBar.classList.remove('icons-only');
+    if (tabBar.scrollWidth > tabBar.clientWidth) {
+      tabBar.classList.add('icons-only');
+    }
+  }
+
+  window.addEventListener('resize', updateTabLabels);
+  updateTabLabels();
+
+  /* ----------------------------------------------------------------
+   * Confirmation banners dismiss themselves after a delay set per message
+   * by the server (data-auto-dismiss-ms). Errors deliberately carry no such
+   * attribute and stay until the user closes them: a missed confirmation
+   * costs nothing, whereas a missed error leaves someone believing an
+   * action succeeded when it did not.
+   * ---------------------------------------------------------------- */
   var banners = document.querySelectorAll('[data-auto-dismiss-ms]');
 
   Array.prototype.forEach.call(banners, function (banner) {
@@ -30,4 +56,162 @@
       }
     }, delay);
   });
+
+  /* ----------------------------------------------------------------
+   * Role add / edit modal
+   * ---------------------------------------------------------------- */
+  var roleModal = document.getElementById('roleModal');
+  var roleForm = document.getElementById('roleForm');
+  var roleTitle = document.getElementById('roleModalLabel');
+
+  var ADD_ROLE_ACTION = '/admin/users_roles/roles';
+
+  // Add/Modify implies Read (see user_roles_design.md §4.1): ticking
+  // Add/Modify auto-ticks and locks Read, since the combination of
+  // add-modify-without-read is rejected by the backend anyway. Locking it
+  // client-side turns a would-be validation error into something that is
+  // simply not reachable through the checkboxes.
+  function wirePermissionRow(area) {
+    var readBox = document.getElementById('role-perm-' + area + '-read');
+    var addModifyBox = document.getElementById('role-perm-' + area + '-add-modify');
+
+    if (!readBox || !addModifyBox) {
+      return;
+    }
+
+    addModifyBox.addEventListener('change', function () {
+      if (addModifyBox.checked) {
+        readBox.checked = true;
+        readBox.disabled = true;
+      } else {
+        readBox.disabled = false;
+      }
+    });
+  }
+
+  if (roleForm) {
+    Array.prototype.forEach.call(
+      roleForm.querySelectorAll('.role-perm-add-modify'),
+      function (box) {
+        wirePermissionRow(box.getAttribute('data-area'));
+      });
+
+    // Disabled form fields are not submitted by the browser at all - so a
+    // Read checkbox locked (disabled) by the rule above would silently
+    // vanish from the submitted form, sending can_add_modify=true with
+    // can_read absent/false and tripping the exact validation error the
+    // lock exists to prevent. Re-enable everything just before submission,
+    // once the user can no longer change it, so its "on" value is included.
+    roleForm.addEventListener('submit', function () {
+      Array.prototype.forEach.call(
+        roleForm.querySelectorAll('input[type="checkbox"]:disabled'),
+        function (box) {
+          box.disabled = false;
+        });
+    });
+  }
+
+  function resetPermissionGrid() {
+    if (!roleForm) {
+      return;
+    }
+    Array.prototype.forEach.call(
+      roleForm.querySelectorAll('input[type="checkbox"]'),
+      function (box) {
+        box.checked = false;
+        box.disabled = false;
+      });
+  }
+
+  function applyPermissionGrid(permissionsByArea) {
+    resetPermissionGrid();
+    Object.keys(permissionsByArea).forEach(function (area) {
+      var perm = permissionsByArea[area];
+      var readBox = document.getElementById('role-perm-' + area + '-read');
+      var addModifyBox = document.getElementById('role-perm-' + area + '-add-modify');
+      var deleteBox = document.getElementById('role-perm-' + area + '-delete');
+
+      if (readBox) {
+        readBox.checked = !!perm.can_read;
+      }
+      if (addModifyBox) {
+        addModifyBox.checked = !!perm.can_add_modify;
+      }
+      if (deleteBox) {
+        deleteBox.checked = !!perm.can_delete;
+      }
+      if (addModifyBox && addModifyBox.checked && readBox) {
+        readBox.checked = true;
+        readBox.disabled = true;
+      }
+    });
+  }
+
+  // Populate the shared modal for either "add" or "edit" when it opens.
+  if (roleModal && roleForm) {
+    roleModal.addEventListener('show.bs.modal', function (event) {
+      var trigger = event.relatedTarget;
+      var isEdit = trigger && trigger.classList.contains('edit-role-btn');
+
+      if (isEdit) {
+        var id = trigger.getAttribute('data-id');
+        roleTitle.textContent = 'Edit Role';
+        roleForm.action = ADD_ROLE_ACTION + '/' + id + '/modify';
+        roleForm.name.value = trigger.getAttribute('data-name') || '';
+
+        var permissions;
+        try {
+          permissions = JSON.parse(trigger.getAttribute('data-permissions') || '{}');
+        } catch (e) {
+          permissions = {};
+        }
+        applyPermissionGrid(permissions);
+      } else {
+        roleTitle.textContent = 'Add Role';
+        roleForm.action = ADD_ROLE_ACTION;
+        roleForm.reset();
+        resetPermissionGrid();
+      }
+    });
+  }
+
+  /* ----------------------------------------------------------------
+   * Role delete confirmation
+   * ---------------------------------------------------------------- */
+  var deleteRoleModal = document.getElementById('confirmDeleteRoleModal');
+  var deleteRoleForm = document.getElementById('roleDeleteForm');
+  var deleteRoleName = document.getElementById('role-delete-name');
+  var deleteRoleFormName = document.getElementById('role-delete-form-name');
+  var roleConfirmCheckbox = document.getElementById('roleConfirmCheckbox');
+  var roleConfirmButton = document.getElementById('roleConfirmDeleteButton');
+
+  if (deleteRoleModal) {
+    deleteRoleModal.addEventListener('show.bs.modal', function (event) {
+      var trigger = event.relatedTarget;
+      var id = trigger.getAttribute('data-id');
+      var name = trigger.getAttribute('data-name') || '';
+      deleteRoleName.textContent = name;
+      deleteRoleFormName.value = name;
+      deleteRoleForm.action = '/admin/users_roles/roles/' + id + '/delete';
+      roleConfirmCheckbox.checked = false;
+      roleConfirmButton.disabled = true;
+    });
+
+    deleteRoleModal.addEventListener('hidden.bs.modal', function () {
+      roleConfirmCheckbox.checked = false;
+      roleConfirmButton.disabled = true;
+    });
+  }
+
+  if (roleConfirmCheckbox) {
+    roleConfirmCheckbox.addEventListener('change', function () {
+      roleConfirmButton.disabled = !this.checked;
+    });
+  }
+
+  if (roleConfirmButton) {
+    roleConfirmButton.addEventListener('click', function () {
+      deleteRoleForm.submit();
+    });
+  }
 })();

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -44,17 +44,17 @@
       <!-- Tab navigation -->
       <ul class="nav nav-tabs users-roles-tabs flex-nowrap" id="usersRolesTabs" role="tablist">
         <li class="nav-item" role="presentation">
-          <button class="nav-link active" id="users-tab" data-bs-toggle="tab"
+          <button class="nav-link{{ ' active' if active_tab == 'users' else '' }}" id="users-tab" data-bs-toggle="tab"
                   data-bs-target="#users-tab-pane" type="button" role="tab"
-                  aria-controls="users-tab-pane" aria-selected="true" title="Users">
+                  aria-controls="users-tab-pane" aria-selected="{{ 'true' if active_tab == 'users' else 'false' }}" title="Users">
             <i class="bi bi-people"></i>
             <span class="tab-label">Users</span>
           </button>
         </li>
         <li class="nav-item" role="presentation">
-          <button class="nav-link" id="roles-tab" data-bs-toggle="tab"
+          <button class="nav-link{{ ' active' if active_tab == 'roles' else '' }}" id="roles-tab" data-bs-toggle="tab"
                   data-bs-target="#roles-tab-pane" type="button" role="tab"
-                  aria-controls="roles-tab-pane" aria-selected="false" title="Roles">
+                  aria-controls="roles-tab-pane" aria-selected="{{ 'true' if active_tab == 'roles' else 'false' }}" title="Roles">
             <i class="bi bi-person-badge"></i>
             <span class="tab-label">Roles</span>
           </button>
@@ -63,7 +63,7 @@
 
       <!-- Tab content -->
       <div class="tab-content users-roles-tab-content" id="usersRolesTabsContent">
-        <div class="tab-pane fade show active" id="users-tab-pane" role="tabpanel"
+        <div class="tab-pane fade{{ ' show active' if active_tab == 'users' else '' }}" id="users-tab-pane" role="tabpanel"
              aria-labelledby="users-tab">
           <table class="table">
             <thead>
@@ -158,7 +158,7 @@
             </tbody>
           </table>
         </div>
-        <div class="tab-pane fade" id="roles-tab-pane" role="tabpanel"
+        <div class="tab-pane fade{{ ' show active' if active_tab == 'roles' else '' }}" id="roles-tab-pane" role="tabpanel"
              aria-labelledby="roles-tab">
           <table class="table">
             <thead>

--- a/items/services/items_web_portal/templates/instance_admin_users_roles.html
+++ b/items/services/items_web_portal/templates/instance_admin_users_roles.html
@@ -17,7 +17,6 @@
 {% block instance_admin_body %}
     <div class="flex-grow-1">
       <h4 class="mb-3">Users & Roles</h4>
-      <hr />
 
       {% if error_msg_str %}
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
@@ -42,98 +41,169 @@
       </div>
       {% endif %}
 
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col">Full Name</th>
-            <th scope="col">Display Name</th>
-            <th scope="col">Email Address</th>
-            <th scope="col">Status</th>
-            <th scope="col">Administrator</th>
-            <th scope="col" class="text-end">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for user in users %}
-        <tr>
-          <td>{{ user.full_name }}</td>
-          <td>{{ user.display_name }}</td>
-          <td>{{ user.email_address }}</td>
-          <td>
-            {% if user.account_status == 1 %}
-              <span class="badge bg-success">Active</span>
-            {% else %}
-              <span class="badge bg-secondary">Inactive</span>
-            {% endif %}
-          </td>
-          <td>
-            {% if user.is_administrator %}
-              <span class="badge bg-primary">Admin</span>
-            {% else %}
-              &mdash;
-            {% endif %}
-          </td>
-          <td class="text-end">
-            <button class="btn btn-link text-primary"
-                    title="Edit user"
-                    onclick="window.location.href='/admin/users_roles/{{ user.id }}/modify'">
-              <i class="bi bi-pencil"></i>
-            </button>
-            <button class="btn btn-link text-secondary"
-                    title="Reset password"
-                    onclick="window.location.href='/admin/users_roles/{{ user.id }}/reset_password'">
-              <i class="bi bi-key"></i>
-            </button>
-          </td>
-        </tr>
-        {% endfor %}
-        </tbody>
-      </table>
-      <div class="mt-3 mb-4">
-        <button class="btn btn-primary" onclick="window.location.href='/admin/users_roles/add'">+ Add User</button>
-        <button class="btn btn-outline-primary" type="button"
-                data-bs-toggle="modal" data-bs-target="#inviteUserModal">+ Invite User</button>
-      </div>
+      <!-- Tab navigation -->
+      <ul class="nav nav-tabs users-roles-tabs flex-nowrap" id="usersRolesTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button class="nav-link active" id="users-tab" data-bs-toggle="tab"
+                  data-bs-target="#users-tab-pane" type="button" role="tab"
+                  aria-controls="users-tab-pane" aria-selected="true" title="Users">
+            <i class="bi bi-people"></i>
+            <span class="tab-label">Users</span>
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button class="nav-link" id="roles-tab" data-bs-toggle="tab"
+                  data-bs-target="#roles-tab-pane" type="button" role="tab"
+                  aria-controls="roles-tab-pane" aria-selected="false" title="Roles">
+            <i class="bi bi-person-badge"></i>
+            <span class="tab-label">Roles</span>
+          </button>
+        </li>
+      </ul>
 
-      <h5 class="mb-3">Pending Invites</h5>
-      <table class="table">
-        <thead>
-          <tr>
-            <th scope="col">Email Address</th>
-            <th scope="col">Invited</th>
-            <th scope="col">Expires</th>
-            <th scope="col" class="text-end">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-        {% for invite in invites %}
-        <tr>
-          <td>{{ invite.email_address }}</td>
-          <td>{{ invite.created_display }}</td>
-          <td>{{ invite.expires_display }}</td>
-          <td class="text-end">
-            <form class="d-inline" method="POST" action="/admin/users_roles/invite/resend">
-              <input type="hidden" name="email_address" value="{{ invite.email_address }}">
-              <button type="submit" class="btn btn-link text-primary p-1" title="Resend invite">
-                <i class="bi bi-arrow-repeat"></i>
-              </button>
-            </form>
-            <form class="d-inline" method="POST" action="/admin/users_roles/invite/uninvite"
-                  onsubmit="return confirm('Cancel the invite for {{ invite.email_address }}?');">
-              <input type="hidden" name="email_address" value="{{ invite.email_address }}">
-              <button type="submit" class="btn btn-link text-danger p-1" title="Cancel invite">
-                <i class="bi bi-x-circle"></i>
-              </button>
-            </form>
-          </td>
-        </tr>
-        {% else %}
-        <tr>
-          <td colspan="4" class="text-muted">No pending invites.</td>
-        </tr>
-        {% endfor %}
-        </tbody>
-      </table>
+      <!-- Tab content -->
+      <div class="tab-content users-roles-tab-content" id="usersRolesTabsContent">
+        <div class="tab-pane fade show active" id="users-tab-pane" role="tabpanel"
+             aria-labelledby="users-tab">
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Full Name</th>
+                <th scope="col">Display Name</th>
+                <th scope="col">Email Address</th>
+                <th scope="col">Status</th>
+                <th scope="col">Administrator</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for user in users %}
+            <tr>
+              <td>{{ user.full_name }}</td>
+              <td>{{ user.display_name }}</td>
+              <td>{{ user.email_address }}</td>
+              <td>
+                {% if user.account_status == 1 %}
+                  <span class="badge bg-success">Active</span>
+                {% else %}
+                  <span class="badge bg-secondary">Inactive</span>
+                {% endif %}
+              </td>
+              <td>
+                {% if user.is_administrator %}
+                  <span class="badge bg-primary">Admin</span>
+                {% else %}
+                  &mdash;
+                {% endif %}
+              </td>
+              <td class="text-end">
+                <button class="btn btn-link text-primary"
+                        title="Edit user"
+                        onclick="window.location.href='/admin/users_roles/{{ user.id }}/modify'">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button class="btn btn-link text-secondary"
+                        title="Reset password"
+                        onclick="window.location.href='/admin/users_roles/{{ user.id }}/reset_password'">
+                  <i class="bi bi-key"></i>
+                </button>
+              </td>
+            </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          <div class="mt-3 mb-4">
+            <button class="btn btn-primary" onclick="window.location.href='/admin/users_roles/add'">+ Add User</button>
+            <button class="btn btn-outline-primary" type="button"
+                    data-bs-toggle="modal" data-bs-target="#inviteUserModal">+ Invite User</button>
+          </div>
+
+          <h5 class="mb-3">Pending Invites</h5>
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Email Address</th>
+                <th scope="col">Invited</th>
+                <th scope="col">Expires</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for invite in invites %}
+            <tr>
+              <td>{{ invite.email_address }}</td>
+              <td>{{ invite.created_display }}</td>
+              <td>{{ invite.expires_display }}</td>
+              <td class="text-end">
+                <form class="d-inline" method="POST" action="/admin/users_roles/invite/resend">
+                  <input type="hidden" name="email_address" value="{{ invite.email_address }}">
+                  <button type="submit" class="btn btn-link text-primary p-1" title="Resend invite">
+                    <i class="bi bi-arrow-repeat"></i>
+                  </button>
+                </form>
+                <form class="d-inline" method="POST" action="/admin/users_roles/invite/uninvite"
+                      onsubmit="return confirm('Cancel the invite for {{ invite.email_address }}?');">
+                  <input type="hidden" name="email_address" value="{{ invite.email_address }}">
+                  <button type="submit" class="btn btn-link text-danger p-1" title="Cancel invite">
+                    <i class="bi bi-x-circle"></i>
+                  </button>
+                </form>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="4" class="text-muted">No pending invites.</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <div class="tab-pane fade" id="roles-tab-pane" role="tabpanel"
+             aria-labelledby="roles-tab">
+          <table class="table">
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col" class="text-end">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for role in roles %}
+            <tr>
+              <td>{{ role.name }}</td>
+              <td class="text-end">
+                <button type="button" class="btn btn-link text-primary p-1 edit-role-btn"
+                        title="Edit"
+                        data-bs-toggle="modal" data-bs-target="#roleModal"
+                        data-id="{{ role.id }}"
+                        data-name="{{ role.name }}"
+                        data-permissions="{{ role.permissions_json }}">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button type="button" class="btn btn-link text-danger p-1 delete-role-btn"
+                        title="Delete"
+                        data-bs-toggle="modal" data-bs-target="#confirmDeleteRoleModal"
+                        data-id="{{ role.id }}"
+                        data-name="{{ role.name }}">
+                  <i class="bi bi-x-circle"></i>
+                </button>
+              </td>
+            </tr>
+            {% else %}
+            <tr>
+              <td colspan="2" class="text-muted">No roles defined yet.</td>
+            </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          <div class="mt-3 mb-4">
+            <button type="button" class="btn btn-primary" id="add-role-btn"
+                    data-bs-toggle="modal" data-bs-target="#roleModal">
+              + Add Role
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
 <!-- Invite User modal -->
@@ -165,4 +235,103 @@
     </div>
   </div>
 </div>
+
+<!-- Add / Edit role modal -->
+<div class="modal fade" id="roleModal" tabindex="-1"
+     aria-labelledby="roleModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <form id="roleForm" method="POST" action="/admin/users_roles/roles">
+        <div class="modal-header">
+          <h5 class="modal-title" id="roleModalLabel">Add Role</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label for="role-name" class="form-label">Name</label>
+            <input type="text" class="form-control" id="role-name" name="name"
+                   required placeholder="e.g. Tester, Lead or Guest">
+          </div>
+          <table class="table table-sm role-permissions-table">
+            <thead>
+              <tr>
+                <th scope="col">Permissions</th>
+                <th scope="col" class="text-center">Read</th>
+                <th scope="col" class="text-center">Add/Modify</th>
+                <th scope="col" class="text-center">Delete</th>
+              </tr>
+            </thead>
+            <tbody>
+            {% for area_value, area_label in permission_areas.items() %}
+              <tr>
+                <td>{{ area_label }}</td>
+                <td class="text-center">
+                  <input class="form-check-input role-perm-read" type="checkbox"
+                         id="role-perm-{{ area_value }}-read"
+                         name="perm_{{ area_value }}_read"
+                         data-area="{{ area_value }}">
+                </td>
+                <td class="text-center">
+                  <input class="form-check-input role-perm-add-modify" type="checkbox"
+                         id="role-perm-{{ area_value }}-add-modify"
+                         name="perm_{{ area_value }}_add_modify"
+                         data-area="{{ area_value }}">
+                </td>
+                <td class="text-center">
+                  <input class="form-check-input" type="checkbox"
+                         id="role-perm-{{ area_value }}-delete"
+                         name="perm_{{ area_value }}_delete"
+                         data-area="{{ area_value }}">
+                </td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          <div class="form-text">
+            Ticking Add/Modify also grants Read - the two cannot be
+            separated.
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-primary">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- Delete role confirmation modal -->
+<div class="modal fade" id="confirmDeleteRoleModal" tabindex="-1"
+     aria-labelledby="confirmDeleteRoleModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirmDeleteRoleModalLabel">Confirmation</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>Are you sure you want to delete the role
+           "<span id="role-delete-name"></span>"? This action cannot be undone.</p>
+        <p class="text-muted">
+          Any user assigned this role on a project keeps their membership -
+          their role there is cleared to "Unassigned" rather than being
+          removed.
+        </p>
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="roleConfirmCheckbox">
+          <label class="form-check-label" for="roleConfirmCheckbox">I confirm I want to delete this item.</label>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="roleConfirmDeleteButton" disabled>OK</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<form id="roleDeleteForm" method="POST" style="display: none;">
+  <input type="hidden" name="name" id="role-delete-form-name">
+</form>
 {% endblock %}

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 7"
+PRE_RELEASE = "Alpha Build 8"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -43,6 +43,11 @@ from test_admin_users_and_roles_page_handler import (
     TestInviteUser,
     TestResendInvite,
     TestUninvite,
+    TestUsersAndRolesReadRoles,
+    TestRoleAdd,
+    TestRoleModify,
+    TestRoleDelete,
+    TestParsePermissionsFromForm,
     TestFormatEpoch,
 )
 from test_admin_projects_handlers import (

--- a/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
+++ b/unit_tests/web_portal_svc/test_admin_users_and_roles_page_handler.py
@@ -33,6 +33,14 @@ _INVITES_OK = ApiResponse(
     status_code=HTTPStatus.OK, body={"invites": [
         {"email_address": "new@b.com", "created_at": 1700000000,
          "expires_at": 1700172800}]})
+_ROLES_LIST_OK = ApiResponse(
+    status_code=HTTPStatus.OK, body={"roles": [{"id": 1, "name": "Tester"}]})
+_ROLE_DETAIL_OK = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"id": 1, "name": "Tester", "permissions": [
+        {"area": "test_cases", "can_read": True, "can_add_modify": True,
+         "can_delete": False}]})
+_ROLES_EMPTY = ApiResponse(status_code=HTTPStatus.OK, body={"roles": []})
 
 
 def _config():
@@ -215,6 +223,17 @@ class TestInviteUser(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn('data-auto-dismiss-ms="10000"', text)
 
+    async def test_success_stays_on_the_users_tab(self):
+        """A non-role write shouldn't jump the admin over to Roles."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+
+        response = await self._post({"email_address": "new@b.com"})
+        text = await response.get_data(as_text=True)
+
+        self.assertIn(
+            'tab-pane fade show active" id="users-tab-pane"', text)
+
 
 class TestResendInvite(unittest.IsolatedAsyncioTestCase):
     """POST /admin/users_roles/invite/resend"""
@@ -371,6 +390,382 @@ class TestUninvite(unittest.IsolatedAsyncioTestCase):
         response = await self._post({"email_address": "new@b.com"})
         text = await response.get_data(as_text=True)
         self.assertIn("No pending invite found", text)
+
+
+class TestUsersAndRolesReadRoles(unittest.IsolatedAsyncioTestCase):
+    """GET /admin/users_roles - the Roles section."""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK, _ROLES_LIST_OK, _ROLE_DETAIL_OK]
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles", methods=["GET"])
+        async def route():
+            return await handler.users_and_roles()
+
+        self.client = app.test_client()
+
+    async def _get(self, headers=_AUTH_HEADERS):
+        async with self.client as c:
+            return await c.get("/admin/users_roles", headers=headers)
+
+    async def test_renders_page_with_roles(self):
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Tester", text)
+
+    async def test_no_roles_shows_placeholder(self):
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK, _ROLES_EMPTY]
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("No roles defined yet", text)
+
+    async def test_roles_fetch_failure_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK,
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("No roles defined yet", text)
+
+    async def test_roles_fetch_exception_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK, RuntimeError("boom")]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("No roles defined yet", text)
+
+    async def test_role_detail_failure_still_lists_the_role(self):
+        """A bad detail fetch for one role doesn't drop it from the table -
+        it's shown with an empty grid instead."""
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK, _ROLES_LIST_OK,
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={})]
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Tester", text)
+
+    async def test_permissions_embedded_for_the_edit_modal(self):
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("data-permissions=", text)
+        self.assertIn("test_cases", text)
+
+    async def test_role_detail_fetch_exception_still_lists_the_role(self):
+        """A raised exception fetching one role's grid (as opposed to a
+        plain error status) is caught the same way - the role stays listed
+        with an empty grid rather than taking the whole page down."""
+        self.mock_rest_client.get.side_effect = [
+            _USERS_OK, _INVITES_OK, _ROLES_LIST_OK, RuntimeError("boom")]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Tester", text)
+
+
+class TestRoleAdd(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/roles"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/roles", methods=["POST"])
+        async def route():
+            return await handler.role_add()
+
+        self.client = app.test_client()
+
+    async def _post(self, form):
+        async with self.client as c:
+            return await c.post(
+                "/admin/users_roles/roles", form=form, headers=_AUTH_HEADERS)
+
+    async def test_missing_name_renders_error(self):
+        response = await self._post({})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role name is required", text)
+        self.mock_rest_client.post.assert_called_once()  # only session check
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 1})]
+        response = await self._post({"name": "Tester"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_name_and_permissions_forwarded_to_gateway(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 1})]
+        await self._post({
+            "name": "Tester",
+            "perm_test_cases_read": "on",
+            "perm_test_cases_add_modify": "on",
+        })
+        call = self.mock_rest_client.post.call_args_list[1]
+        self.assertEqual(call[0][0], "http://gateway/web/roles")
+        self.assertEqual(call[1]["json_data"], {
+            "name": "Tester",
+            "permissions": [{
+                "area": "test_cases", "can_read": True,
+                "can_add_modify": True, "can_delete": False,
+            }],
+        })
+
+    async def test_unticked_area_omitted_from_permissions(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 1})]
+        await self._post({"name": "Tester"})
+        call = self.mock_rest_client.post.call_args_list[1]
+        self.assertEqual(call[1]["json_data"]["permissions"], [])
+
+    async def test_duplicate_name_shows_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT,
+                       body={"error": "Role name already in use"})]
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role name already in use", text)
+
+    async def test_success_confirms_the_role(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 1})]
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("alert-success", text)
+        self.assertIn("Tester", text)
+        self.assertIn("created", text)
+
+    async def test_success_returns_to_the_roles_tab(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CREATED, body={"id": 1})]
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn(
+            'tab-pane fade show active" id="roles-tab-pane"', text)
+
+    async def test_validation_error_stays_on_the_roles_tab(self):
+        """A missing-name resubmit shouldn't bounce the admin back to the
+        Users tab, away from the form they were just filling in."""
+        response = await self._post({})
+        text = await response.get_data(as_text=True)
+        self.assertIn(
+            'tab-pane fade show active" id="roles-tab-pane"', text)
+
+    async def test_gateway_error_stays_on_the_roles_tab(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT,
+                       body={"error": "Role name already in use"})]
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn(
+            'tab-pane fade show active" id="roles-tab-pane"', text)
+
+
+class TestRoleModify(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/roles/<id>/modify"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/roles/<int:role_id>/modify",
+                  methods=["POST"])
+        async def route(role_id: int):
+            return await handler.role_modify(role_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, form, role_id=1):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/users_roles/roles/{role_id}/modify", form=form,
+                headers=_AUTH_HEADERS)
+
+    async def test_missing_name_renders_error(self):
+        response = await self._post({})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role name is required", text)
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Lead"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_url_and_body_forwarded_to_gateway(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        await self._post({
+            "name": "Lead",
+            "perm_test_cases_delete": "on",
+        }, role_id=9)
+        call = self.mock_rest_client.patch.call_args
+        self.assertEqual(call[0][0], "http://gateway/web/roles/9")
+        self.assertEqual(call[1]["json_data"], {
+            "name": "Lead",
+            "permissions": [{
+                "area": "test_cases", "can_read": False,
+                "can_add_modify": False, "can_delete": True,
+            }],
+        })
+
+    async def test_not_found_shows_error(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            body={"error": "Role not found"})
+        response = await self._post({"name": "Lead"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role not found", text)
+
+    async def test_success_confirms_the_update(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Lead"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("alert-success", text)
+        self.assertIn("Lead", text)
+        self.assertIn("updated", text)
+
+    async def test_success_returns_to_the_roles_tab(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Lead"})
+        text = await response.get_data(as_text=True)
+        self.assertIn(
+            'tab-pane fade show active" id="roles-tab-pane"', text)
+
+
+class TestRoleDelete(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/roles/<id>/delete"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=HTTPStatus.OK, body={"users": [], "invites": []})
+        handler = AdminUsersAndRolesPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/roles/<int:role_id>/delete",
+                  methods=["POST"])
+        async def route(role_id: int):
+            return await handler.role_delete(role_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, form, role_id=1):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/users_roles/roles/{role_id}/delete", form=form,
+                headers=_AUTH_HEADERS)
+
+    async def test_success_rerenders_page(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Tester"})
+        self.assertEqual(response.status_code, 200)
+
+    async def test_url_includes_role_id(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        await self._post({"name": "Tester"}, role_id=7)
+        self.mock_rest_client.delete.assert_called_once_with(
+            "http://gateway/web/roles/7")
+
+    async def test_not_found_shows_error(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            body={"error": "Role not found"})
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role not found", text)
+
+    async def test_success_confirms_the_deletion(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("alert-success", text)
+        self.assertIn("Tester", text)
+        self.assertIn("deleted", text)
+
+    async def test_missing_name_falls_back_to_a_generic_label(self):
+        """The delete form always carries a name (JS sets the hidden field
+        before submitting), but a missing one still produces a sensible
+        message rather than a KeyError or a blank subject."""
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role", text)
+        self.assertIn("deleted", text)
+
+    async def test_success_returns_to_the_roles_tab(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.OK)
+        response = await self._post({"name": "Tester"})
+        text = await response.get_data(as_text=True)
+        self.assertIn(
+            'tab-pane fade show active" id="roles-tab-pane"', text)
+
+
+class TestParsePermissionsFromForm(unittest.TestCase):
+    """Direct unit tests for the _parse_permissions_from_form helper."""
+
+    def test_no_checkboxes_ticked_returns_empty_list(self):
+        result = AdminUsersAndRolesPageHandler._parse_permissions_from_form({})
+        self.assertEqual(result, [])
+
+    def test_read_only_area_included(self):
+        form = {"perm_test_cases_read": "on"}
+        result = AdminUsersAndRolesPageHandler._parse_permissions_from_form(
+            form)
+        self.assertEqual(result, [{
+            "area": "test_cases", "can_read": True,
+            "can_add_modify": False, "can_delete": False,
+        }])
+
+    def test_multiple_areas_preserve_definition_order(self):
+        form = {
+            "perm_test_cases_read": "on",
+            "perm_milestones_delete": "on",
+        }
+        result = AdminUsersAndRolesPageHandler._parse_permissions_from_form(
+            form)
+        self.assertEqual([p["area"] for p in result],
+                         ["test_cases", "milestones"])
 
 
 class TestFormatEpoch(unittest.TestCase):

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -156,6 +156,24 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
                 form={"email_address": "a@b.com"})
         self.assertNotEqual(response.status_code, 405)
 
+    async def test_admin_role_add_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/roles", form={"name": "Tester"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_role_modify_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/roles/1/modify", form={"name": "Tester"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_role_delete_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post(
+                "/admin/users_roles/roles/1/delete", form={"name": "Tester"})
+        self.assertNotEqual(response.status_code, 405)
+
     async def test_admin_manage_data_route_is_reachable(self):
         async with self.client as c:
             response = await c.get("/admin/manage_data")


### PR DESCRIPTION
# Web Portal: Roles admin UI

**Branch:** `portal_user_roles_and_membership` (pushed, PR pending)
**Theme:** Roles & permissions (post-0.3.0) — fifth application-code piece,
the first Portal-side UI on top of the Identity/Gateway data-and-access
layer (`identity_roles_db_update` → `identity_roles_crud` →
`identity_project_membership` → `gateway_roles_and_membership`)

## Summary

Despite the branch name, this branch delivers **only** the Roles admin
UI half. The Project Membership UI (the "Projects" tab on Add/Modify
User) is being split into its own branch instead - mirroring the split
already used on the Identity side (`identity_roles_crud` vs
`identity_project_membership`) rather than combining, since the two
touch entirely different files (this branch never goes near the
Add/Modify User handlers or templates) and the membership UI still has
real UX design ahead of it - unlike the Gateway proxy branch, where the
API contract was already fully settled by Identity before that branch
started, which was the specific reason *that* branch was combined.

## Portal: Roles section on the existing Users & Roles page

Added as a third section on `admin_users_and_roles_page_handler.py` /
`instance_admin_users_roles.html` rather than a new top-level admin
page - that page already handled two domains (Users + Pending Invites)
via a shared render, and is literally already named for this.

- New `role_add`/`role_modify`/`role_delete` handler methods, proxying
  to the Gateway's `/web/roles` endpoints from the already-merged
  `gateway_roles_and_membership` branch. All `@require_administrator`.
- `_fetch_roles()` pre-fetches every role's full permission grid
  individually (`GET /web/roles/<id>` per role, since the list endpoint
  deliberately returns names only) and embeds it via a
  `data-permissions` attribute, mirroring the Case Fields
  `data-projects` pattern - a deliberate N+1-on-page-load choice over a
  new on-demand JS-fetch route, discussed with the user before
  implementing rather than picked unilaterally.
- Add/Edit role modal: shared modal populated from `data-*` attributes
  (same shared-modal-via-JS convention as Case Fields), a 6-area ×
  Read/Add-Modify/Delete grid matching `user_roles_design.md` §4.
  Add-Modify-implies-Read is enforced both client-side (JS auto-ticks
  and visually locks Read) and server-side (Identity's existing
  validation) - belt and braces, not a replacement for either.
- Delete confirmation modal explicitly tells the admin that deleting a
  role clears (not removes) affected memberships to "Unassigned" per
  §4.3/§10.4 of the design doc - the `ON DELETE SET NULL` FK behaviour
  this relies on was already smoke-tested against a real SQLite DB back
  in the Identity membership branch.
- `_render_after_write` generalised from an invite-only, email-specific
  helper to accept arbitrary `**format_kwargs`, so it now drives both
  invite and role confirmation messages from one place.

## Portal: Users/Roles tabbed layout

Restructured the page from stacked sections into a tab bar (Users |
Roles), matching the Customisations page's existing tab convention -
raised by the user after comparing against TestRail's own Users & Roles
layout. Mirrors Customisations exactly: same `nav-tabs`/`tab-content`
structure, same responsive icons-only-on-overflow JS behaviour, CSS
kept independently scoped (`.users-roles-tabs` vs `.customisations-tabs`)
rather than shared, so the two pages can diverge later without coupling.

A role write (add/modify/delete, including a rejected validation
attempt) now re-renders with the Roles tab active instead of always
resetting to Users - `_render()` gained an `active_tab` parameter that
`_render_after_write` derives automatically from the action name.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

296 tests in the web portal service, 100% coverage maintained on
`items/services/items_web_portal`, pylint 10.00/10. New: role
add/modify/delete write-path tests (including active-tab assertions),
roles-section rendering tests (including non-fatal failure/exception
paths for both the roles-list fetch and each per-role detail fetch),
direct unit tests for `_parse_permissions_from_form`, and route
reachability for the three new role routes in `test_route_factories.py`.

## Deliberately out of scope

- **No Project Membership UI** - split into its own branch, see Summary.
- **No enforcement of membership on read routes** - unchanged from every
  prior branch's scope note. `GET /web/projects`, `GET /web/projects/<id>`,
  `GET /web/<project_id>/testcases`, `GET /web/testcases/<id>` are all
  still `@require_session`-only. Still the final piece of this theme,
  with the original acceptance test still the target: assigned to
  projects 1/3/5, project 2 returns nothing.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
