### PR TITLE
[Gateway] Membership enforcement

### DIFF
--- a/items/services/items_gateway/auth_decorators.py
+++ b/items/services/items_gateway/auth_decorators.py
@@ -112,3 +112,84 @@ def require_administrator(sessions: Sessions):
             return await func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def require_project_member(sessions: Sessions):
+    """Decorator factory requiring the caller to be a member of the project
+    named in the request, or an administrator.
+
+    The project id is read from the route's ``project_id`` keyword argument
+    if present, otherwise from a ``project_id`` query parameter. If neither
+    yields a parseable integer, the check is skipped entirely and the
+    wrapped function is called unchanged - that's a malformed-request
+    concern for the handler's own validation to report specifically (e.g.
+    "project_id is required"), not something this decorator should mask
+    behind a generic 403.
+
+    Administrators bypass the membership check, matching every other
+    admin-gated route in this codebase.
+
+    Args:
+        sessions: The gateway's in-memory session store, captured once at
+            blueprint-registration time.
+
+    Returns:
+        A decorator that 401s the request if no valid session is presented,
+        403s if the session is valid, names a specific project, and the
+        caller isn't a member of it, otherwise calls the wrapped route
+        function unchanged.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            entry = await _resolve_session(sessions)
+            if entry is None:
+                return _unauthorized()
+            if entry.is_administrator:
+                return await func(*args, **kwargs)
+
+            project_id = kwargs.get("project_id")
+            if project_id is None:
+                raw_project_id = request.args.get("project_id")
+                if raw_project_id is not None:
+                    try:
+                        project_id = int(raw_project_id)
+                    except ValueError:
+                        project_id = None
+
+            if project_id is not None and project_id not in entry.project_ids:
+                return _forbidden()
+            return await func(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def require_session_with_entry(sessions: Sessions):
+    """Decorator factory requiring any valid session, passing the resolved
+    ``SessionEntry`` to the wrapped function as ``session_entry``.
+
+    Only exists for the rare route that genuinely needs to know who's
+    calling to do its job correctly - e.g. filtering a list down to the
+    caller's own permissions - rather than a simple allow/deny gate. Every
+    other route stays authorization-agnostic; prefer :func:`require_session`,
+    :func:`require_administrator` or :func:`require_project_member` unless
+    the handler truly can't do its job without the caller's identity.
+
+    Args:
+        sessions: The gateway's in-memory session store, captured once at
+            blueprint-registration time.
+
+    Returns:
+        A decorator that 401s the request if no valid session is presented,
+        otherwise calls the wrapped route function with the resolved
+        ``SessionEntry`` passed as ``session_entry``.
+    """
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            entry = await _resolve_session(sessions)
+            if entry is None:
+                return _unauthorized()
+            return await func(*args, session_entry=entry, **kwargs)
+        return wrapper
+    return decorator

--- a/items/services/items_gateway/routes/web/projects/__init__.py
+++ b/items/services/items_gateway/routes/web/projects/__init__.py
@@ -18,7 +18,7 @@ import logging
 from quart import Blueprint
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_gateway.auth_decorators import (
-    require_administrator, require_session)
+    require_administrator, require_project_member, require_session_with_entry)
 from items.services.items_gateway.gateway_configuration import (
     GatewayConfiguration)
 from items.services.items_gateway.sessions import Sessions
@@ -44,12 +44,12 @@ def create_projects_routes(logger: logging.Logger,
     gateway endpoints. Each route delegates request handling to a dedicated
     handler class responsible for communicating with the CMS service.
 
-    The two read routes require only a valid session (``@require_session``)
-    - they are called by both the regular dashboard/project-overview pages
-    and the admin projects page, so they can't require administrator
-    rights. The three write routes are admin-only
-    (``@require_administrator``) - only the admin add/modify/delete project
-    pages call them.
+    The two read routes require a valid session and project membership
+    (``@require_project_member`` / ``@require_session_with_entry``) -
+    administrators see and reach every project regardless of membership,
+    matching every other admin-gated view. The three write routes are
+    admin-only (``@require_administrator``) - only the admin
+    add/modify/delete project pages call them.
 
     The following endpoints are registered:
 
@@ -99,7 +99,7 @@ def create_projects_routes(logger: logging.Logger,
                  "Get project details".ljust(40))
 
     @projects_routes.route('/projects/<int:project_id>', methods=['GET'])
-    @require_session(sessions)
+    @require_project_member(sessions)
     async def get_project(project_id: int):
         return await handler_get_project.get_project(project_id)
 
@@ -108,9 +108,9 @@ def create_projects_routes(logger: logging.Logger,
                  "List accessible projects".ljust(40))
 
     @projects_routes.route('/projects', methods=['GET'])
-    @require_session(sessions)
-    async def list_projects():
-        return await handler_get_all_projects.list_all_projects()
+    @require_session_with_entry(sessions)
+    async def list_projects(session_entry):
+        return await handler_get_all_projects.list_all_projects(session_entry)
 
     # Create project
     logger.debug("=> %s POST /projects",

--- a/items/services/items_gateway/routes/web/projects/get_all_projects_handler.py
+++ b/items/services/items_gateway/routes/web/projects/get_all_projects_handler.py
@@ -22,6 +22,7 @@ from weaver_framework.microservice.api_response import ApiResponse
 from weaver_framework.microservice.base_api_route import BaseApiRoute
 from weaver_framework.microservice.rest_client import RestClient
 from items.services.items_gateway.gateway_configuration import GatewayConfiguration
+from items.services.items_gateway.sessions import SessionEntry
 
 
 class GetAllProjectsHandler(BaseApiRoute):
@@ -51,12 +52,23 @@ class GetAllProjectsHandler(BaseApiRoute):
         self._config: GatewayConfiguration = config
         self._rest_client: RestClient = rest_client
 
-    async def list_all_projects(self):
-        """Retrieve the list of accessible projects.
+    async def list_all_projects(self, session_entry: SessionEntry):
+        """Retrieve the list of projects accessible to the caller.
 
         Forwards the request to the CMS service. If present, the
         ``value_fields`` and ``count_fields`` query parameters are passed
         through to control the fields included in the response.
+
+        Administrators see every project, matching every other admin-gated
+        view in this codebase. Everyone else sees only the projects they
+        are a member of, per ``session_entry.project_ids`` - filtered here
+        rather than pushed down to CMS, since CMS has no concept of the
+        caller's identity and this keeps that boundary unchanged.
+
+        Args:
+            session_entry: The caller's resolved session, supplied by the
+                ``require_session_with_entry`` decorator wrapping this
+                route.
 
         Returns:
             A Quart ``Response`` containing the list of projects if the
@@ -96,6 +108,13 @@ class GetAllProjectsHandler(BaseApiRoute):
                 status=HTTPStatus.INTERNAL_SERVER_ERROR,
                 content_type="application/json")
 
-        return Response(json.dumps(response.body),
+        body = response.body
+        if not session_entry.is_administrator:
+            projects = body.get("projects", [])
+            visible = [p for p in projects
+                      if p.get("id") in session_entry.project_ids]
+            body = dict(body, projects=visible)
+
+        return Response(json.dumps(body),
                         status=HTTPStatus.OK,
                         content_type="application/json")

--- a/items/services/items_gateway/routes/web/sessions/new_session_password_handler.py
+++ b/items/services/items_gateway/routes/web/sessions/new_session_password_handler.py
@@ -128,9 +128,11 @@ class NewSessionPasswordHandler(BaseApiRoute):
             self._logger.info("User '%s' logged in",
                               email_address)
 
-        # Fetch the user profile so we can store is_administrator against
-        # the session and return it on every subsequent validate call.
+        # Fetch the user profile so we can store is_administrator and the
+        # user's id against the session and return it on every subsequent
+        # validate call.
         is_administrator: bool = False
+        user_id: str = ""
         profile_url: str = (f"{self._configuration.apis_identity_svc}"
                             f"users/profile")
         profile_response: ApiResponse = await self._rest_client.post(
@@ -139,18 +141,68 @@ class NewSessionPasswordHandler(BaseApiRoute):
         if profile_response.status_code == HTTPStatus.OK and profile_response.body:
             is_administrator = bool(
                 profile_response.body.get("is_administrator", False))
+            user_id = profile_response.body.get("id", "")
         else:
             self._logger.warning(
                 "Could not retrieve profile for '%s' (status %s); "
                 "is_administrator will default to False",
                 email_address, profile_response.status_code)
 
+        # Snapshot the user's project memberships too, so read routes can
+        # enforce access without a per-request identity lookup. Same
+        # cached-at-login tradeoff as is_administrator above - see
+        # SessionEntry's docstring.
+        project_ids: frozenset[int] = await self._fetch_member_project_ids(
+            user_id)
+
         await self._sessions.add_session(email_address,
                                          token,
                                          AccountLogonType.BASIC,
-                                         is_administrator)
+                                         is_administrator=is_administrator,
+                                         user_id=user_id,
+                                         project_ids=project_ids)
 
         return Response(
             json.dumps({"status": 1, "token": token}),
             status=HTTPStatus.OK,
             content_type="application/json")
+
+    async def _fetch_member_project_ids(self, user_id: str) -> frozenset[int]:
+        """Fetch the set of project ids the user is a member of.
+
+        A failure here is non-fatal to login: the session is simply
+        cached with no memberships (the safe default - no membership
+        already means no access anywhere else in this system), rather
+        than failing the login entirely over a read that isn't essential
+        to authenticating the user.
+
+        Args:
+            user_id: The user's identity-service UUID. Empty if it could
+                not be resolved from their profile.
+
+        Returns:
+            A frozenset of project ids, or an empty frozenset on any
+            failure (including no user_id being available at all).
+        """
+        if not user_id:
+            return frozenset()
+
+        url = (f"{self._configuration.apis_identity_svc}"
+              f"users/{user_id}/projects")
+        try:
+            response: ApiResponse = await self._rest_client.get(url)
+        except Exception:  # pylint: disable=broad-except
+            self._logger.warning(
+                "Unable to fetch project memberships for user '%s'", user_id)
+            return frozenset()
+
+        if response.status_code != HTTPStatus.OK or not response.body:
+            self._logger.warning(
+                "Unable to fetch project memberships for user '%s' "
+                "(status %s)", user_id, response.status_code)
+            return frozenset()
+
+        memberships = response.body.get("memberships", [])
+        return frozenset(
+            m["project_id"] for m in memberships
+            if m.get("project_id") is not None)

--- a/items/services/items_gateway/routes/web/testcases/__init__.py
+++ b/items/services/items_gateway/routes/web/testcases/__init__.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from quart import Blueprint
-from items.services.items_gateway.auth_decorators import require_session
+from items.services.items_gateway.auth_decorators import require_project_member
 from items.services.items_gateway.route_injections import RouteInjections
 from items.services.items_gateway.routes.web.testcases.get_testcase_handler \
     import GetTestcaseHandler
@@ -31,11 +31,17 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
     handlers, registers the available endpoints, and logs the registered routes
     during application startup.
 
-    Both routes require a valid session (``@require_session``) but not
-    administrator rights - any authenticated user with access to the portal
-    can browse testcases, not just admins. (There is no per-project
-    membership check yet - see ``user_roles_design.md`` and the
-    `future.md` items tracking that work.)
+    Both routes require a valid session and membership of the project the
+    testcase(s) belong to (``@require_project_member``) - any authenticated
+    member of that project can browse its testcases, not just admins, who
+    bypass the membership check entirely and see every project's testcases.
+
+    ``GET /web/testcases/<id>`` checks membership against its
+    ``project_id`` query parameter before ever calling CMS. That's safe
+    despite being client-supplied: CMS independently verifies the testcase
+    actually belongs to the stated project and 404s otherwise (see
+    ``GetTestcaseHandler``), so a caller can't use a project they belong to
+    as a lie to reach a testcase in one they don't.
 
     Registered routes:
         - GET /<project_id>/testcases:
@@ -69,7 +75,7 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
 
     @routes.route('/<int:project_id>/testcases',
                   methods=['GET'])
-    @require_session(injections.sessions)
+    @require_project_member(injections.sessions)
     async def testcases_details_request(project_id: int):
         return await handler_get_testcases.get_testcases(project_id)
 
@@ -79,7 +85,7 @@ def create_testcases_routes(injections: RouteInjections) -> Blueprint:
 
     @routes.route('/testcases/<int:case_id>',
                   methods=['GET'])
-    @require_session(injections.sessions)
+    @require_project_member(injections.sessions)
     async def get_case_request(case_id: int):
         # pylint: disable=unused-variable
         return await handler_get_testcase.get_testcase(case_id)

--- a/items/services/items_gateway/routes/web/users/create_user_handler.py
+++ b/items/services/items_gateway/routes/web/users/create_user_handler.py
@@ -57,8 +57,10 @@ class CreateUserHandler(BaseApiRoute):
                 content_type="application/json")
 
         url: str = f"{self._configuration.apis_identity_svc}users"
-        response: ApiResponse = await self._rest_client.post(url,
-                                                              json_data=body)
+        # See reset_password_handler.py - the same argon2 hashing cost
+        # applies to user creation and can exceed RestClient's 2s default.
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=body, timeout=10)
 
         if response.exception_msg is not None:
             self._logger.error("Connection to identity service failed: %s",

--- a/items/services/items_gateway/routes/web/users/reset_password_handler.py
+++ b/items/services/items_gateway/routes/web/users/reset_password_handler.py
@@ -83,8 +83,13 @@ class ResetPasswordHandler(BaseApiRoute):
 
         url: str = (f"{self._configuration.apis_identity_svc}"
                     f"users/{user_id}/password")
-        response: ApiResponse = await self._rest_client.post(url,
-                                                              json_data=body)
+        # A longer timeout than RestClient's 2s default: password hashing
+        # (argon2, in identity's user_management_service) is deliberately
+        # expensive and can exceed 2s under load, which would otherwise
+        # surface here as a spurious 504 on a reset that's still genuinely
+        # in progress rather than actually failed.
+        response: ApiResponse = await self._rest_client.post(
+            url, json_data=body, timeout=10)
 
         if response.exception_msg is not None:
             self._logger.error("Connection to identity service failed: %s",

--- a/items/services/items_gateway/sessions.py
+++ b/items/services/items_gateway/sessions.py
@@ -60,6 +60,7 @@ class Sessions:
         self._sessions: dict[str, SessionEntry] = {}
         self._lock: asyncio.Lock = asyncio.Lock()
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     async def add_session(self,
                           email_address: str,
                           token: str,

--- a/items/services/items_gateway/sessions.py
+++ b/items/services/items_gateway/sessions.py
@@ -30,12 +30,21 @@ class SessionEntry:
         session_expiry (int): The session expiration timestamp (Unix time).
         token (str): The unique token identifying the session.
         is_administrator (bool): Whether the user has administrator privileges.
+        user_id (str): The user's identity-service UUID. Empty if it could
+            not be resolved at login (treated the same as no memberships).
+        project_ids (frozenset[int]): The project ids this user was a member
+            of at login/refresh time. Snapshotted, not re-checked per
+            request - same staleness tradeoff already accepted for
+            ``is_administrator`` (see the "deactivating a user does not
+            touch their existing session" item in future.md).
     """
     email_address: str = ""
     authentication_type: AccountLogonType = AccountLogonType.BASIC
     session_expiry: int = 0
     token: str = ""
     is_administrator: bool = False
