### PR TITLE
[Portal] Project Membership

### DIFF
--- a/items/services/items_web_portal/page_handlers/admin/users/__init__.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/__init__.py
@@ -86,6 +86,33 @@ def create_admin_users_page_handlers(injections: PageHandlerInjections) -> Bluep
     async def admin_modify_user_post(user_id: str):
         return await handler_modify_user.modify_user_post(user_id)
 
+    injections.logger.debug("=> %s POST /admin/users_roles/<id>/projects",
+                            "Admin add user project".ljust(40))
+
+    @routes.route('/<string:user_id>/projects', methods=['POST'])
+    async def admin_add_user_project(user_id: str):
+        return await handler_modify_user.add_user_project(user_id)
+
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/<id>/projects/<id>/modify",
+        "Admin modify user project role".ljust(40))
+
+    @routes.route('/<string:user_id>/projects/<int:project_id>/modify',
+                  methods=['POST'])
+    async def admin_modify_user_project(user_id: str, project_id: int):
+        return await handler_modify_user.modify_user_project(
+            user_id, project_id)
+
+    injections.logger.debug(
+        "=> %s POST /admin/users_roles/<id>/projects/<id>/delete",
+        "Admin remove user project".ljust(40))
+
+    @routes.route('/<string:user_id>/projects/<int:project_id>/delete',
+                  methods=['POST'])
+    async def admin_remove_user_project(user_id: str, project_id: int):
+        return await handler_modify_user.remove_user_project(
+            user_id, project_id)
+
     injections.logger.debug("=> %s GET /admin/users_roles/<id>/reset_password",
                             "Admin reset password page (read)".ljust(40))
 

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_modify_user_page_handler.py
@@ -15,7 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import http
+from http import HTTPStatus
 import logging
+from typing import Optional
 from quart import make_response, request
 from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.rest_client import RestClient
@@ -31,8 +33,12 @@ class AdminModifyUserPageHandler(PortalPageHandler):
     """Handles requests for editing an existing user.
 
     Fetches the current user data from the gateway on GET and submits a
-    patch-style update on POST.
+    patch-style update on POST. Also owns the Projects tab: listing,
+    adding, changing the role on, and removing this user's project
+    memberships.
     """