+    user_id: str = ""
+    project_ids: frozenset[int] = frozenset()
 
 
 class Sessions:
@@ -55,7 +64,9 @@ class Sessions:
                           email_address: str,
                           token: str,
                           auth_type: AccountLogonType,
-                          is_administrator: bool = False) -> None:
+                          is_administrator: bool = False,
+                          user_id: str = "",
+                          project_ids: frozenset[int] | None = None) -> None:
         """
         Add an authentication session. Any existing session for the same email
         address is invalidated and replaced.
@@ -66,6 +77,11 @@ class Sessions:
             auth_type (AccountLogonType): Type of authentication used.
             is_administrator (bool): Whether the user has administrator
                 privileges. Defaults to False.
+            user_id (str): The user's identity-service UUID, if resolved.
+            project_ids (frozenset[int] | None): The project ids the user
+                was a member of at login/refresh time. Defaults to an
+                empty set - "no memberships" is the safe default, matching
+                the existing "no membership = no access" rule elsewhere.
         """
         async with self._lock:
             entry: SessionEntry = SessionEntry()
@@ -73,6 +89,9 @@ class Sessions:
             entry.token = token
             entry.authentication_type = auth_type
             entry.is_administrator = is_administrator
+            entry.user_id = user_id
+            entry.project_ids = project_ids if project_ids is not None \
+                else frozenset()
 
             # If you logon a second time it will invalid any previous session.
             self._sessions.pop(email_address, None)

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_add_user_page_handler.py
@@ -103,8 +103,11 @@ class AdminAddUserPageHandler(PortalPageHandler):
         }
 
         url = f"{self._config.apis_gateway_svc}web/users"
+        # See admin_reset_password_page_handler.py - the same argon2
+        # hashing cost applies to user creation and can exceed
+        # RestClient's 2s default across this two-hop call chain.
         response: ApiResponse = await self._rest_client.post(
-            url, json_data=gateway_body)
+            url, json_data=gateway_body, timeout=10)
 
         if response.status_code == http.HTTPStatus.CONFLICT:
             return await self._render(

--- a/items/services/items_web_portal/page_handlers/admin/users/admin_reset_password_page_handler.py
+++ b/items/services/items_web_portal/page_handlers/admin/users/admin_reset_password_page_handler.py
@@ -112,8 +112,14 @@ class AdminResetPasswordPageHandler(PortalPageHandler):
                 error_msg_str="Passwords do not match.")
 
         url = f"{self._config.apis_gateway_svc}web/users/{user_id}/password"
+        # A longer timeout than RestClient's 2s default: password hashing
+        # (argon2, in identity's user_management_service) is deliberately
+        # expensive, and this call is chained through the gateway's own
+        # call to identity - either hop's default timeout can otherwise
+        # fire first and surface as a spurious 504 on a legitimate,
+        # still-in-progress reset.
         response: ApiResponse = await self._rest_client.post(
-            url, json_data={"new_password": new_password})
+            url, json_data={"new_password": new_password}, timeout=10)
 
         if response.status_code == http.HTTPStatus.NOT_FOUND:
             return await self._render(

--- a/items/shared/__init__.py
+++ b/items/shared/__init__.py
@@ -21,7 +21,7 @@ MINOR = 3
 PATCH = 0
 
 # e.g. "alpha", "beta", "rc1", or None
-PRE_RELEASE = "Alpha Build 9"
+PRE_RELEASE = "Alpha Build 10"
 
 # Version tuple for comparisons
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)