+
+    _DEFAULT_ACTIVE_TAB: str = "tab-user"
 
     def __init__(self,
                  logger: logging.Logger,
@@ -49,6 +55,10 @@ class AdminModifyUserPageHandler(PortalPageHandler):
         """
         super().__init__(logger, config, rest_client)
         self._metadata_settings = metadata
+
+    # ------------------------------------------------------------------
+    # Read / write: core user fields (User and Access tabs)
+    # ------------------------------------------------------------------
 
     @require_administrator
     async def modify_user_get(self, user_id: str):
@@ -79,14 +89,7 @@ class AdminModifyUserPageHandler(PortalPageHandler):
                 form_data={},
                 error_msg_str="Could not load user — please try again.")
 
-        user = response.body
-        form_data = {
-            "full_name": user.get("full_name", ""),
-            "display_name": user.get("display_name", ""),
-            "email_address": user.get("email_address", ""),
-            "account_status": user.get("account_status", 1),
-            "is_administrator": bool(user.get("is_administrator", False)),
-        }
+        form_data = self._user_to_form_data(response.body)
         return await self._render(user_id=user_id, form_data=form_data)
 
     @require_administrator
@@ -160,20 +163,295 @@ class AdminModifyUserPageHandler(PortalPageHandler):
         return await make_response(
             self._generate_redirect('/admin/users_roles'))
 
+    # ------------------------------------------------------------------
+    # Write: project membership (Projects tab)
+    # ------------------------------------------------------------------
+
+    _PROJECT_SUCCESS_MESSAGES: dict = {
+        "add": "Project access added.",
+        "modify": "Role updated.",
+        "remove": "Project access removed.",
+    }
+
+    @require_administrator
+    async def add_user_project(self, user_id: str):
+        """Add a project membership for the user from the submitted form.
+
+        Args:
+            user_id: The ID of the user being granted access.
+
+        Returns:
+            The re-rendered edit user page, on the Projects tab.
+        """
+        form = await request.form
+        project_id_str = form.get("project_id", "").strip()
+        role_id_str = form.get("role_id", "").strip()
+
+        if not project_id_str:
+            return await self._render_projects_after_write(
+                user_id, error_msg_str="Select a project.")
+
+        try:
+            project_id = int(project_id_str)
+        except ValueError:
+            return await self._render_projects_after_write(
+                user_id, error_msg_str="Invalid project.")
+
+        body: dict = {"project_id": project_id}
+        if role_id_str:
+            try:
+                body["role_id"] = int(role_id_str)
+            except ValueError:
+                return await self._render_projects_after_write(
+                    user_id, error_msg_str="Invalid role.")
+
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}/projects"
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=body)
+
+        return await self._render_projects_after_write(
+            user_id, response=response, action="add")
+
+    @require_administrator
+    async def modify_user_project(self, user_id: str, project_id: int):
+        """Change (or clear) the role on an existing project membership.
+
+        Args:
+            user_id: The ID of the user whose membership is being changed.
+            project_id: The project the membership belongs to.
+
+        Returns:
+            The re-rendered edit user page, on the Projects tab.
+        """
+        form = await request.form
+        role_id_str = form.get("role_id", "").strip()
+
+        role_id: Optional[int] = None
+        if role_id_str:
+            try:
+                role_id = int(role_id_str)
+            except ValueError:
+                return await self._render_projects_after_write(
+                    user_id, error_msg_str="Invalid role.")
+
+        url = (f"{self._config.apis_gateway_svc}web/users/{user_id}"
+               f"/projects/{project_id}")
+        response: ApiResponse = await self._rest_client.patch(
+            url, json_data={"role_id": role_id})
+
+        return await self._render_projects_after_write(
+            user_id, response=response, action="modify")
+
+    @require_administrator
+    async def remove_user_project(self, user_id: str, project_id: int):
+        """Remove a project membership.
+
+        Args:
+            user_id: The ID of the user losing access.
+            project_id: The project the membership belongs to.
+
+        Returns:
+            The re-rendered edit user page, on the Projects tab.
+        """
+        url = (f"{self._config.apis_gateway_svc}web/users/{user_id}"
+               f"/projects/{project_id}")
+        response: ApiResponse = await self._rest_client.delete(url)
+
+        return await self._render_projects_after_write(
+            user_id, response=response, action="remove")
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _user_to_form_data(user: dict) -> dict:
+        """Map a gateway user body to the template's form_data shape."""
+        return {
+            "full_name": user.get("full_name", ""),
+            "display_name": user.get("display_name", ""),
+            "email_address": user.get("email_address", ""),
+            "account_status": user.get("account_status", 1),
+            "is_administrator": bool(user.get("is_administrator", False)),
+        }
+
+    async def _render_projects_after_write(
+            self, user_id: str,
+            response: Optional[ApiResponse] = None,
+            action: Optional[str] = None,
+            error_msg_str: Optional[str] = None):
+        """Re-render the edit user page after a project-membership write.
+
+        Always lands back on the Projects tab, confirming the write or
+        showing an error - mirrors the Roles admin page's
+        _render_after_write.
+
+        Args:
+            user_id: The ID of the user whose memberships were changed.
+            response: The gateway response for the write, or None if the
+                request never reached the gateway (form validation failed
+                first).
+            action: Short action name used to select the confirmation
+                message ("add", "modify", "remove"). Ignored if response
+                is None.
+            error_msg_str: Error to show directly, for validation failures
+                that happened before any gateway call.
+
+        Returns:
+            The re-rendered edit user page, on the Projects tab.
+        """
+        success_msg_str: Optional[str] = None
+
+        if response is not None:
+            if response.status_code not in (HTTPStatus.OK, HTTPStatus.CREATED):
+                error_msg_str = self._extract_error(response)
+                self._logger.warning(
+                    "Project %s failed for user %s (status %s): %s",
+                    action, user_id, response.status_code, error_msg_str)
+            else:
+                success_msg_str = self._PROJECT_SUCCESS_MESSAGES.get(action)
+
+        form_data = await self._current_form_data(user_id)
+
+        return await self._render(
+            user_id=user_id,
+            form_data=form_data,
+            error_msg_str=error_msg_str,
+            success_msg_str=success_msg_str,
+            active_tab="tab-projects")
+
+    async def _current_form_data(self, user_id: str) -> dict:
+        """Re-fetch the user's core fields to re-populate the User/Access
+        tabs after a project-membership write (which doesn't touch them,
+        but the shared form still needs correct values to show).
+
+        A failure here is non-fatal: the User/Access tabs would simply show
+        blank fields rather than the Projects tab write itself failing.
+        """
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}"
+        response: ApiResponse = await self._rest_client.get(url)
+        if response.status_code != HTTPStatus.OK:
+            return {}
+        return self._user_to_form_data(response.body)
+
+    @staticmethod
+    def _extract_error(response: ApiResponse) -> str:
+        """Extract a human-readable error message from a gateway response."""
+        if isinstance(response.body, dict) and response.body.get("error"):
+            return str(response.body["error"])
+        return "The request could not be completed. Please try again."
+
+    async def _fetch_projects(self) -> list[dict]:
+        """Fetch every project's id and name, for the Add Project picker.
+
+        A failure here is non-fatal: the picker is simply rendered empty
+        so the rest of the page still works.
+
+        Returns:
+            A list of ``{"id", "name"}`` dicts, or [] on failure.
+        """
+        url = f"{self._config.apis_gateway_svc}web/projects?value_fields=name"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch projects")
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch projects (status %s)", response.status_code)
+            return []
+
+        projects = (response.body or {}).get("projects", [])
+        return [{"id": p.get("id"), "name": p.get("name", "")}
+                for p in projects if p.get("id") is not None]
+
+    async def _fetch_roles(self) -> list[dict]:
+        """Fetch every role's id and name, for the role picker dropdowns.
+
+        A failure here is non-fatal: the dropdowns are simply rendered
+        with no options beyond "Unassigned" so the rest of the page still
+        works.
+
+        Returns:
+            A list of ``{"id", "name"}`` dicts, or [] on failure.
+        """
+        url = f"{self._config.apis_gateway_svc}web/roles"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning("Unable to fetch roles")
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch roles (status %s)", response.status_code)
+            return []
+
+        return (response.body or {}).get("roles", [])
+
+    async def _fetch_memberships(self, user_id: str) -> list[dict]:
+        """Fetch the user's project memberships.
+
+        A failure here is non-fatal: the Projects tab is simply rendered
+        with no rows so the rest of the page still works.
+
+        Returns:
+            A list of ``{"project_id", "role_id", "role_name"}`` dicts, or
+            [] on failure.
+        """
+        url = f"{self._config.apis_gateway_svc}web/users/{user_id}/projects"
+        try:
+            response = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning(
+                "Unable to fetch project memberships for %s", user_id)
+            return []
+
+        if response.status_code != HTTPStatus.OK:
+            self._logger.warning(
+                "Unable to fetch project memberships for %s (status %s)",
+                user_id, response.status_code)
+            return []
+
+        return (response.body or {}).get("memberships", [])
+
     async def _render(self,
                       user_id: str,
                       form_data: dict,
-                      error_msg_str: str | None = None):
-        """Render the edit user page.
+                      error_msg_str: Optional[str] = None,
+                      success_msg_str: Optional[str] = None,
+                      active_tab: str = _DEFAULT_ACTIVE_TAB):
+        """Render the edit user page, including the Projects tab's data.
 
         Args:
             user_id: ID of the user being edited (used in the form action).