--- a/postman/ITEMS.postman_collection.json
+++ b/postman/ITEMS.postman_collection.json
@@ -1619,11 +1619,12 @@
                       }
                     },
                     "url": {
-                      "raw": "{{GATEWAY_SVC_URL}}/sessions",
+                      "raw": "{{GATEWAY_SVC_URL}}/web/sessions",
                       "host": [
                         "{{GATEWAY_SVC_URL}}"
                       ],
                       "path": [
+                        "web",
                         "sessions"
                       ]
                     }

--- a/unit_tests/items_gateway/main.py
+++ b/unit_tests/items_gateway/main.py
@@ -83,7 +83,12 @@ from test_email_service import (
     TestSmtpEmailServiceSend,
 )
 from test_webhook_handler import TestGetMetadataHandler
-from test_auth_decorators import TestRequireSession, TestRequireAdministrator
+from test_auth_decorators import (
+    TestRequireSession,
+    TestRequireAdministrator,
+    TestRequireProjectMember,
+    TestRequireSessionWithEntry,
+)
 from test_admin_route_enforcement import TestAdminRouteEnforcement
 
 if __name__ == "__main__":

--- a/unit_tests/items_gateway/test_admin_route_enforcement.py
+++ b/unit_tests/items_gateway/test_admin_route_enforcement.py
@@ -44,8 +44,15 @@ _VALID_FIELD_BODY = {
 
 _USER_TOKEN = "a" * 32
 _ADMIN_TOKEN = "b" * 32
+_OUTSIDER_TOKEN = "c" * 32
 _USER_HEADERS = {HEADER_USER: "user@x.com", HEADER_TOKEN: _USER_TOKEN}
 _ADMIN_HEADERS = {HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN}
+# A valid, non-administrator session with no project memberships at all -
+# used to confirm membership is actually enforced, not just "any session
+# passes". _USER_HEADERS above is a member of project 1, matching every
+# project-scoped path in _SESSION_ONLY_ROUTES, so it can't tell the two
+# apart on its own.
+_OUTSIDER_HEADERS = {HEADER_USER: "outsider@x.com", HEADER_TOKEN: _OUTSIDER_TOKEN}
 
 # (method, path, json_body) - every admin-only /web/* route.
 _ADMIN_ONLY_ROUTES = [
@@ -80,12 +87,26 @@ _ADMIN_ONLY_ROUTES = [
 ]
 
 # (method, path, json_body) - routes that need a valid session but not
-# administrator rights.
+# administrator rights. All four also require project membership except
+# the list, which filters rather than gates - _USER_HEADERS' session is a
+# member of project 1, matching every project-scoped path here, so these
+# tables alone exercise "a member reaches their own project", not
+# "membership is actually checked" - see test_member_only_routes_reject_
+# non_member below for the negative case.
 _SESSION_ONLY_ROUTES = [
     ("GET", "/web/projects", None),
     ("GET", "/web/projects/1", None),
     ("GET", "/web/1/testcases", None),
     ("GET", "/web/testcases/1?project_id=1", None),
+]
+
+# (method, path) - the three of the four above that actually gate on
+# membership (unlike the list, which filters its response instead of
+# rejecting the request).
+_MEMBER_ONLY_ROUTES = [
+    ("GET", "/web/projects/1"),
+    ("GET", "/web/1/testcases"),
+    ("GET", "/web/testcases/1?project_id=1"),
 ]
 
 # (method, path, json_body) - routes that must stay reachable with no
@@ -130,10 +151,13 @@ class TestAdminRouteEnforcement(unittest.IsolatedAsyncioTestCase):
         self.sessions = Sessions()
         await self.sessions.add_session(
             "user@x.com", _USER_TOKEN, AccountLogonType.BASIC,
-            is_administrator=False)
+            is_administrator=False, project_ids=frozenset({1}))
         await self.sessions.add_session(
             "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
             is_administrator=True)
+        await self.sessions.add_session(
+            "outsider@x.com", _OUTSIDER_TOKEN, AccountLogonType.BASIC,
+            is_administrator=False, project_ids=frozenset())
         configuration = MagicMock()
         configuration.apis_cms_svc = "http://cms/"
         configuration.apis_identity_svc = "http://identity/"
@@ -220,6 +244,38 @@ class TestAdminRouteEnforcement(unittest.IsolatedAsyncioTestCase):
                 self.assertNotIn(
                     response.status_code,
                     (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    async def test_member_only_routes_reject_non_member(self):
+        """A valid session with no membership of project 1 must be
+        rejected by these three - proves membership is actually being
+        checked, not just "any session passes" (which _USER_HEADERS, a
+        member of project 1, can't distinguish on its own)."""
+        for method, path in _MEMBER_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, None, headers=_OUTSIDER_HEADERS)
+                self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    async def test_member_only_routes_accept_administrator(self):
+        """Administrators bypass membership entirely, same as every other
+        admin-gated view - not covered by _SESSION_ONLY_ROUTES' admin
+        check alone, since that uses _ADMIN_HEADERS which never proves
+        the bypass is membership-specific rather than coincidental."""
+        for method, path in _MEMBER_ONLY_ROUTES:
+            with self.subTest(method=method, path=path):
+                response = await self._call(
+                    method, path, None, headers=_ADMIN_HEADERS)
+                self.assertNotIn(
+                    response.status_code,
+                    (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN))
+
+    async def test_project_list_never_rejects_a_non_member_just_filters(self):
+        """Unlike the three above, the list route has nothing to 403 - a
+        member of nothing still gets a 200 with an empty list, not a
+        rejection."""
+        response = await self._call(
+            "GET", "/web/projects", None, headers=_OUTSIDER_HEADERS)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
 
 if __name__ == "__main__":

--- a/unit_tests/items_gateway/test_auth_decorators.py
+++ b/unit_tests/items_gateway/test_auth_decorators.py
@@ -17,7 +17,8 @@ import unittest
 from http import HTTPStatus
 from quart import Quart
 from items.services.items_gateway.auth_decorators import (
-    require_administrator, require_session, HEADER_TOKEN, HEADER_USER)
+    require_administrator, require_project_member, require_session,
+    require_session_with_entry, HEADER_TOKEN, HEADER_USER)
 from items.services.items_gateway.sessions import Sessions
 from items.shared.account_logon_type import AccountLogonType
 
@@ -37,6 +38,21 @@ def _make_app(sessions: Sessions) -> Quart:
     @require_administrator(sessions)
     async def admin_only():
         return "ok"
+
+    @app.route('/projects/<int:project_id>')
+    @require_project_member(sessions)
+    async def project_member_route_param(project_id: int):
+        return "ok"
+
+    @app.route('/testcases')
+    @require_project_member(sessions)
+    async def project_member_query_param():
+        return "ok"
+
+    @app.route('/list-for-caller')
+    @require_session_with_entry(sessions)
+    async def list_for_caller(session_entry):
+        return "member" if session_entry.is_administrator else "non-admin"
 
     return app
 
@@ -121,6 +137,111 @@ class TestRequireAdministrator(unittest.IsolatedAsyncioTestCase):
                 HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN})
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertEqual(await response.get_data(as_text=True), "ok")
+
+
+class TestRequireProjectMember(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.sessions = Sessions()
+        await self.sessions.add_session(
+            "member@x.com", _USER_TOKEN, AccountLogonType.BASIC,
+            is_administrator=False, project_ids=frozenset({1}))
+        await self.sessions.add_session(
+            "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
+            is_administrator=True)
+        self.client = _make_app(self.sessions).test_client()
+
+    async def test_no_headers_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/projects/1')
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_member_of_the_route_project_calls_through(self):
+        async with self.client as c:
+            response = await c.get('/projects/1', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_not_a_member_of_the_route_project_returns_403(self):
+        async with self.client as c:
+            response = await c.get('/projects/2', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    async def test_administrator_bypasses_membership(self):
+        async with self.client as c:
+            response = await c.get('/projects/2', headers={
+                HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_member_of_the_query_param_project_calls_through(self):
+        async with self.client as c:
+            response = await c.get('/testcases?project_id=1', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_not_a_member_of_the_query_param_project_returns_403(self):
+        async with self.client as c:
+            response = await c.get('/testcases?project_id=2', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+    async def test_missing_project_id_falls_through_to_the_handler(self):
+        """No project_id anywhere in the request - nothing to check
+        membership against, so this decorator gets out of the way and lets
+        the handler's own validation respond (here, just "ok", since the
+        stub route doesn't validate anything itself)."""
+        async with self.client as c:
+            response = await c.get('/testcases', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_non_integer_project_id_query_param_falls_through(self):
+        async with self.client as c:
+            response = await c.get('/testcases?project_id=abc', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    async def test_invalid_session_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/projects/1', headers={
+                HEADER_USER: "member@x.com", HEADER_TOKEN: "wrong"})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+
+class TestRequireSessionWithEntry(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self.sessions = Sessions()
+        await self.sessions.add_session(
+            "user@x.com", _USER_TOKEN, AccountLogonType.BASIC,
+            is_administrator=False)
+        await self.sessions.add_session(
+            "admin@x.com", _ADMIN_TOKEN, AccountLogonType.BASIC,
+            is_administrator=True)
+        self.client = _make_app(self.sessions).test_client()
+
+    async def test_no_headers_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/list-for-caller')
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_invalid_session_returns_401(self):
+        async with self.client as c:
+            response = await c.get('/list-for-caller', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: "wrong"})
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
+
+    async def test_passes_the_resolved_entry_through_to_the_handler(self):
+        async with self.client as c:
+            admin_response = await c.get('/list-for-caller', headers={
+                HEADER_USER: "admin@x.com", HEADER_TOKEN: _ADMIN_TOKEN})
+            user_response = await c.get('/list-for-caller', headers={
+                HEADER_USER: "user@x.com", HEADER_TOKEN: _USER_TOKEN})
+        self.assertEqual(
+            await admin_response.get_data(as_text=True), "member")
+        self.assertEqual(
+            await user_response.get_data(as_text=True), "non-admin")
 
 
 if __name__ == "__main__":

--- a/unit_tests/items_gateway/test_projects_handlers.py
+++ b/unit_tests/items_gateway/test_projects_handlers.py
@@ -27,6 +27,7 @@ from items.services.items_gateway.routes.web.projects.get_project_handler \
     import GetProjectHandler
 from items.services.items_gateway.routes.web.projects.update_project_handler \
     import UpdateProjectHandler
+from items.services.items_gateway.sessions import SessionEntry
 
 _LOGGER = MagicMock()
 
@@ -35,6 +36,9 @@ _VALID_PROJECT_BODY = {
     "announcement": "",
     "announcement_on_overview": False,
 }
+
+_ADMIN_ENTRY = SessionEntry(is_administrator=True)
+_MEMBER_ENTRY = SessionEntry(is_administrator=False, project_ids=frozenset({1, 3}))
 
 
 def _config():
@@ -166,19 +170,28 @@ class TestGetAllProjectsHandler(unittest.IsolatedAsyncioTestCase):
 
     async def asyncSetUp(self):
         self.mock_rest_client = AsyncMock()
-        handler = GetAllProjectsHandler(_LOGGER, _config(), self.mock_rest_client)
+        self.handler = GetAllProjectsHandler(
+            _LOGGER, _config(), self.mock_rest_client)
 
         app = Quart(__name__)
 
+        # session_entry is normally supplied by the require_session_with_entry
+        # decorator - a query param stands in for it here so each test can
+        # choose which caller is asking without needing a real session store.
         @app.route("/projects", methods=["GET"])
         async def list_projects():
-            return await handler.list_all_projects()
+            from quart import request
+            entry = _ADMIN_ENTRY if request.args.get("as") == "admin" \
+                else _MEMBER_ENTRY
+            return await self.handler.list_all_projects(entry)
 
         self.client = app.test_client()
 
-    async def _get(self, qs=""):
+    async def _get(self, qs="", as_admin=False):
+        sep = "&" if qs.startswith("?") else "?"
+        admin_qs = f"{sep}as=admin" if as_admin else ""
         async with self.client as c:
-            return await c.get(f"/projects{qs}")
+            return await c.get(f"/projects{qs}{admin_qs}")
 
     async def test_no_query_params(self):
         self.mock_rest_client.get.return_value = ApiResponse(
@@ -220,6 +233,51 @@ class TestGetAllProjectsHandler(unittest.IsolatedAsyncioTestCase):
         self.mock_rest_client.get.return_value = ApiResponse(status_code=503)
         response = await self._get()
         self.assertEqual(response.status_code, 500)
+
+    async def test_administrator_sees_every_project(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"projects": [
+                {"id": 1, "name": "Alpha"},
+                {"id": 2, "name": "Beta"},
+                {"id": 3, "name": "Gamma"}]})
+        response = await self._get(as_admin=True)
+        data = await response.get_json()
+        self.assertEqual(len(data["projects"]), 3)
+
+    async def test_member_only_sees_their_own_projects(self):
+        """_MEMBER_ENTRY belongs to projects 1 and 3, not 2."""
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"projects": [
+                {"id": 1, "name": "Alpha"},
+                {"id": 2, "name": "Beta"},
+                {"id": 3, "name": "Gamma"}]})
+        response = await self._get()
+        data = await response.get_json()
+        self.assertEqual(
+            sorted(p["id"] for p in data["projects"]), [1, 3])
+
+    async def test_member_of_nothing_sees_an_empty_list(self):
+        no_projects = SessionEntry(is_administrator=False)
+        app = Quart(__name__)
+
+        @app.route("/projects", methods=["GET"])
+        async def list_projects():
+            return await self.handler.list_all_projects(no_projects)
+
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"projects": [{"id": 1, "name": "Alpha"}]})
+        async with app.test_client() as c:
+            response = await c.get("/projects")
+        data = await response.get_json()
+        self.assertEqual(data["projects"], [])
+
+    async def test_filtering_preserves_other_body_fields(self):
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200,
+            body={"projects": [{"id": 1, "name": "Alpha"}], "total": 5})
+        response = await self._get()
+        data = await response.get_json()
+        self.assertEqual(data["total"], 5)
 
 
 # ------------------------------------------------------------------

--- a/unit_tests/items_gateway/test_sessions.py
+++ b/unit_tests/items_gateway/test_sessions.py
@@ -77,6 +77,8 @@ class TestSessions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(entry.session_expiry, 0)
         self.assertEqual(entry.token, "")
         self.assertFalse(entry.is_administrator)
+        self.assertEqual(entry.user_id, "")
+        self.assertEqual(entry.project_ids, frozenset())
 
     async def test_add_session_stores_is_administrator(self):
         await self.sessions.add_session(
@@ -89,6 +91,26 @@ class TestSessions(unittest.IsolatedAsyncioTestCase):
         await self.sessions.add_session(self.email, self.token, self.auth_type)
         entry = await self.sessions.get_session_entry(self.email, self.token)
         self.assertFalse(entry.is_administrator)
+
+    async def test_add_session_stores_user_id_and_project_ids(self):
+        await self.sessions.add_session(
+            self.email, self.token, self.auth_type,
+            user_id="uuid-123", project_ids=frozenset({1, 2}))
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertEqual(entry.user_id, "uuid-123")
+        self.assertEqual(entry.project_ids, frozenset({1, 2}))
+
+    async def test_add_session_user_id_and_project_ids_default(self):
+        await self.sessions.add_session(self.email, self.token, self.auth_type)
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertEqual(entry.user_id, "")
+        self.assertEqual(entry.project_ids, frozenset())
+
+    async def test_add_session_project_ids_none_normalises_to_empty(self):
+        await self.sessions.add_session(
+            self.email, self.token, self.auth_type, project_ids=None)
+        entry = await self.sessions.get_session_entry(self.email, self.token)
+        self.assertEqual(entry.project_ids, frozenset())
 
     async def test_get_session_entry_valid_token_returns_entry(self):
         await self.sessions.add_session(self.email, self.token, self.auth_type)

--- a/unit_tests/items_gateway/test_sessions_handlers.py
+++ b/unit_tests/items_gateway/test_sessions_handlers.py
@@ -130,6 +130,89 @@ class TestNewSessionPasswordHandler(unittest.IsolatedAsyncioTestCase):
         is_admin = kwargs.get("is_administrator", args[3] if len(args) > 3 else False)
         self.assertFalse(is_admin)
 
+    async def test_success_stores_user_id_from_profile(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200,
+                       body={"is_administrator": False, "id": "uuid-123"})
+        ]
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"memberships": []})
+        await self._post({"email_address": "a@b.com", "password": "password1"})
+        _, kwargs = self.mock_sessions.add_session.call_args
+        self.assertEqual(kwargs["user_id"], "uuid-123")
+
+    async def test_success_stores_project_ids_from_memberships(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200,
+                       body={"is_administrator": False, "id": "uuid-123"})
+        ]
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"memberships": [
+                {"project_id": 5, "role_id": 1},
+                {"project_id": 7, "role_id": None}]})
+        await self._post({"email_address": "a@b.com", "password": "password1"})
+        _, kwargs = self.mock_sessions.add_session.call_args
+        self.assertEqual(kwargs["project_ids"], frozenset({5, 7}))
+
+    async def test_membership_fetch_uses_the_resolved_user_id(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200,
+                       body={"is_administrator": False, "id": "uuid-123"})
+        ]
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=200, body={"memberships": []})
+        await self._post({"email_address": "a@b.com", "password": "password1"})
+        self.mock_rest_client.get.assert_called_once_with(
+            "http://identity/users/uuid-123/projects")
+
+    async def test_no_user_id_skips_membership_fetch(self):
+        """A failed/empty profile fetch leaves user_id empty - nothing to
+        look memberships up by, so don't bother calling identity again."""
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=503)
+        ]
+        await self._post({"email_address": "a@b.com", "password": "password1"})
+        self.mock_rest_client.get.assert_not_called()
+        _, kwargs = self.mock_sessions.add_session.call_args
+        self.assertEqual(kwargs["project_ids"], frozenset())
+
+    async def test_membership_fetch_failure_defaults_to_no_projects(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200,
+                       body={"is_administrator": False, "id": "uuid-123"})
+        ]
+        self.mock_rest_client.get.return_value = ApiResponse(
+            status_code=503, body={})
+        response = await self._post(
+            {"email_address": "a@b.com", "password": "password1"})
+        self.assertEqual(response.status_code, 200)
+        _, kwargs = self.mock_sessions.add_session.call_args
+        self.assertEqual(kwargs["project_ids"], frozenset())
+
+    async def test_membership_fetch_exception_defaults_to_no_projects(self):
+        self.mock_sessions.has_session.return_value = False
+        self.mock_rest_client.post.side_effect = [
+            ApiResponse(status_code=200),
+            ApiResponse(status_code=200,
+                       body={"is_administrator": False, "id": "uuid-123"})
+        ]
+        self.mock_rest_client.get.side_effect = RuntimeError("boom")
+        response = await self._post(
+            {"email_address": "a@b.com", "password": "password1"})
+        self.assertEqual(response.status_code, 200)
+        _, kwargs = self.mock_sessions.add_session.call_args
+        self.assertEqual(kwargs["project_ids"], frozenset())
+
 
 # ------------------------------------------------------------------
 # DeleteSessionHandler


### PR DESCRIPTION
# Gateway: project membership enforcement on read routes

**Branch:** `gateway_membership_enforcement` (manually tested, PR pending)
**Theme:** Roles & permissions (post-0.3.0) — seventh and **final**
application-code piece (`identity_roles_db_update` → `identity_roles_crud`
→ `identity_project_membership` → `gateway_roles_and_membership` →
`portal_user_roles_and_membership` → `portal_project_membership` → this
branch)

## Summary

Closes out the theme's original acceptance test, stated at the very
start of this work: if a user is assigned to projects 1, 3 and 5, they
cannot get information on project 2. Until this branch, `GET
/web/projects`, `GET /web/projects/<id>`, `GET /web/<project_id>/testcases`
and `GET /web/testcases/<id>` were all `@require_session`-only - any
authenticated user could reach any project's data regardless of
membership. They're now scoped, administrators still see everything.

## Gateway: session-cached membership

- `SessionEntry` gained `user_id` and `project_ids` (`frozenset[int]`),
  cached once at login - same tradeoff already accepted for
  `is_administrator` (no per-request identity lookup, staleness matches
  the existing "deactivation doesn't clear a live session" gap in
  `future.md`).
- `NewSessionPasswordHandler` now reads the UUID off the profile response
  it already fetches (previously discarded) and does one extra call to
  snapshot the user's memberships (`GET users/<uuid>/projects`) - fails
  safe to "no projects" on any error, never fails the login itself.