-            form_data: Values used to pre-populate the form fields.
+            form_data: Values used to pre-populate the User/Access tabs.
             error_msg_str: Optional error message to display.
+            success_msg_str: Optional confirmation message to display.
+            active_tab: Which tab ("tab-user", "tab-access" or
+                "tab-projects") should be shown as active on render - so a
+                project-membership write lands back on Projects rather
+                than always resetting to the first tab.
 
         Returns:
             The rendered edit user page response.
         """
+        all_projects = await self._fetch_projects()
+        project_names_by_id = {p["id"]: p["name"] for p in all_projects}
+
+        memberships = await self._fetch_memberships(user_id)
+        for membership in memberships:
+            project_id = membership.get("project_id")
+            membership["project_name"] = project_names_by_id.get(
+                project_id, f"Project {project_id}")
+
+        assigned_ids = {m.get("project_id") for m in memberships}
+        available_projects = [
+            p for p in all_projects if p["id"] not in assigned_ids]
+
+        roles = await self._fetch_roles()
+
         return await self._render_page(
             pages.PAGE_INSTANCE_ADMIN_MODIFY_USER,
             instance_name=self._metadata_settings.instance_name,
@@ -181,4 +459,9 @@ class AdminModifyUserPageHandler(PortalPageHandler):
             active_admin_page="admin_page_users_roles",
             user_id=user_id,
             form_data=form_data,
-            error_msg_str=error_msg_str)
+            memberships=memberships,
+            roles=roles,
+            available_projects=available_projects,
+            active_tab=active_tab,
+            error_msg_str=error_msg_str,
+            success_msg_str=success_msg_str)

--- a/items/services/items_web_portal/static/css/instance_admin_add_user.css
+++ b/items/services/items_web_portal/static/css/instance_admin_add_user.css
@@ -44,6 +44,18 @@
     border-radius: 4px;
 }
 
+#success_msg {
+    color: #155724;
+    font-weight: bold;
+    padding: 1rem;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    border-radius: 6px;
+    border: 2px solid #28a745;
+    background-color: #e6f4ea;
+    text-align: center;
+}
+
 .cancelButton:hover {
   background-color: #ede9e8 !important;
   border-color: red !important;

--- a/items/services/items_web_portal/static/scripts/instance_admin_modify_user.js
+++ b/items/services/items_web_portal/static/scripts/instance_admin_modify_user.js
@@ -1,0 +1,40 @@
+/*
+ * Modify User page behaviour: Projects tab remove-access confirmation.
+ */
+(function () {
+  var deleteModal = document.getElementById('confirmRemoveProjectModal');
+  var deleteForm = document.getElementById('removeProjectForm');
+  var deleteName = document.getElementById('rp-project-name');
+  var confirmCheckbox = document.getElementById('rpConfirmCheckbox');
+  var confirmButton = document.getElementById('rpConfirmRemoveButton');
+
+  if (deleteModal) {
+    deleteModal.addEventListener('show.bs.modal', function (event) {
+      var trigger = event.relatedTarget;
+      var userId = trigger.getAttribute('data-user-id');
+      var projectId = trigger.getAttribute('data-project-id');
+      deleteName.textContent = trigger.getAttribute('data-project-name') || '';
+      deleteForm.action = '/admin/users_roles/' + userId +
+        '/projects/' + projectId + '/delete';
+      confirmCheckbox.checked = false;
+      confirmButton.disabled = true;
+    });
+
+    deleteModal.addEventListener('hidden.bs.modal', function () {
+      confirmCheckbox.checked = false;
+      confirmButton.disabled = true;
+    });
+  }
+
+  if (confirmCheckbox) {
+    confirmCheckbox.addEventListener('change', function () {
+      confirmButton.disabled = !this.checked;
+    });
+  }
+
+  if (confirmButton) {
+    confirmButton.addEventListener('click', function () {
+      deleteForm.submit();
+    });
+  }
+})();

--- a/items/services/items_web_portal/templates/instance_admin_modify_user.html
+++ b/items/services/items_web_portal/templates/instance_admin_modify_user.html
@@ -11,25 +11,36 @@
   <h4 class="mb-3">Edit User</h4>
   <hr />
 
+  {% if error_msg_str %}
+  <div id="error_msg">{{ error_msg_str }}</div>
+  {% endif %}
+
+  {% if success_msg_str %}
+  <div id="success_msg">{{ success_msg_str }}</div>
+  {% endif %}
+
+  <!-- Tab Navigation -->
+  <ul class="nav user-create-tab mb-3" id="modifyUserTabs">
+    <li class="nav-item">
+      <a class="nav-link{{ ' active' if active_tab == 'tab-user' else '' }}" data-bs-toggle="tab" href="#tab-user">User</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link{{ ' active' if active_tab == 'tab-access' else '' }}" data-bs-toggle="tab" href="#tab-access">Access</a>
+    </li>
+    <li class="nav-item">
+      <a class="nav-link{{ ' active' if active_tab == 'tab-projects' else '' }}" data-bs-toggle="tab" href="#tab-projects">Projects</a>
+    </li>
+  </ul>
+
+  <!-- User/Access tabs share one form and one Save button - project
+       membership actions below save immediately via their own mini-forms,
+       so they can't live inside this form (nested <form> elements aren't
+       valid HTML). -->
   <form id="modifyUserForm" action="/admin/users_roles/{{ user_id }}/modify" method="post">
-
-    <!-- Tab Navigation -->
-    <ul class="nav user-create-tab mb-3" id="modifyUserTabs">
-      <li class="nav-item">
-        <a class="nav-link active" data-bs-toggle="tab" href="#tab-user">User</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" data-bs-toggle="tab" href="#tab-access">Access</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" data-bs-toggle="tab" href="#tab-projects">Projects</a>
-      </li>
-    </ul>
-
     <div class="tab-content">
 
       <!-- USER TAB -->
-      <div class="tab-pane active" id="tab-user">
+      <div class="tab-pane{{ ' active' if active_tab == 'tab-user' else '' }}" id="tab-user">
 
         <div class="mb-3">
           <label for="full_name" class="form-label">Full Name *</label>
@@ -82,7 +93,7 @@
       </div>
 
       <!-- ACCESS TAB -->
-      <div class="tab-pane" id="tab-access">
+      <div class="tab-pane{{ ' active' if active_tab == 'tab-access' else '' }}" id="tab-access">
 
         <div class="mb-3 mt-3">
           <div class="form-check form-switch">
@@ -113,15 +124,7 @@
         </div>
 
         <p class="text-muted mt-4">
-          Per-project access configuration will be available in a future
-          release.
-        </p>
-      </div>
-
-      <!-- PROJECTS TAB -->
-      <div class="tab-pane" id="tab-projects">
-        <p class="text-muted mt-3">
-          Per-user project access configuration will be available in a future release.
+          Configure this user's per-project access on the <strong>Projects</strong> tab.
         </p>
       </div>
 
@@ -140,6 +143,135 @@
     </div>
 
   </form>
+
+  <!-- PROJECTS TAB -->
+  <div class="tab-content">
+    <div class="tab-pane{{ ' active' if active_tab == 'tab-projects' else '' }}" id="tab-projects">
+      <table class="table mt-3">
+        <thead>
+          <tr>
+            <th scope="col">Project</th>
+            <th scope="col">Role</th>
+            <th scope="col" class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+        {% for membership in memberships %}
+        <tr>
+          <td>{{ membership.project_name }}</td>
+          <td>
+            <form class="d-inline-flex align-items-center gap-2" method="POST"
+                  action="/admin/users_roles/{{ user_id }}/projects/{{ membership.project_id }}/modify">
+              <select class="form-select form-select-sm w-auto" name="role_id">
+                <option value="">Unassigned</option>
+                {% for role in roles %}
+                <option value="{{ role.id }}"{% if membership.role_id == role.id %} selected{% endif %}>{{ role.name }}</option>
+                {% endfor %}
+              </select>
+              <button type="submit" class="btn btn-link text-primary p-1" title="Save role">
+                <i class="bi bi-check-lg"></i>
+              </button>
+            </form>
+          </td>
+          <td class="text-end">
+            <button type="button" class="btn btn-link text-danger p-1 remove-project-btn"
+                    title="Remove"
+                    data-bs-toggle="modal" data-bs-target="#confirmRemoveProjectModal"
+                    data-user-id="{{ user_id }}"
+                    data-project-id="{{ membership.project_id }}"
+                    data-project-name="{{ membership.project_name }}">
+              <i class="bi bi-x-circle"></i>
+            </button>
+          </td>
+        </tr>
+        {% else %}
+        <tr>
+          <td colspan="3" class="text-muted">Not a member of any projects.</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      <div class="mt-3">
+        <button type="button" class="btn btn-primary" id="add-project-btn"
+                data-bs-toggle="modal" data-bs-target="#addProjectModal"
+                {% if not available_projects %}disabled{% endif %}>
+          + Add Project
+        </button>
+        {% if not available_projects %}
+        <span class="text-muted ms-2">Already a member of every project.</span>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Project modal -->
+  <div class="modal fade" id="addProjectModal" tabindex="-1"
+       aria-labelledby="addProjectModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form method="POST" action="/admin/users_roles/{{ user_id }}/projects">
+          <div class="modal-header">
+            <h5 class="modal-title" id="addProjectModalLabel">Add Project</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label for="ap-project" class="form-label">Project</label>
+              <select class="form-select" id="ap-project" name="project_id" required>
+                {% for project in available_projects %}
+                <option value="{{ project.id }}">{{ project.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="mb-3">
+              <label for="ap-role" class="form-label">Role</label>
+              <select class="form-select" id="ap-role" name="role_id">
+                <option value="">Unassigned</option>
+                {% for role in roles %}
+                <option value="{{ role.id }}">{{ role.name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Add</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- Remove project confirmation modal -->
+  <div class="modal fade" id="confirmRemoveProjectModal" tabindex="-1"
+       aria-labelledby="confirmRemoveProjectModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="confirmRemoveProjectModalLabel">Confirmation</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p>Remove this user's access to "<span id="rp-project-name"></span>"?</p>
+          <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="rpConfirmCheckbox">
+            <label class="form-check-label" for="rpConfirmCheckbox">I confirm I want to remove this access.</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-danger" id="rpConfirmRemoveButton" disabled>OK</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <form id="removeProjectForm" method="POST" style="display: none;"></form>
+
 {% endblock %}
 
-{% block postBody %}{{ super() }}{% endblock %}
+{% block postBody %}{{ super() }}
+<script type="text/javascript"
+        src="{{ url_for('static', filename='scripts/instance_admin_modify_user.js') }}">
+</script>
+{% endblock %}

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 8"
+PRE_RELEASE = "Alpha Build 9"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/unit_tests/web_portal_svc/main.py
+++ b/unit_tests/web_portal_svc/main.py
@@ -59,6 +59,9 @@ from test_admin_users_handlers import (
     TestAdminAddUserPageHandler,
     TestAdminModifyUserPageHandler,
     TestAdminResetPasswordPageHandler,
+    TestAddUserProject,
+    TestModifyUserProject,
+    TestRemoveUserProject,
 )
 from test_projects_testcases_handlers import (
     TestGetProjectOverviewPageHandler,

--- a/unit_tests/web_portal_svc/test_admin_users_handlers.py
+++ b/unit_tests/web_portal_svc/test_admin_users_handlers.py
@@ -56,6 +56,32 @@ _VALID_MODIFY_FORM = {
     "account_status": "1",
 }
 
+_PROJECTS_OK = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"projects": [{"id": 5, "name": "Alpha"}, {"id": 7, "name": "Beta"}]})
+_ROLES_OK = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"roles": [{"id": 2, "name": "Tester"}, {"id": 3, "name": "Lead"}]})
+_MEMBERSHIPS_OK = ApiResponse(
+    status_code=HTTPStatus.OK,
+    body={"memberships": [{"project_id": 5, "role_id": 2, "role_name": "Tester"}]})
+_MEMBERSHIPS_EMPTY = ApiResponse(
+    status_code=HTTPStatus.OK, body={"memberships": []})
+_USER_OK = ApiResponse(status_code=HTTPStatus.OK, body=_USER)
+
+
+def _get_side_effect(user=None, memberships=None, roles=None):
+    """Build a get() side_effect list matching _render()'s call order:
+    user (if fetched fresh), then projects, then memberships, then roles.
+    """
+    calls = []
+    if user is not None:
+        calls.append(user)
+    calls.append(_PROJECTS_OK)
+    calls.append(memberships if memberships is not None else _MEMBERSHIPS_EMPTY)
+    calls.append(roles if roles is not None else _ROLES_OK)
+    return calls
+
 
 def _config():
     cfg = MagicMock()
@@ -358,6 +384,301 @@ class TestAdminModifyUserPageHandler(unittest.IsolatedAsyncioTestCase):
         await self._post(_VALID_MODIFY_FORM)
         patch_call = self.mock_rest_client.patch.await_args
         self.assertFalse(patch_call.kwargs["json_data"]["is_administrator"])
+
+    # -- Projects tab rendering ---------------------------------------
+
+    async def test_get_shows_membership_with_joined_project_name(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(
+            user=_USER_OK, memberships=_MEMBERSHIPS_OK)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Alpha", text)
+        self.assertIn("Tester", text)
+
+    async def test_get_no_memberships_shows_placeholder(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(
+            user=_USER_OK, memberships=_MEMBERSHIPS_EMPTY)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Not a member of any projects", text)
+
+    async def test_get_add_project_excludes_assigned_projects(self):
+        """Alpha (id 5) is already assigned - only Beta should be offered."""
+        self.mock_rest_client.get.side_effect = _get_side_effect(
+            user=_USER_OK, memberships=_MEMBERSHIPS_OK)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        add_modal_start = text.index('id="addProjectModal"')
+        add_modal_text = text[add_modal_start:add_modal_start + 2000]
+        self.assertIn("Beta", add_modal_text)
+        self.assertNotIn("Alpha", add_modal_text)
+
+    async def test_get_member_of_every_project_disables_add_button(self):
+        all_assigned = ApiResponse(
+            status_code=HTTPStatus.OK,
+            body={"memberships": [
+                {"project_id": 5, "role_id": 2, "role_name": "Tester"},
+                {"project_id": 7, "role_id": None, "role_name": None}]})
+        self.mock_rest_client.get.side_effect = _get_side_effect(
+            user=_USER_OK, memberships=all_assigned)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Already a member of every project", text)
+
+    async def test_get_defaults_to_the_user_tab(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._get()
+        text = await response.get_data(as_text=True)
+        self.assertIn('nav-link active" data-bs-toggle="tab" href="#tab-user"', text)
+
+    async def test_projects_fetch_failure_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USER_OK,
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={}),
+            _MEMBERSHIPS_EMPTY, _ROLES_OK]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+
+    async def test_roles_fetch_exception_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USER_OK, _PROJECTS_OK, _MEMBERSHIPS_EMPTY, RuntimeError("boom")]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+
+    async def test_projects_fetch_exception_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USER_OK, RuntimeError("boom"), _MEMBERSHIPS_EMPTY, _ROLES_OK]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+
+    async def test_memberships_fetch_exception_is_non_fatal(self):
+        self.mock_rest_client.get.side_effect = [
+            _USER_OK, _PROJECTS_OK, RuntimeError("boom"), _ROLES_OK]
+        response = await self._get()
+        self.assertEqual(response.status_code, 200)
+
+
+# ---------------------------------------------------------------------------
+# Project membership actions (Projects tab)
+# ---------------------------------------------------------------------------
+
+class TestAddUserProject(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/<id>/projects"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminModifyUserPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route("/admin/users_roles/<string:user_id>/projects",
+                  methods=["POST"])
+        async def route(user_id: str):
+            return await handler.add_user_project(user_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, form, user_id=_UUID):
+        async with self.client as c:
+            return await c.post(f"/admin/users_roles/{user_id}/projects",
+                                form=form, headers=_AUTH_HEADERS)
+
+    async def test_missing_project_id_renders_error(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Select a project", text)
+        self.mock_rest_client.post.assert_called_once()  # only session check
+
+    async def test_non_integer_project_id_renders_error(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"project_id": "abc"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Invalid project", text)
+
+    async def test_non_integer_role_id_renders_error(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"project_id": "5", "role_id": "abc"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Invalid role", text)
+
+    async def test_success_forwards_project_and_role_to_gateway(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        await self._post({"project_id": "5", "role_id": "2"})
+        call = self.mock_rest_client.post.call_args_list[1]
+        self.assertEqual(call[0][0], "http://gateway/web/users/" + _UUID + "/projects")
+        self.assertEqual(call[1]["json_data"], {"project_id": 5, "role_id": 2})
+
+    async def test_no_role_selected_omits_role_id(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        await self._post({"project_id": "5"})
+        call = self.mock_rest_client.post.call_args_list[1]
+        self.assertEqual(call[1]["json_data"], {"project_id": 5})
+
+    async def test_gateway_conflict_shows_error(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.CONFLICT,
+                       body={"error": "User is already a member of this project"})]
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"project_id": "5"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("already a member", text)
+
+    async def test_success_confirms_and_returns_to_projects_tab(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"project_id": "5"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Project access added", text)
+        self.assertIn('nav-link active" data-bs-toggle="tab" href="#tab-projects"', text)
+
+    async def test_error_without_body_uses_fallback_message(self):
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID,
+            ApiResponse(status_code=HTTPStatus.INTERNAL_SERVER_ERROR, body={})]
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"project_id": "5"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("could not be completed", text)
+
+    async def test_stale_user_fetch_failure_falls_back_to_blank_form(self):
+        """A failed re-fetch of the user's core fields after a successful
+        project write shouldn't fail the whole page - just re-render the
+        User/Access tabs blank."""
+        self.mock_rest_client.post.side_effect = [
+            _SESSION_VALID, ApiResponse(status_code=HTTPStatus.CREATED)]
+        self.mock_rest_client.get.side_effect = [
+            ApiResponse(status_code=HTTPStatus.SERVICE_UNAVAILABLE, body={}),
+            _PROJECTS_OK, _MEMBERSHIPS_EMPTY, _ROLES_OK]
+        response = await self._post({"project_id": "5"})
+        self.assertEqual(response.status_code, 200)
+        text = await response.get_data(as_text=True)
+        self.assertIn("Project access added", text)
+
+
+class TestModifyUserProject(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/<id>/projects/<project_id>/modify"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminModifyUserPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route(
+            "/admin/users_roles/<string:user_id>/projects/<int:project_id>/modify",
+            methods=["POST"])
+        async def route(user_id: str, project_id: int):
+            return await handler.modify_user_project(user_id, project_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, form, user_id=_UUID, project_id=5):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/users_roles/{user_id}/projects/{project_id}/modify",
+                form=form, headers=_AUTH_HEADERS)
+
+    async def test_success_forwards_role_id_to_gateway(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        await self._post({"role_id": "3"}, project_id=9)
+        self.mock_rest_client.patch.assert_called_once_with(
+            "http://gateway/web/users/" + _UUID + "/projects/9",
+            json_data={"role_id": 3})
+
+    async def test_unassigned_selection_sends_null_role(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        await self._post({"role_id": ""})
+        self.mock_rest_client.patch.assert_called_once_with(
+            "http://gateway/web/users/" + _UUID + "/projects/5",
+            json_data={"role_id": None})
+
+    async def test_non_integer_role_id_renders_error_without_calling_gateway(self):
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"role_id": "abc"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Invalid role", text)
+        self.mock_rest_client.patch.assert_not_called()
+
+    async def test_not_a_member_shows_error(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            body={"error": "User is not a member of this project"})
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"role_id": "3"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("not a member", text)
+
+    async def test_success_confirms_and_returns_to_projects_tab(self):
+        self.mock_rest_client.patch.return_value = ApiResponse(status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post({"role_id": "3"})
+        text = await response.get_data(as_text=True)
+        self.assertIn("Role updated", text)
+        self.assertIn('nav-link active" data-bs-toggle="tab" href="#tab-projects"', text)
+
+
+class TestRemoveUserProject(unittest.IsolatedAsyncioTestCase):
+    """POST /admin/users_roles/<id>/projects/<project_id>/delete"""
+
+    async def asyncSetUp(self):
+        self.mock_rest_client = AsyncMock()
+        self.mock_rest_client.post.return_value = _SESSION_VALID
+        handler = AdminModifyUserPageHandler(
+            _LOGGER, _config(), self.mock_rest_client, _metadata())
+
+        app = make_app()
+
+        @app.route(
+            "/admin/users_roles/<string:user_id>/projects/<int:project_id>/delete",
+            methods=["POST"])
+        async def route(user_id: str, project_id: int):
+            return await handler.remove_user_project(user_id, project_id)
+
+        self.client = app.test_client()
+
+    async def _post(self, user_id=_UUID, project_id=5):
+        async with self.client as c:
+            return await c.post(
+                f"/admin/users_roles/{user_id}/projects/{project_id}/delete",
+                headers=_AUTH_HEADERS)
+
+    async def test_success_calls_gateway_delete(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        await self._post(project_id=9)
+        self.mock_rest_client.delete.assert_called_once_with(
+            "http://gateway/web/users/" + _UUID + "/projects/9")
+
+    async def test_not_a_member_shows_error(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(
+            status_code=HTTPStatus.NOT_FOUND,
+            body={"error": "User is not a member of this project"})
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post()
+        text = await response.get_data(as_text=True)
+        self.assertIn("not a member", text)
+
+    async def test_success_confirms_and_returns_to_projects_tab(self):
+        self.mock_rest_client.delete.return_value = ApiResponse(status_code=HTTPStatus.OK)
+        self.mock_rest_client.get.side_effect = _get_side_effect(user=_USER_OK)
+        response = await self._post()
+        text = await response.get_data(as_text=True)
+        self.assertIn("Project access removed", text)
+        self.assertIn('nav-link active" data-bs-toggle="tab" href="#tab-projects"', text)
 
 
 # ---------------------------------------------------------------------------

--- a/unit_tests/web_portal_svc/test_route_factories.py
+++ b/unit_tests/web_portal_svc/test_route_factories.py
@@ -289,6 +289,23 @@ class TestRouteWiring(unittest.IsolatedAsyncioTestCase):
                                           "display_name": "Alice"})
         self.assertNotEqual(response.status_code, 405)
 
+    async def test_admin_add_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/1/projects",
+                                    form={"project_id": "5"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_modify_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/1/projects/5/modify",
+                                    form={"role_id": "2"})
+        self.assertNotEqual(response.status_code, 405)
+
+    async def test_admin_remove_user_project_route_is_reachable(self):
+        async with self.client as c:
+            response = await c.post("/admin/users_roles/1/projects/5/delete")
+        self.assertNotEqual(response.status_code, 405)
+
     async def test_admin_reset_password_get_route_is_reachable(self):
         async with self.client as c:
             response = await c.get("/admin/users_roles/1/reset_password")


### PR DESCRIPTION
# Web Portal: Project Membership UI (Projects tab)

**Branch:** `portal_project_membership` (manually tested, PR pending)
**Theme:** Roles & permissions (post-0.3.0) — sixth application-code piece,
completing the Portal UI half of the theme (`identity_roles_db_update` →
`identity_roles_crud` → `identity_project_membership` →
`gateway_roles_and_membership` → `portal_user_roles_and_membership` →
this branch)

## Summary

Builds out the "Projects" tab on the **Modify User** page - previously a
placeholder reading "Per-user project access configuration will be
available in a future release." An admin can now list, add, change the
role on, and remove a user's project memberships directly from this
page. **Add User's** Projects tab stays a placeholder deliberately - a
user has no ID until created, so membership assignment only makes sense
post-creation via Modify User.

## Portal: Projects tab

- `AdminModifyUserPageHandler` gained `add_user_project`,
  `modify_user_project`, and `remove_user_project`, proxying to the
  Gateway's `/web/users/<uuid>/projects[...]` endpoints from the
  already-merged `gateway_roles_and_membership` branch.
- Membership rows show the project name, not just its id - the
  membership list endpoint only returns `project_id`, so `_render()`
  joins it against a separate `GET /web/projects?value_fields=name` call
  (the same lightweight id+name fetch Customisations already uses for
  its own project selector, reused here with `id` kept instead of
  discarded).
- Role change is an inline `<select>` + save button per row (explicit
  submit, not TestRail's auto-submit-on-change, to match every other
  write action already on this page). Selecting "Unassigned" sends
  `role_id: null`, clearing the role - the same valid "member, no role"
  state used throughout this theme.
- **Add Project** is a modal (mirrors the Roles Add/Edit modal
  convention): a project dropdown pre-filtered server-side to exclude
  projects the user already belongs to, plus a role dropdown defaulting
  to "Unassigned". The button disables itself with an explanatory note
  when the user is already a member of every project.
- **Remove** uses the same confirm-checkbox-gates-the-button delete
  modal pattern as Roles/Case Fields, in a new
  `instance_admin_modify_user.js` (this page had no JS file until now).
- A project-membership write (add/modify/remove, including a rejected
  validation attempt) re-renders with the **Projects** tab left active
  instead of resetting to the first tab - same `active_tab` mechanism
  built for the Roles branch, adapted to this page's tab id scheme
  (`tab-user`/`tab-access`/`tab-projects`).
- The Access tab's stale "per-project access configuration will be
  available in a future release" note is replaced with a pointer to the
  Projects tab, since it's no longer true on this page.

## Structural fix: nested forms aren't valid HTML

The page previously wrapped **all three tabs** in one `<form
id="modifyUserForm">`. The Projects tab's per-row role-change forms, the
Add Project modal's form, and the remove-confirmation form can't legally
nest inside another `<form>` - browsers silently flatten nested form
tags, which would have made every Projects-tab action actually submit
through the outer User/Access form instead. Fixed by splitting the
template into two independent top-level forms: `modifyUserForm` (User +
Access tabs only, unchanged behaviour) and the Projects tab's own
mini-forms living outside it. Bootstrap's tab switching doesn't require
the tab panes to share a DOM parent, only matching `data-bs-target`/`id`
pairs, so the visual tab bar is unaffected. Verified by rendering the
page and confirming `</form>` closes before the Projects tab-content
begins, rather than relying on visual inspection alone.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing
325 tests via `unittest discover`; confirmed 100% coverage through the
**official entry point** (`python -m unittest unit_tests/web_portal_svc/main.py`,
what `testWebPortal.bat` actually runs) rather than only via discover -
learned the hard way on the previous branch that `main.py`'s explicit
import list silently excludes anything not added to it, so every new
test class was wired into `main.py` as part of writing it this time, not
after the fact. New: full write-path tests for add/modify/remove
(including malformed project_id/role_id, gateway conflict/not-found
propagation, and active-tab assertions), membership-rendering tests
(project name joining, empty state, "already a member of every project"
disabled state, excluded-from-picker filtering), and non-fatal
failure/exception coverage for all three new fetch helpers plus the
post-write user re-fetch. Route reachability added to
`test_route_factories.py`. Pylint 10.00/10.

## Deliberately out of scope

- **No Add User Projects tab** - stays a placeholder, see Summary.
- **No enforcement of membership on read routes** - unchanged from every
  prior branch's scope note. `GET /web/projects`, `GET /web/projects/<id>`,
  `GET /web/<project_id>/testcases`, `GET /web/testcases/<id>` are all
  still `@require_session`-only. This is now the **last remaining piece**
  of the whole theme, with the original acceptance test still the
  target: assigned to projects 1/3/5, project 2 returns nothing.

## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