## Gateway: two new decorators, not one

Investigated the shape of the actual work before writing any of it -
`require_session`/`require_administrator` resolve the session *inside
the decorator* and discard it; handler classes are explicitly
authorization-agnostic by design, called directly (bypassing HTTP) from
most of this codebase's unit tests. Establishing which of the four read
routes could stay that way, and which genuinely couldn't, mattered more
than just wiring something in:

- **`require_project_member`** - same shape as `require_administrator`:
  checks a `project_id` (route param or query param) against the
  session's cached set, admins bypass, a missing/unparseable project_id
  falls through to the handler's own validation rather than masking it
  behind a generic 403. Covers three of the four routes, including `GET
  /web/testcases/<id>` - safe to check against its client-supplied
  `project_id` query param specifically because CMS independently
  verifies the testcase actually belongs to the stated project and 404s
  otherwise, so a caller can't lie about the project to reach a testcase
  in one they don't belong to.
- **`require_session_with_entry`** - the one deliberate exception, for
  `GET /web/projects` (the list). Passes the resolved `SessionEntry` into
  `GetAllProjectsHandler.list_all_projects()` so it can filter the
  response rather than gate the whole request - a list has nothing
  proportionate to 403 on. Documented explicitly as the exception, not a
  new norm; every other route stays untouched.

## Real bugs found during manual verification (fixed here)

Verification surfaced two genuine, pre-existing bugs unrelated to this
branch's own logic - both fixed rather than deferred, since they were
actively blocking the ability to verify the enforcement work itself:

- **Password reset / user creation silently 504ing.** `RestClient`
  defaults to a 2-second timeout; `argon2.PasswordHasher()` (default
  cost, called synchronously, not offloaded to a thread) can exceed that
  under load on a dev machine, and this call chain is two hops deep
  (Portal→Gateway→Identity), so either hop's timeout could fire first.
  `weaver_framework`'s `RestClient` catches the client-side
  `asyncio.TimeoutError` and returns a synthesized `ApiResponse(status_code
  =504, ...)`, silent on both server logs since nothing server-side
  actually failed - the caller just gave up waiting. Fixed by bumping
  `timeout=10` on the four call sites in this chain (Portal/Gateway ×
  reset-password/create-user). The deeper fix - offloading the hash to a
  thread so it stops blocking the event loop - is a bigger, more
  careful change, logged in `future.md` rather than done here.
- **Postman collection: Logout missing `/web/`.** `{{GATEWAY_SVC_URL}}/sessions`
  instead of `{{GATEWAY_SVC_URL}}/web/sessions`, unlike its siblings
  "Create Session" and "Is Session Valid" in the same folder. Pure
  collection drift, unrelated to any branch's code - fixed with a
  targeted 3-line edit once found.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / infrastructure
- [ ] Dependency update

## Testing

416 tests via the official entry point (`python -m unittest
unit_tests/items_gateway/main.py`, what the CI script actually runs),
100% coverage confirmed through that entry point specifically (not just
`unittest discover`) - the `main.py`-import lesson from the previous
branch was applied proactively this time, every new test class wired in
as it was written. New: `require_project_member`/`require_session_with_entry`
decorator tests (route-param and query-param project checks, admin
bypass, malformed/missing project_id fall-through), session/login tests
for the new `user_id`/`project_ids` fields and the membership-fetch
failure/exception paths, `GetAllProjectsHandler` filtering tests
(administrator sees everything, member sees only their own, member of
nothing sees an empty list, other body fields preserved), and extended
`test_admin_route_enforcement.py` with a genuine negative case (a valid
session with zero memberships, proving membership is actually checked -
the existing member-of-project-1 fixture couldn't distinguish "checked
and passed" from "not checked at all"). Pylint 10.00/10.

## Manually verified end-to-end

Walked the full acceptance test as a non-admin user: project list scoped
to actual memberships, direct project/testcase URLs for a non-member
project return 403, a role granted via the Portal only takes effect
after that user's next login (the documented staleness tradeoff, seen
firsthand rather than just designed for). Also incidentally confirmed
the Projects tab's role-change flow works correctly end-to-end (Portal →
Gateway → Identity → persisted) once the row's own Save button is
actually clicked, distinct from the page's main "Save User" button.

## Deliberately out of scope

- **Reactive session push-update on admin writes** (updating/invalidating
  a specific live session when an admin changes their project membership,
  role permissions, or deactivates them - so changes apply without
  needing a fresh login) - discussed and roughly sized as small
  (comparable to or smaller than this branch, since `Sessions`/`SessionEntry`
  already exist), but a distinct piece of work from enforcement itself.
  Logged in `future.md` rather than folded in here.
- **A real refresh-token mechanism** (`RefreshSessionHandler` stays a 501
  stub) - a different, much larger problem (staying logged in without a
  full re-login) than the staleness gap above, not needed for this theme.
- **Discoverability of the Projects tab's per-row Save button** - it's
  icon-only today (`title="Save role"` tooltip only), unlike "Save
  User"/"Cancel" on the same page which both pair icon with visible text.
  Real finding from manual testing, small fix, but Portal-only - belongs
  in its own tiny branch, not bundled into this Gateway-only one.

## Theme status: complete

Schema → role CRUD → project membership (Identity) → Gateway proxy →
Portal Roles UI → Portal Project Membership UI → Gateway read-route
enforcement (this branch). Named roles and per-project membership now
exist end-to-end, data layer through UI through enforcement, with the
original acceptance test manually walked and confirmed. Three small,
independent follow-ups identified along the way (session push-update,
Save-button discoverability, event-loop-blocking password hashing) are
each logged rather than folded in, keeping this branch - and the theme -
cleanly closed.


## Checklist

- [x] Code follows the project style guidelines
- [x] Self-review completed
- [x] Tests added / updated (if applicable)
- [ ] Documentation updated (if applicable)
